### PR TITLE
Updated setup scripts

### DIFF
--- a/demo-ling/setup-catchdistribution.R
+++ b/demo-ling/setup-catchdistribution.R
@@ -1,10 +1,14 @@
-minage <-  ling_imm$iterate %>% environment() %>% .$minage
-maxage <-  ling_mat$iterate %>% environment() %>% .$maxage
-maxlength <-  ling_mat$iterate %>% environment() %>% .$lengthgroups %>% max()
-minlength <-  ling_imm$iterate %>% environment() %>% .$lengthgroups %>% min()
-dl <- ling_imm$iterate %>% environment() %>% .$stock__dl %>% min()
+## -----------------------------------------------------------------------------
+## Catch age and length distributions:
+## -----------------------------------------------------------------------------
 
-## Query length data to create IGFS catchdistribution components
+min_age <- unlist(minage) %>% min()
+max_age <- unlist(maxage) %>% max()
+min_len <- unlist(minlength) %>% min()
+max_len <- unlist(maxlength) %>% max()
+d_len <- dl$imm_stock
+
+## Query length data to create IGFS catch distribution components
 ldist.igfs <-
   mfdb_sample_count(mdb,
                     c('age', 'length'),
@@ -135,13 +139,14 @@ aldist.gil <-
                       defaults))
 
 
-
-save(aldist.bmt,file = 'demo-ling/data/aldist.bmt.Rdata')
-save(aldist.lln,file = 'demo-ling/data/aldist.lln.Rdata')
-save(aldist.igfs,file = 'demo-ling/data/aldist.igfs.Rdata')
-save(aldist.gil,file = 'demo-ling/data/aldist.gil.Rdata')
-save(ldist.bmt,file = 'demo-ling/data/ldist.bmt.Rdata')
-save(ldist.lln,file = 'demo-ling/data/ldist.lln.Rdata')
-save(ldist.igfs,file = 'demo-ling/data/ldist.igfs.Rdata')
-save(ldist.gil,file = 'demo-ling/data/ldist.gil.Rdata')
-save(matp.igfs,file = 'demo-ling/data/matp.igfs.Rdata')
+if (TRUE){
+  save(aldist.bmt,file = 'demo-ling/data/aldist.bmt.Rdata')
+  save(aldist.lln,file = 'demo-ling/data/aldist.lln.Rdata')
+  save(aldist.igfs,file = 'demo-ling/data/aldist.igfs.Rdata')
+  save(aldist.gil,file = 'demo-ling/data/aldist.gil.Rdata')
+  save(ldist.bmt,file = 'demo-ling/data/ldist.bmt.Rdata')
+  save(ldist.lln,file = 'demo-ling/data/ldist.lln.Rdata')
+  save(ldist.igfs,file = 'demo-ling/data/ldist.igfs.Rdata')
+  save(ldist.gil,file = 'demo-ling/data/ldist.gil.Rdata')
+  save(matp.igfs,file = 'demo-ling/data/matp.igfs.Rdata')
+}

--- a/demo-ling/setup-fleet-data.R
+++ b/demo-ling/setup-fleet-data.R
@@ -1,18 +1,24 @@
-
+## -----------------------------------------------------------------------------
 ## Collect catches by fleet:
+## -----------------------------------------------------------------------------
+
+## Surveys
+igfs_landings <- 
+  structure(data.frame(year=defaults$year,step=2,area=1,total_weight=1),
+            area_group = mfdb_group(`1` = 1))
+
+## Commercial
 lln_landings <- mfdb_sample_totalweight(mdb, NULL, c(list(
   gear=c('HLN','LLN'),
   sampling_type = 'LND',
   species = defaults$species),
   defaults))
 
-
 bmt_landings <- mfdb_sample_totalweight(mdb, NULL, c(list(
   gear=c('BMT','NPT','DSE','PSE','PGT','SHT'),
   sampling_type = 'LND',
   species = defaults$species),
   defaults))
-
 
 gil_landings <- mfdb_sample_totalweight(mdb, NULL, c(list(
   gear='GIL',
@@ -27,3 +33,11 @@ foreign_landings <-
                             data_source = c('lods.foreign.landings','statlant.foreign.landings'),
                             species = defaults$species),
                             defaults))
+
+if (TRUE){
+  save(lln_landings, file="demo-ling/data/lln_landings.Rdata")
+  save(bmt_landings, file="demo-ling/data/bmt_landings.Rdata")
+  save(gil_landings, file="demo-ling/data/gil_landings.Rdata")
+  save(foreign_landings, file="demo-ling/data/foreign_landings.Rdata")
+  save(igfs_landings, file="demo-ling/data/igfs_landings.Rdata")
+}

--- a/demo-ling/setup-fleets.R
+++ b/demo-ling/setup-fleets.R
@@ -1,70 +1,110 @@
+## -----------------------------------------------------------------------------
+##
+## Fleet actions:
+##
+## -----------------------------------------------------------------------------
 
-igfs_landings <-
-  structure(expand.grid(year=defaults$year,step=2,area=1,total_weight=1),
-            area_group = mfdb_group(`1` = 1))
+## Bounded parameters for fleet suitabilities
+l50 <- ~bounded(fleet_l50, 40, 100)               #~avoid_zero(fleet_l50)
+igfs.l50 <- ~bounded(fleet_l50, 20, 50)
+alpha <- ~bounded(fleet_alpha, 0.01, 1)
 
+## List of alpha and l50 for each fleet
+fleet_params <- list(
+  
+  lln_alpha = g3_stock_param(species_name, param="lln.alpha"),
+  lln_l50 = g3_stock_param(species_name, param="lln.l50"),
+  
+  bmt_alpha = g3_stock_param(species_name, param="bmt.alpha"),
+  bmt_l50 = g3_stock_param(species_name, param="bmt.l50"),
+  
+  gil_alpha = g3_stock_param(species_name, param="gil.alpha"),
+  gil_l50 = g3_stock_param(species_name, param="gil.l50"),
+  
+  igfs_alpha = g3_stock_param(species_name, param="igfs.alpha"),
+  igfs_l50 = g3_stock_param(species_name, param="igfs.l50")
+  
+)
 
-l50 <-
-  #~avoid_zero(fleet_l50)
-  ~bounded(fleet_l50,40,100)
-
-
-## create fleet actions
+## Define actions
 fleet_actions <-
   list(
     lln %>%
       g3a_predate_totalfleet(list(ling_imm, ling_mat),
                              suitabilities = list(
-                               ling_imm = g3_suitability_exponentiall50(~bounded(g3_param('ling.lln.alpha'),0.01,1),
-                                                                        gadget3:::f_substitute(l50,list(fleet_l50=~g3_param('ling.lln.l50')))),
-                               ling_mat = g3_suitability_exponentiall50(~bounded(g3_param('ling.lln.alpha'),0.01,1),
-                                                                        gadget3:::f_substitute(l50,list(fleet_l50=~g3_param('ling.lln.l50'))))),
+                               ling_imm = g3_suitability_exponentiall50(
+                                 gadget3:::f_substitute(alpha, list(fleet_alpha = fleet_params[['lln_alpha']])),
+                                 gadget3:::f_substitute(l50, list(fleet_l50 = fleet_params[['lln_l50']]))),
+                               
+                               ling_mat = g3_suitability_exponentiall50(
+                                 gadget3:::f_substitute(alpha, list(fleet_alpha = fleet_params[['lln_alpha']])),
+                                 gadget3:::f_substitute(l50, list(fleet_l50 = fleet_params[['lln_l50']])))),
+                             
                              amount_f = g3_timeareadata('lln_landings', lln_landings[[1]] %>%
                                                           mutate(area = as.numeric(area),
                                                                  step = as.numeric(step),
                                                                  year = as.numeric(year)))),
+    
     bmt %>%
       g3a_predate_totalfleet(list(ling_imm, ling_mat),
                              suitabilities = list(
-                               ling_imm = g3_suitability_exponentiall50(~bounded(g3_param('ling.bmt.alpha'),0.01,1),
-                                                                        gadget3:::f_substitute(l50,list(fleet_l50=~g3_param('ling.bmt.l50')))),
-                               ling_mat = g3_suitability_exponentiall50(~bounded(g3_param('ling.bmt.alpha'),0.01,1),
-                                                                        gadget3:::f_substitute(l50,list(fleet_l50=~g3_param('ling.bmt.l50'))))),
-                             amount_f = g3_timeareadata('bmt_landings', bmt_landings[[1]]%>%
+                               ling_imm = g3_suitability_exponentiall50(
+                                 gadget3:::f_substitute(alpha, list(fleet_alpha = fleet_params[['bmt_alpha']])),
+                                 gadget3:::f_substitute(l50, list(fleet_l50 = fleet_params[['bmt_l50']]))),
+                               
+                               ling_mat = g3_suitability_exponentiall50(
+                                 gadget3:::f_substitute(alpha, list(fleet_alpha = fleet_params[['bmt_alpha']])),
+                                 gadget3:::f_substitute(l50, list(fleet_l50 = fleet_params[['bmt_l50']])))),
+                             
+                             amount_f = g3_timeareadata('bmt_landings', bmt_landings[[1]] %>%
                                                           mutate(area = as.numeric(area),
                                                                  step = as.numeric(step),
                                                                  year = as.numeric(year)))),
+    
     gil %>%
       g3a_predate_totalfleet(list(ling_imm, ling_mat),
                              suitabilities = list(
-                               ling_imm = g3_suitability_exponentiall50(~bounded(g3_param('ling.gil.alpha'),0.01,1),
-                                                                        gadget3:::f_substitute(l50,list(fleet_l50=~g3_param('ling.gil.l50')))),
-                               ling_mat = g3_suitability_exponentiall50(~bounded(g3_param('ling.gil.alpha'),0.01,1),
-                                                                        gadget3:::f_substitute(l50,list(fleet_l50=~g3_param('ling.gil.l50'))))),
-                             amount_f = g3_timeareadata('gil_landings', gil_landings[[1]]%>%
+                               ling_imm = g3_suitability_exponentiall50(
+                                 gadget3:::f_substitute(alpha, list(fleet_alpha = fleet_params[['gil_alpha']])),
+                                 gadget3:::f_substitute(l50, list(fleet_l50 = fleet_params[['gil_l50']]))),
+                               
+                               ling_mat = g3_suitability_exponentiall50(
+                                 gadget3:::f_substitute(alpha, list(fleet_alpha = fleet_params[['gil_alpha']])),
+                                 gadget3:::f_substitute(l50, list(fleet_l50 = fleet_params[['gil_l50']])))),
+                             
+                             amount_f = g3_timeareadata('gil_landings', gil_landings[[1]] %>%
                                                           mutate(area = as.numeric(area),
                                                                  step = as.numeric(step),
                                                                  year = as.numeric(year)))),
-    foreign  %>%
+    
+    foreign %>%
       g3a_predate_totalfleet(list(ling_imm, ling_mat),
                              suitabilities = list(
-                               ling_imm = g3_suitability_exponentiall50(~bounded(g3_param('ling.lln.alpha'),0.01,1),
-                                                                        gadget3:::f_substitute(l50,list(fleet_l50=~g3_param('ling.lln.l50')))),
-                               ling_mat = g3_suitability_exponentiall50(~bounded(g3_param('ling.lln.alpha'),0.01,1),
-                                                                        gadget3:::f_substitute(l50,list(fleet_l50=~g3_param('ling.lln.l50'))))),
-                             amount_f = g3_timeareadata('foreign_landings', foreign_landings[[1]]%>%
+                               ling_imm = g3_suitability_exponentiall50(
+                                 gadget3:::f_substitute(alpha, list(fleet_alpha = fleet_params[['lln_alpha']])),
+                                 gadget3:::f_substitute(l50, list(fleet_l50 = fleet_params[['lln_l50']]))),
+                               
+                               ling_mat = g3_suitability_exponentiall50(
+                                 gadget3:::f_substitute(alpha, list(fleet_alpha = fleet_params[['lln_alpha']])),
+                                 gadget3:::f_substitute(l50, list(fleet_l50 = fleet_params[['lln_l50']])))),
+                             
+                             amount_f = g3_timeareadata('foreign_landings', foreign_landings[[1]] %>%
                                                           mutate(area = as.numeric(area),
                                                                  step = as.numeric(step),
                                                                  year = as.numeric(year)))),
-
+    
     igfs %>%
       g3a_predate_totalfleet(list(ling_imm, ling_mat),
                              suitabilities = list(
-                               ling_imm = g3_suitability_exponentiall50(~bounded(g3_param('ling.igfs.alpha'),0.01,1),
-                                                                        ~bounded(g3_param('ling.igfs.l50'),20,50)),
-                               ling_mat = g3_suitability_exponentiall50(~bounded(g3_param('ling.igfs.alpha'),0.01,1),
-                                                                        ~bounded(g3_param('ling.igfs.l50'),20,50))),
-                             amount_f = g3_timeareadata('igfs_landings', igfs_landings%>%
+                               ling_imm = g3_suitability_exponentiall50(
+                                 gadget3:::f_substitute(alpha, list(fleet_alpha = fleet_params[['igfs_alpha']])),
+                                 gadget3:::f_substitute(igfs.l50, list(fleet_l50 = fleet_params[['igfs_l50']]))),
+                               
+                               ling_mat = g3_suitability_exponentiall50(
+                                 gadget3:::f_substitute(alpha, list(fleet_alpha = fleet_params[['igfs_alpha']])),
+                                 gadget3:::f_substitute(igfs.l50, list(fleet_l50 = fleet_params[['igfs_l50']])))),
+                             
+                             amount_f = g3_timeareadata('igfs_landings', igfs_landings %>%
                                                           mutate(area = as.numeric(area),
                                                                  step = as.numeric(step),
                                                                  year = as.numeric(year)))))

--- a/demo-ling/setup-indices.R
+++ b/demo-ling/setup-indices.R
@@ -1,4 +1,6 @@
-## IGFS survey indices
+## -----------------------------------------------------------------------------
+## Survey indices
+## -----------------------------------------------------------------------------
 
 igfs.SI1 <- 
   mfdb_sample_count(mdb, c('length'), c(list(
@@ -58,8 +60,18 @@ igfs.SI3d <-
   mfdb_sample_count(mdb, 
                     c('length'),
                     c(list(
-                          data_source = 'iceland-ldist',
+                      data_source = 'iceland-ldist',
                       sampling_type = 'IGFS',
                       length = mfdb_interval("len", c(100,160),open_ended = 'upper')),
                       defaults))
+
+if (TRUE){
+  save(igfs.SI1, file="demo-ling/data/igfs.SI1.Rdata")
+  save(igfs.SI2a, file="demo-ling/data/igfs.SI2a.Rdata")
+  save(igfs.SI2b, file="demo-ling/data/igfs.SI2b.Rdata")
+  save(igfs.SI3a, file="demo-ling/data/igfs.SI3a.Rdata")
+  save(igfs.SI3b, file="demo-ling/data/igfs.SI3b.Rdata")
+  save(igfs.SI3c, file="demo-ling/data/igfs.SI3c.Rdata")
+  save(igfs.SI3d, file="demo-ling/data/igfs.SI3d.Rdata")
+}
 

--- a/demo-ling/setup-initial_parameters.R
+++ b/demo-ling/setup-initial_parameters.R
@@ -39,3 +39,8 @@ mat.l50 <-
   dplyr::summarise(l50=min(length)) %>% 
   collect(n=Inf)
 
+if (TRUE){
+  save(mat.l50, file="demo-ling/data/mat.l50.Rdata")
+  save(lw.constants, file="demo-ling/data/lw.constants.Rdata")
+  save(init.sigma, file="demo-ling/data/init.sigma.Rdata")
+}

--- a/demo-ling/setup-likelihood.R
+++ b/demo-ling/setup-likelihood.R
@@ -1,5 +1,8 @@
-
-## all age reading before 1999 are omitted
+## -----------------------------------------------------------------------------
+##
+## Setup likelihood 
+##
+## -----------------------------------------------------------------------------
 
 ## weird inconsistencies in Gadget
 aldist.igfs[[1]]$step <- 2
@@ -10,26 +13,28 @@ nll_breakdown <- TRUE  # Turn to TRUE to get per-step nll
 lik_report <- TRUE
 
 ling_likelihood_actions <- list(
-  g3l_understocking(list(ling_imm, ling_mat), nll_breakdown = nll_breakdown, weight = 1e6),
-
+  g3l_understocking(stock_list, nll_breakdown = nll_breakdown, weight = 1e6),
+  
   g3l_catchdistribution(
     'ldist_lln',
     ldist.lln[[1]] %>% ## tow == 60228 was wrongly assigned, omit samples from that quarter
       filter(!(year==1993&step==4)),
     fleets = list(lln),
-    stocks = list(ling_imm, ling_mat),
+    stocks = stock_list,
     g3l_distribution_sumofsquares(),
     nll_breakdown = nll_breakdown,
     report = lik_report),
+  
   g3l_catchdistribution(
     'aldist_lln',
     aldist.lln[[1]] %>%  ## only 20 fish aged taken in those quarters
       filter(year>1998,!((year==2002|year==2003)&step==2)),
     fleets = list(lln),
-    stocks = list(ling_imm, ling_mat),
+    stocks = stock_list,
     g3l_distribution_sumofsquares(),
     nll_breakdown = nll_breakdown,
     report = lik_report),
+  
   g3l_catchdistribution(
     'ldist_bmt',
     (ldist.bmt[[1]]) %>% ## to few samples (<=20 fish lengths)
@@ -40,112 +45,126 @@ ling_likelihood_actions <- list(
              !(year==1998&step==3),
              !(year==1989&step==3)),
     fleets = list(bmt),
-    stocks = list(ling_imm, ling_mat),
+    stocks = stock_list,
     g3l_distribution_sumofsquares(),
     nll_breakdown = nll_breakdown,     report = lik_report),
+  
   g3l_catchdistribution(
     'aldist_bmt',
     (aldist.bmt[[1]]) %>%
       filter(year>1998),
     fleets = list(bmt),
-    stocks = list(ling_imm, ling_mat),
+    stocks = stock_list,
     g3l_distribution_sumofsquares(),
     nll_breakdown = nll_breakdown,     report = lik_report),
+  
   g3l_catchdistribution(
     'ldist_gil',
     (ldist.gil[[1]]) %>% ## only one fish lengthmeasured
       filter(!(year==2005&step==2)),
     fleets = list(gil),
-    stocks = list(ling_imm, ling_mat),
+    stocks = stock_list,
     g3l_distribution_sumofsquares(),
     nll_breakdown = nll_breakdown,     report = lik_report),
+  
   g3l_catchdistribution(
     'aldist_gil',
     (aldist.gil[[1]]) %>%
       filter(year>1998),
     fleets = list(gil),
-    stocks = list(ling_imm, ling_mat),
+    stocks = stock_list,
     g3l_distribution_sumofsquares(),
     nll_breakdown = nll_breakdown,     report = lik_report),
+  
   g3l_catchdistribution(
     'ldist_igfs',
     (ldist.igfs[[1]]),
     fleets = list(igfs),
-    stocks = list(ling_imm, ling_mat),
+    stocks = stock_list,
     g3l_distribution_sumofsquares(),
     nll_breakdown = nll_breakdown,     report = lik_report),
+  
   g3l_catchdistribution(
     'aldist_igfs',
     (aldist.igfs[[1]]) %>% ## only two age samples in 1989
       filter(year>1998),
     fleets = list(igfs),
-    stocks = list(ling_imm, ling_mat),
+    stocks = stock_list,
     g3l_distribution_sumofsquares(),
     nll_breakdown = nll_breakdown,     report = lik_report),
+  
   g3l_catchdistribution(
     'matp_igfs',
     (matp.igfs[[1]] %>%
-      rename(stock = maturity_stage) %>%
-      mutate(stock = recode(as.factor(stock), lingimm = "ling_imm", lingmat = "ling_mat"))),
+       rename(stock = maturity_stage) %>%
+       mutate(stock = recode(as.factor(stock), lingimm = "ling_imm", lingmat = "ling_mat"))),
     fleets = list(igfs),
-    stocks = list(ling_imm, ling_mat),
+    stocks = stock_list,
     g3l_distribution_sumofsquares(),
     nll_breakdown = nll_breakdown,     report = lik_report),
+  
   g3l_distribution(
     'si_igfs_si1',
     (igfs.SI1[[1]]),
     fleets = list(),
-    stocks = list(ling_imm, ling_mat),
-    g3l_distribution_surveyindices_log(alpha = ~g3_param('ling_si_alpha1'),
-                                            beta = ~g3_param('ling_si_beta1')),
+    stocks = stock_list,
+    g3l_distribution_surveyindices_log(alpha = g3_stock_param(species_name, "si_alpha1", sep0="_"),
+                                       beta = g3_stock_param(species_name, "si_beta1", sep0="_")),
     nll_breakdown = nll_breakdown,     report = lik_report),
+  
   g3l_distribution(
     'si_igfs_si2a',
     (igfs.SI2a[[1]]),
     fleets = list(),
-    stocks = list(ling_imm, ling_mat),
-    g3l_distribution_surveyindices_log(alpha = ~g3_param('ling_si_alpha2'),
-                                            beta = ~g3_param('ling_si_beta2')),
+    stocks = stock_list,
+    g3l_distribution_surveyindices_log(alpha = g3_stock_param(species_name, "si_alpha2", sep0="_"),
+                                       beta = g3_stock_param(species_name, "si_beta2", sep0="_")),
     nll_breakdown = nll_breakdown,     report = lik_report),
+  
   g3l_distribution(
     'si_igfs_si2b',
     (igfs.SI2b[[1]]),
     fleets = list(),
-    stocks = list(ling_imm, ling_mat),
-    g3l_distribution_surveyindices_log(alpha = ~g3_param('ling_si_alpha3'),
-                                            beta = 1),
+    stocks = stock_list,
+    g3l_distribution_surveyindices_log(alpha = g3_stock_param(species_name, "si_alpha3", sep0="_"),
+                                       beta = 1),
     nll_breakdown = nll_breakdown,     report = lik_report),
+  
   g3l_distribution(
     'si_igfs_si3a',
     (igfs.SI3a[[1]]),
     fleets = list(),
-    stocks = list(ling_imm, ling_mat),
-    g3l_distribution_surveyindices_log(alpha = ~g3_param('ling_si_alpha4'),
-                                            beta = 1),
+    stocks = stock_list,
+    g3l_distribution_surveyindices_log(alpha = g3_stock_param(species_name, "si_alpha4", sep0="_"),
+                                       beta = 1),
     nll_breakdown = nll_breakdown,     report = lik_report),
+  
   g3l_distribution(
     'si_igfs_si3b',
     (igfs.SI3b[[1]]),
     fleets = list(),
-    stocks = list(ling_imm, ling_mat),
-    g3l_distribution_surveyindices_log(alpha = ~g3_param('ling_si_alpha5'),
-                                            beta = 1),
+    stocks = stock_list,
+    g3l_distribution_surveyindices_log(alpha = g3_stock_param(species_name, "si_alpha5", sep0="_"),
+                                       beta = 1),
     nll_breakdown = nll_breakdown,     report = lik_report),
+  
   g3l_distribution(
     'si_igfs_si3c',
     (igfs.SI3b[[1]]),
     fleets = list(),
-    stocks = list(ling_imm, ling_mat),
-    g3l_distribution_surveyindices_log(alpha = ~g3_param('ling_si_alpha6'),
-                                            beta = 1),
+    stocks = stock_list,
+    g3l_distribution_surveyindices_log(alpha = g3_stock_param(species_name, "si_alpha6", sep0="_"),
+                                       beta = 1),
     nll_breakdown = nll_breakdown,     report = lik_report),
+  
   g3l_distribution(
     'si_igfs_si3d',
     (igfs.SI3d[[1]]),
     fleets = list(),
-    stocks = list(ling_imm, ling_mat),
-    g3l_distribution_surveyindices_log(alpha = ~g3_param('ling_si_alpha7'),
-                                            beta = 1),
+    stocks = stock_list,
+    g3l_distribution_surveyindices_log(alpha = g3_stock_param(species_name, "si_alpha7", sep0="_"),
+                                       beta = 1),
     nll_breakdown = nll_breakdown,     report = lik_report),
+  
   list()
 )

--- a/demo-ling/setup-model.R
+++ b/demo-ling/setup-model.R
@@ -1,7 +1,94 @@
-## setup the immature stock first
+## -----------------------------------------------------------------------------
+##
+## SETUP MODEL
+##
+## -----------------------------------------------------------------------------
+
+## Age bounds as symbols
+imm_minage <- as.symbol(paste0(imm_stock, "__minage"))
+imm_maxage <- as.symbol(paste0(imm_stock, "__maxage"))
+mat_minage <- as.symbol(paste0(mat_stock, "__minage"))
+mat_maxage <- as.symbol(paste0(mat_stock, "__maxage"))
+
+## Stock names without space
+imm_name <- paste0(species_name, "imm")
+mat_name <- paste0(species_name, "mat")
+
+# -----------------------------
+# Define bounded parameters
+# -----------------------------
+
+## MODEL PARAMETERS
+# List containing references to parameters in the model
+# function "g3_stock_param" is a wrapper for g3_param that inserts the species/stock name into the parameter reference
+# if lower and/or upper are NULL, then the parameter will be unbounded e.g. ~g3_param("ling.k")
+# if the lower and upper parameters are integers a reference to a bounded parameter will be created e.g. ~bounded(g3_param(ling.k), lower, upper)
+# if a vector is provided to lower or upper, the minimum and maximum will be used as bounds respectively
+# "g3_stock_param_table" is an equivalent function that creates a reference to a table of parameters e.g. g3_param_table(ling.init, minage:maxage)
+
+model_params <- list(
+  
+  ## Initial conditions:
+  walpha.imm = g3_stock_param(imm_name, param = "walpha", lower = NULL, upper = NULL),
+  wbeta.imm = g3_stock_param(imm_name, param = "wbeta", lower = NULL, upper = NULL),
+  init.sd.imm = g3_stock_param_table(imm_name, param = "init.sd", 
+                                     lowage = imm_minage, highage = imm_maxage,
+                                     lower = NULL, upper = NULL),
+  
+  walpha.mat = g3_stock_param(mat_name, param = "walpha", lower = NULL, upper = NULL),
+  wbeta.mat = g3_stock_param(mat_name, param = "wbeta", lower = NULL, upper = NULL),
+  init.sd.mat = g3_stock_param_table(mat_name, param = "init.sd", 
+                                     lowage = mat_minage, highage = mat_maxage,
+                                     lower = NULL, upper = NULL),
+  
+  # Scalar for initial abundance and recruitment (all stocks)
+  scalar = g3_stock_param(species_name, param = "scalar", lower = 1, upper = 100),
+  
+  ## Renewal:
+  rec.sd = g3_stock_param(species_name, param = "rec.sd", lower = 1, upper = 5),
+  recl = g3_stock_param(species_name, param = "recl", lower = -5, upper = 30),
+  
+  ## Growth:
+  linf = g3_stock_param(species_name, param = "Linf", lower = 150, upper = 200),
+  K = g3_stock_param(species_name, param = "k", lower = 40, upper = 120, xby = 0.001),
+  bbin = g3_stock_param(species_name, param = "bbin", lower = 1, upper = 1000),
+  
+  ## Maturity:
+  mat1 = gadget3:::f_substitute(~(0.001 * exp(g3_param(x))), 
+                                list(x=paste(species_name, "mat1", sep="."))),
+  mat2 = g3_stock_param(species_name, param = "mat2", lower = 20, upper = 120),
+  mat.a = g3_stock_param(species_name, param = "mat.a", lower = 0.5, upper = 2),  ## For initial abundance
+  
+  ## Mortality:
+  init_F = g3_stock_param(species_name, param = "init.F", lower = 0.2, upper = 0.8),
+  M.imm = g3_stock_param_table(imm_name, param = "M", lowage = imm_minage, highage = imm_maxage,
+                               lower = NULL, upper = NULL),
+  M.mat = g3_stock_param_table(mat_name, param = "M", lowage = mat_minage, highage = mat_maxage,
+                               lower = NULL, upper = NULL)
+  
+)
+
+## OTHER
+# INITIAL ABUNDANCE AND RECRUITMENT
+# recruitment and initial numbers at age come from the same distribution..
+
+ling_init_abund <- gadget3:::f_substitute(~scalar * bounded(
+  if (cur_time == 0)
+    g3_param_table(p1, expand.grid(
+      age = seq(
+        min(x1, y1),
+        max(x2, y2))))
+  else
+    g3_param_table(p2, expand.grid(
+      cur_year = seq(start_year, end_year)))
+  , 0.001, 200),
+  list(scalar = model_params[['scalar']],
+       p1 = paste0(species_name, ".init"),
+       p2 = paste0(species_name, ".renew"),
+       x1 = imm_minage, x2 = imm_maxage,
+       y1 = mat_minage, y2 = mat_maxage))
 
 
-## recruitment and initial numbers at age come from the same distribution..
 # ling_init_abund <-
 #   ~bounded(g3_param("ling.scalar"), 1, 100) *
 #   bounded(g3_param_table("ling.init",
@@ -12,115 +99,107 @@
 #           0.001,200)
 #
 # #
-ling_init_abund <- ~bounded(g3_param("ling.scalar"), 1, 100) * bounded(
-  if (cur_time == 0)
-    g3_param_table("ling.init", expand.grid(
-      age = seq(
-        min(ling_imm__minage, ling_mat__minage),
-        max(ling_imm__maxage, ling_mat__maxage))))
-  else
-    g3_param_table("ling.renew", expand.grid(
-      cur_year = seq(start_year, end_year)))
-  , 0.001, 200)
-
-
 
 ## main a50 between bounds
-a50 <-
-  ~bounded(g3_param('ling.mat.a50'),min(ling_imm__minage, ling_mat__minage),max(ling_imm__maxage, ling_mat__maxage))
+a50 <- gadget3:::f_substitute(~bounded(g3_param(mata), min(x, y), max(x2, y2)), 
+                              list(mata=sprintf("%s.mat.a50", species_name), 
+                                   x = imm_minage, x2 = imm_maxage,
+                                   y = mat_minage, y2 = mat_maxage))
 
 ## ensure that old fish are not immature
 prop_m_age <-
-  gadget3:::f_substitute(~ 1/(1 + exp(-bounded(g3_param("ling.mat.a"),0.5,2)*(age - a50))),
-                         list(a50 = a50))
-
-## ensure recruitment length at age 1 is within the appropriate range
-recl <-
-  ~bounded(g3_param('ling.recl'),-5,30)
-
-## Linf and K should be within bounds
-linf <-
-  ~bounded(g3_param("ling.Linf"),150,200)
-
-K <-
-  ~0.001 * bounded(g3_param("ling.k"),40,120)
-
-
+  gadget3:::f_substitute(~ 1/(1 + exp(-mata*(age - a50))),
+                         list(a50 = a50, mata = model_params[['mat.a']]))
 
 ## mean length is estimated based on a Von B relationship used for immature and mature
 mean_l <-
   gadget3:::f_substitute(~linf * (1 - exp(-1 * K *
                                             (age - (1 + log(1 - recl/linf)/K)))),
-                         list(recl = recl, linf = linf, K = K))
-init_F <-
-  ~bounded(g3_param("ling.init.F"),0.2,0.8)
-
-
-
-
+                         list(recl = model_params[['recl']], linf = model_params[['linf']], K = model_params[['K']]))
 
 ling_imm_actions <- list(
-  g3a_initialconditions_normalparam(ling_imm,
+  
+  g3a_initialconditions_normalparam(stock_list[["imm_stock"]],
                                     # NB: area & age factor together (gadget2 just multiplied them)
                                     # initial abundance at age is 1e4 * q
-                                    factor_f = gadget3:::f_substitute(~ling_init_abund *
-                                                                        exp(-1 * (g3_param_table("lingimm.M",
-                                                                                                 data.frame(age = seq(ling_imm__minage, ling_imm__maxage) )) +
-                                                                                    init_F) * (age - ling_imm__minage)) * (1 - prop_m_age ),
-                                                                      list(ling_init_abund = ling_init_abund, prop_m_age = prop_m_age, init_F = init_F)),
+                                    factor_f =
+                                      gadget3:::f_substitute(
+                                        ~ling_init_abund * exp(-1 * (immM + init_F) * (age - x1)) * (1 - prop_m_age ),
+                                        list(ling_init_abund = ling_init_abund,
+                                             x1 = imm_minage,
+                                             prop_m_age = prop_m_age,
+                                             init_F = model_params[['init_F']],
+                                             immM = model_params[['M.imm']])),
                                     mean_f = mean_l,
-                                    stddev_f = ~g3_param_table('lingimm.init.sd',data.frame(age = seq(ling_imm__minage, ling_imm__maxage))),
-                                    alpha_f = ~g3_param("lingimm.walpha"),
-                                    beta_f = ~g3_param("lingimm.wbeta")),
-  g3a_renewal_normalparam(ling_imm,
+                                    stddev_f = model_params[['init.sd.imm']],
+                                    alpha_f = model_params[['walpha.imm']], #g3_stock_param(imm_name, "walpha"),
+                                    beta_f = model_params[['wbeta.imm']]),  #g3_stock_param(imm_name, "wbeta")),
+  
+  g3a_renewal_normalparam(stock_list[["imm_stock"]],
                           factor_f = ling_init_abund,
                           # gadget3:::f_substitute(~rec*exp(-g3_param_table("lingimm.M",
-                          #                                                         data.frame(age = seq(ling_imm__minage, ling_imm__maxage)))),
-                          #                                list(rec=ling_init_abund)),
+                          #                                                 data.frame(age = seq(ling_imm__minage, ling_imm__maxage)))),
+                          #                        list(rec=ling_init_abund)),
                           mean_f = mean_l,
-                          stddev_f = ~bounded(g3_param("ling.rec.sd"),1,5),
-                          alpha_f = ~g3_param("lingimm.walpha"),
-                          beta_f = ~g3_param("lingimm.wbeta"),
-                          run_f = ~cur_step == 1 && age == 3 && cur_time > 0),
+                          stddev_f = model_params[['rec.sd']],
+                          alpha_f = model_params[['walpha.imm']],
+                          beta_f = model_params[['wbeta.imm']],
+                          run_f = gadget3:::f_substitute(~cur_step == 1 && age == x1 && cur_time > 0,
+                                                         list(x1 = imm_minage))),
+  
   g3a_growmature(ling_imm,
                  impl_f = g3a_grow_impl_bbinom(
-                   g3a_grow_lengthvbsimple(linf, K),
-                   g3a_grow_weightsimple(~g3_param("lingimm.walpha"),
-                                         ~g3_param("lingimm.wbeta")),
-                   beta_f = ~bounded(g3_param("ling.bbin"),1,1000),
-                   maxlengthgroupgrowth = 10),
+                   g3a_grow_lengthvbsimple(model_params[['linf']], model_params[['K']]),
+                   g3a_grow_weightsimple(model_params[['walpha.imm']],
+                                         model_params[['wbeta.imm']]),
+                   beta_f = model_params[['bbin']],
+                   maxlengthgroupgrowth = mlgg),
                  maturity_f = g3a_mature_continuous(
-                   alpha = ~(0.001 * exp(g3_param("ling.mat1"))),
-                   l50 = ~bounded(g3_param("ling.mat2"),20,120)),
-                 output_stocks = list(ling_mat)),
-  g3a_naturalmortality(ling_imm,
-                       g3a_naturalmortality_exp(~g3_param_table("lingimm.M", data.frame(age = seq(ling_imm__minage, ling_imm__maxage))))),
-  g3a_age(ling_imm,
-          output_stocks = list(ling_mat)),
+                   alpha = model_params[['mat1']],
+                   l50 = model_params[['mat2']]),
+                 output_stocks = list(stock_list[["mat_stock"]])),
+  
+  g3a_naturalmortality(stock_list[["imm_stock"]],
+                       g3a_naturalmortality_exp(model_params[['M.imm']])),
+  
+  g3a_age(stock_list[["imm_stock"]],
+          output_stocks = list(stock_list[["mat_stock"]])),
   list())
 
+
+## MATURE STOCK
 ling_mat_actions <- list(
-  g3a_initialconditions_normalparam(ling_mat,
+  g3a_initialconditions_normalparam(stock_list[["mat_stock"]],
                                     # NB: area & age factor together (gadget2 just multiplied them)
                                     factor_f =
                                       gadget3:::f_substitute(~ling_init_abund *
-                                                               exp(-1 * (g3_param_table("lingmat.M",
-                                                                                        data.frame(age = seq(ling_imm__minage, ling_mat__maxage) )) +
-                                                                           init_F) * (age - ling_imm__minage)) *prop_m_age,
-                                                             list(ling_init_abund = ling_init_abund, prop_m_age = prop_m_age, init_F = init_F)),
+                                                               exp(-1 * (g3_param_table(nm, data.frame(age = seq(x1, y2))) +
+                                                                           init_F) * (age - x1)) *prop_m_age,
+                                                             list(ling_init_abund = ling_init_abund,
+                                                                  prop_m_age = prop_m_age,
+                                                                  init_F = model_params[['init_F']],
+                                                                  nm = paste0(species_name, "mat.M"),
+                                                                  x1 = imm_minage,
+                                                                  y2 = mat_maxage)),
+                                    
                                     mean_f = mean_l,
-                                    stddev_f = ~g3_param_table('lingmat.init.sd',data.frame(age = seq(ling_mat__minage, ling_mat__maxage))),
-                                    alpha_f = ~g3_param("lingmat.walpha"),
-                                    beta_f = ~g3_param("lingmat.wbeta")),
-  g3a_growmature(ling_mat,
+                                    stddev_f = model_params[['init.sd.mat']],
+                                    alpha_f = model_params[['walpha.mat']],
+                                    beta_f = model_params[['wbeta.mat']]),
+  
+  g3a_growmature(stock_list[["mat_stock"]],
                  impl_f = g3a_grow_impl_bbinom(
-                   g3a_grow_lengthvbsimple(linf, K),
-                   g3a_grow_weightsimple(~g3_param("lingmat.walpha"),
-                                         ~g3_param("lingmat.wbeta")),
-                   beta_f = ~bounded(g3_param("ling.bbin"),1,1000),
-                   maxlengthgroupgrowth = 10)),
-  g3a_naturalmortality(ling_mat,
-                       g3a_naturalmortality_exp(~g3_param_table("lingmat.M", data.frame(age = seq(ling_mat__minage, ling_mat__maxage))))),
-  g3a_age(ling_mat),
+                   g3a_grow_lengthvbsimple(model_params[['linf']], model_params[['K']]),
+                   g3a_grow_weightsimple(model_params[['walpha.mat']],
+                                         model_params[['wbeta.mat']]),
+                   beta_f = model_params[['bbin']],
+                   maxlengthgroupgrowth = mlgg)),
+  
+  g3a_naturalmortality(stock_list[["mat_stock"]],
+                       g3a_naturalmortality_exp(model_params[['M.mat']])),
+  
+  g3a_age(stock_list[["mat_stock"]]),
   list())
+
+
 

--- a/demo-ling/setup-report_actions.R
+++ b/demo-ling/setup-report_actions.R
@@ -1,0 +1,67 @@
+## -----------------------------------------------------------------------------
+## Set up report actions:
+
+# Disaggregated report storage for *_imm stock (we store with same age/step/length as ling itself)
+imm_report <- g3s_clone(stock_list$imm_stock, 'imm_report') %>%
+  g3s_time(year = local(year_range), step = 1:4)
+
+# Disaggregated report storage for *_mat (we store with same age/step/length as ling itself)
+mat_report <- g3s_clone(stock_list$mat_stock, 'mat_report') %>%
+  g3s_time(year = local(year_range), step = 1:4)
+
+
+report_actions <- list(
+  # Report numbers
+  g3a_report_stock(imm_report, stock_list$imm_stock, 
+                   gadget3:::f_substitute(~stock_ss(x), list(x=as.symbol(paste0(imm_stock, "__num"))))),
+  g3a_report_stock(mat_report, stock_list$mat_stock, 
+                   gadget3:::f_substitute(~stock_ss(x), list(x=as.symbol(paste0(mat_stock, "__num"))))),
+  
+  # Report mean weight
+  g3a_report_stock(imm_report, stock_list$imm_stock, 
+                   gadget3:::f_substitute(~stock_ss(x), list(x=as.symbol(paste0(imm_stock, "__wgt"))))),
+  g3a_report_stock(mat_report, stock_list$mat_stock, 
+                   gadget3:::f_substitute(~stock_ss(x), list(x=as.symbol(paste0(mat_stock, "__wgt"))))),
+  
+  # Report biomass caught by survey
+  g3a_report_stock(imm_report, stock_list$imm_stock, 
+                   gadget3:::f_substitute(~stock_ss(x), list(x=as.symbol(paste0(imm_stock, "__igfs"))))),
+  g3a_report_stock(mat_report, stock_list$mat_stock, 
+                   gadget3:::f_substitute(~stock_ss(x), list(x=as.symbol(paste0(mat_stock, "__igfs"))))),
+  
+  # Report biomass caught by commercial, longline
+  g3a_report_stock(imm_report, stock_list$imm_stock, 
+                   gadget3:::f_substitute(~stock_ss(x), list(x=as.symbol(paste0(imm_stock, "__lln"))))),
+  g3a_report_stock(mat_report, stock_list$mat_stock, 
+                   gadget3:::f_substitute(~stock_ss(x), list(x=as.symbol(paste0(mat_stock, "__lln"))))),
+  
+  # Bottom trawl
+  g3a_report_stock(imm_report, stock_list$imm_stock, 
+                   gadget3:::f_substitute(~stock_ss(x), list(x=as.symbol(paste0(imm_stock, "__bmt"))))),
+  g3a_report_stock(mat_report, stock_list$mat_stock, 
+                   gadget3:::f_substitute(~stock_ss(x), list(x=as.symbol(paste0(mat_stock, "__bmt"))))),
+  
+  # Gillnet
+  g3a_report_stock(imm_report, stock_list$imm_stock, 
+                   gadget3:::f_substitute(~stock_ss(x), list(x=as.symbol(paste0(imm_stock, "__gil"))))),
+  g3a_report_stock(mat_report, stock_list$mat_stock, 
+                   gadget3:::f_substitute(~stock_ss(x), list(x=as.symbol(paste0(mat_stock, "__gil"))))),
+  
+  # Foreign 
+  g3a_report_stock(imm_report, stock_list$imm_stock, 
+                   gadget3:::f_substitute(~stock_ss(x), list(x=as.symbol(paste0(imm_stock, "__foreign"))))),
+  g3a_report_stock(mat_report, stock_list$mat_stock, 
+                   gadget3:::f_substitute(~stock_ss(x), list(x=as.symbol(paste0(mat_stock, "__foreign"))))),
+  
+  # Recruitment numbers and weight
+  g3a_report_stock(imm_report, stock_list$imm_stock, 
+                   gadget3:::f_substitute(~stock_ss(x), list(x=as.symbol(paste0(imm_stock, "__renewalnum"))))),
+  g3a_report_stock(imm_report, stock_list$imm_stock, 
+                   gadget3:::f_substitute(~stock_ss(x), list(x=as.symbol(paste0(imm_stock, "__renewalwgt"))))),
+  
+  # Report suitability (survey)
+  g3a_report_stock(imm_report, stock_list$imm_stock, 
+                   gadget3:::f_substitute(~stock_ss(x), list(x=as.symbol(paste0(imm_stock, "__suit_igfs"))))),
+  g3a_report_stock(mat_report, stock_list$mat_stock, 
+                   gadget3:::f_substitute(~stock_ss(x), list(x=as.symbol(paste0(mat_stock, "__suit_igfs"))))))
+  

--- a/demo-ling/setup.R
+++ b/demo-ling/setup.R
@@ -2,8 +2,18 @@ library(mfdb)
 library(tidyverse)
 library(gadget3)
 
+## functions for inserting species name into param references
+source("demo-ling/stock_param_functions.r")
+
+## Some model parameters...
 year_range <- 1982:lubridate::year(Sys.Date())
 read_data <- FALSE
+
+## Stock info.
+species_name <- "ling"
+species_code <- "LIN"
+
+## -----------------------------------------------------------------------------
 
 reitmapping <-
   read.table(
@@ -15,27 +25,59 @@ defaults <- list(
   area = mfdb::mfdb_group("1" = unique(reitmapping$SUBDIVISION)),
   timestep = mfdb::mfdb_timestep_quarterly,
   year = year_range,
-  species = 'LIN')
+  species = species_code)
 
 # Map area names to integer area numbers (in this case only "1" ==> 1, but could be anything)
 areas <- structure(
-    seq_along(defaults$area),
-    names = names(defaults$area))
+  seq_along(defaults$area),
+  names = names(defaults$area))
 
-##### Configure model stocks/fleets ###########################################
+# Timekeeping for the model, i.e. how long we run for
+time_actions <- list(
+  g3a_time(start_year = min(defaults$year),
+           end_year = max(defaults$year),
+           defaults$timestep),
+  list())
 
-## modelled stocks
+##### Configure stocks #########################################################
+
+mat_stock <- paste0(species_name, "_mat")
+imm_stock <- paste0(species_name, "_imm")
+
+## stocks
 ling_imm <-
-  g3_stock('ling_imm', seq(4, 156, 4)) %>%
+  g3_stock(imm_stock, lengthgroups = seq(4, 156, 4)) %>%
   g3s_livesonareas(areas[c('1')]) %>%
-  g3s_age(3, 10)
+  g3s_age(minage = 3, maxage = 10)
 
 ling_mat <-
-  g3_stock('ling_mat', seq(20, 156, 4)) %>%
+  g3_stock(mat_stock, lengthgroups = seq(20, 156, 4)) %>%
   g3s_livesonareas(areas[c('1')]) %>%
-  g3s_age(5, 15)
+  g3s_age(minage = 5, maxage = 15)
 
-## fleets
+## Will configurations change?
+stock_list <- 
+  list(imm_stock = ling_imm,
+       mat_stock = ling_mat)
+
+## Maximum number of length groups a stock can group within a time step (maxlengthgroupgrowth)
+mlgg <- 10
+
+## Age and length bounds per stock
+minage <- lapply(stock_list, function(x){ x$iterate %>% environment %>% .$minage })
+maxage <- lapply(stock_list, function(x){ x$iterate %>% environment %>% .$maxage })
+maxlength <- lapply(stock_list, function(x){ x$iterate %>% environment() %>% .$lengthgroups %>% max() })
+minlength <- lapply(stock_list, function(x){ x$iterate %>% environment() %>% .$lengthgroups %>% min() })
+dl <- lapply(stock_list, function(x){ x$iterate %>% environment() %>% .$stock__dl %>% min() })
+
+############ Configure fleets ##################################################
+
+## Survey(s)
+igfs <-
+  g3_fleet('igfs') %>%
+  g3s_livesonareas(areas[c('1')])
+
+## Commercial
 lln <-
   g3_fleet('lln') %>%
   g3s_livesonareas(areas[c('1')])
@@ -52,13 +94,12 @@ foreign <-
   g3_fleet('foreign') %>%
   g3s_livesonareas(areas[c('1')])
 
-igfs <-
-  g3_fleet('igfs') %>%
-  g3s_livesonareas(areas[c('1')])
 
-# Load required data objects
+#### Load required data objects ################################################
+
 if(read_data){
-  mdb<-mfdb('Iceland', db_params = list(host = 'mfdb.hafro.is'))
+  mdb <- mfdb('Iceland', db_params = list(host = 'mfdb.hafro.is'))
+  #  mdb <- mfdb("../../mfdb/copy/iceland.duckdb")
   source('demo-ling/setup-fleet-data.R')
   source('demo-ling/setup-catchdistribution.R')
   source('demo-ling/setup-indices.R')
@@ -71,56 +112,10 @@ if(read_data){
 
 ##### Configure model actions #################################################
 
-# Timekeeping for the model, i.e. how long we run for
-time_actions <- list(
-    g3a_time(start_year = min(defaults$year),
-        end_year = max(defaults$year),
-        defaults$timestep),
-    list())
-
 source('demo-ling/setup-fleets.R')  # Generates fleet_actions
-source('demo-ling/setup-model.R')  # Generates ling_mat_actions / ling_imm_actions
-source('demo-ling/setup-likelihood.R')  # Generates ling_likelihood_actions
-
-## set up reporting:
-
-# Disaggregated report storage for ling_imm (we store with same age/step/length as ling itself)
-imm_report <- g3s_clone(ling_imm, 'imm_report') %>%
-  g3s_time(year = local(year_range), step = 1:4)
-
-# Disaggregated report storage for ling_mat (we store with same age/step/length as ling itself)
-mat_report <- g3s_clone(ling_mat, 'mat_report') %>%
-  g3s_time(year = local(year_range), step = 1:4)
-
-report_actions <- list(
-       # Report ling numbers
-       g3a_report_stock(imm_report,ling_imm, ~stock_ss(ling_imm__num)),
-       g3a_report_stock(mat_report,ling_mat, ~stock_ss(ling_mat__num)),
-       # Report ling mean weight
-       g3a_report_stock(imm_report,ling_imm, ~stock_ss(ling_imm__wgt)),
-       g3a_report_stock(mat_report,ling_mat, ~stock_ss(ling_mat__wgt)),
-       # Report ling biomass caught by igfs
-       g3a_report_stock(mat_report,ling_mat, ~stock_ss(ling_mat__igfs)),
-       g3a_report_stock(imm_report,ling_imm, ~stock_ss(ling_imm__igfs)),
-       # Report ling biomass caught by bmt
-       g3a_report_stock(mat_report,ling_mat, ~stock_ss(ling_mat__bmt)),
-       g3a_report_stock(imm_report,ling_imm, ~stock_ss(ling_imm__bmt)),
-       # Report ling biomass caught by lln
-       g3a_report_stock(mat_report,ling_mat, ~stock_ss(ling_mat__lln)),
-       g3a_report_stock(imm_report,ling_imm, ~stock_ss(ling_imm__lln)),
-       # Report ling biomass caught by gil
-       g3a_report_stock(mat_report,ling_mat, ~stock_ss(ling_mat__gil)),
-       g3a_report_stock(imm_report,ling_imm, ~stock_ss(ling_imm__gil)),
-       # Report ling biomass caught by foreign
-       g3a_report_stock(mat_report,ling_mat, ~stock_ss(ling_mat__foreign)),
-       g3a_report_stock(imm_report,ling_imm, ~stock_ss(ling_imm__foreign)),
-       ## recruitment
-       g3a_report_stock(imm_report,ling_imm, ~stock_ss(ling_imm__renewalnum)),
-       g3a_report_stock(imm_report,ling_imm, ~stock_ss(ling_imm__renewalwgt)),
-
-       # Report ling suitability caught by igfs
-       g3a_report_stock(mat_report,ling_mat, ~stock_ss(ling_mat__suit_igfs)),
-       g3a_report_stock(imm_report,ling_imm, ~stock_ss(ling_imm__suit_igfs)))
+source('demo-ling/setup-model.R')  # Generates mat_actions / imm_actions
+source('demo-ling/setup-likelihood.R')  # Generates likelihood_actions
+source('demo-ling/setup-report_actions.R')  # Generates report actions
 
 ##### Run r-based model #######################################################
 
@@ -131,29 +126,36 @@ ling_model <- g3_to_r(c(
   fleet_actions,
   ling_likelihood_actions,
   report_actions,
-  time_actions), strict = TRUE)
+  time_actions), 
+  #  trace = T, 
+  strict = T)
 
 # Get pararameter template attached to function, fill it in
 ling_param <- attr(ling_model, 'parameter_template')
-ling_param[["lingimm.walpha"]] <- 2.27567436711055e-06
-ling_param[["lingimm.wbeta"]] <- 3.20200445996187
-ling_param[["ling.bbin"]] <- 6
-#ling_param[["ling.rec.1982"]] <- 1
-ling_param[["lingmat.walpha"]] <- 2.27567436711055e-06
-ling_param[["lingmat.wbeta"]] <- 3.20200445996187
-ling_param[["ling_si_beta1"]] <- 1
-ling_param[["ling_si_beta2"]] <- 1
-ling_param[grepl('^lingimm\\.M\\.', names(ling_param))] <- 0.15
-ling_param[grepl('^lingmat\\.M\\.', names(ling_param))] <- 0.15
-ling_param[grepl('^ling\\.rec\\.', names(ling_param))] <- 1
-ling_param[grepl('^lingimm\\.init\\.sd', names(ling_param))] <- init.sigma$ms[3:10]
-ling_param[grepl('^lingmat\\.init\\.sd', names(ling_param))] <- init.sigma$ms[5:15]
+ling_param[[sprintf("%simm.walpha", species_name)]] <- 2.27567436711055e-06
+ling_param[[sprintf("%smat.walpha", species_name)]] <- 2.27567436711055e-06
 
+ling_param[[sprintf("%simm.wbeta", species_name)]] <- 3.20200445996187
+ling_param[[sprintf("%smat.wbeta", species_name)]] <- 3.20200445996187
+
+ling_param[[sprintf("%s.bbin", species_name)]] <- 6
+
+ling_param[grepl(paste0('^',species_name,"imm\\.M\\."), names(ling_param))] <- 0.15
+ling_param[grepl(paste0('^',species_name,"mat\\.M\\."), names(ling_param))] <- 0.15
+ling_param[grepl(paste0('^',species_name,"\\.rec\\."), names(ling_param))] <- 1
+
+ling_param[grepl(paste0('^',species_name,"imm\\.init\\.sd"), names(ling_param))] <-
+  init.sigma %>% filter(age %in% minage$imm_stock:maxage$imm_stock) %>% .$ms
+
+ling_param[grepl(paste0('^',species_name,"mat\\.init\\.sd"), names(ling_param))] <-
+  init.sigma %>% filter(age %in% minage$mat_stock:maxage$mat_stock) %>% .$ms
+
+## SI's
+ling_param[[sprintf("%s_si_beta1", species_name)]] <- 1
+ling_param[[sprintf("%s_si_beta2", species_name)]] <- 1
 ling_param[grepl('si_igfs_si.+weight$',names(ling_param))] <- 1
 
-
-## Old weights
-
+## Old weights from gadget2
 ling_param['ldist_lln_weight'] <- 3331
 ling_param['aldist_lln_weight'] <- 2512
 ling_param['ldist_bmt_weight'] <- 1247
@@ -167,15 +169,9 @@ ling_param['si_igfs_si1_weight'] <- 40
 ling_param['si_igfs_si2a_weight'] <- 8
 ling_param['si_igfs_si2b_weight'] <- 36
 ling_param['si_igfs_si3a_weight'] <- 19
-
 ling_param['si_igfs_si3b_weight'] <- 16
-
 ling_param['si_igfs_si3c_weight'] <- 13
 ling_param['si_igfs_si3d_weight'] <- 14.5
-#
-
-
-
 
 # You can edit the model code with:
 #ling_model <- edit(ling_model)
@@ -183,8 +179,10 @@ ling_param['si_igfs_si3d_weight'] <- 14.5
 # Run model with params above
 result <- ling_model(ling_param)
 result[[1]]
+
 # List all available reports
 print(names(attributes(result)))
+
 
 ##### Run TMB-based model #####################################################
 
@@ -231,10 +229,10 @@ tmb_param[grepl('^lingmat\\.M\\.', rownames(tmb_param)),]$optimise <- FALSE
 tmb_param[grepl('^lingimm\\.init\\.sd', rownames(tmb_param)),]$optimise <- FALSE
 tmb_param[grepl('^lingmat\\.init\\.sd', rownames(tmb_param)),]$optimise <- FALSE
 
-
 # Compile and generate TMB ADFun (see ?TMB::MakeADFun)
 ling_model_tmb <- g3_tmb_adfun(tmb_ling,tmb_param)
 # writeLines(TMB::gdbsource(g3_tmb_adfun(tmb_ling, tmb_param, compile_flags = "-g", output_script = TRUE)))
+
 # Run model once, using g3_tmb_par to reshape tmb_param into param vector.
 # Will return nll
 ling_model_tmb$fn(g3_tmb_par(tmb_param))
@@ -243,6 +241,11 @@ ling_model_tmb$fn(g3_tmb_par(tmb_param))
 ling_model_tmb$report(g3_tmb_par(tmb_param))
 
 # Run model through R optimiser, using bounds set in tmb_param
+fit.opt <- optim(g3_tmb_par(tmb_param),
+                 ling_model_tmb$fn,
+                 ling_model_tmb$gr,
+                 method = 'BFGS',
+                 control = list(trace = 2,maxit = 1000, reltol = .Machine$double.eps^2))
 
 
 # cl <- parallel::makeCluster(spec=parallel::detectCores(), outfile="")
@@ -257,45 +260,54 @@ ling_model_tmb$report(g3_tmb_par(tmb_param))
 
 #tmp <- set_names(rnorm(length(tmp), sd = 3),names(tmp))
 
-fit.opt <- optim(g3_tmb_par(tmb_param),
-                 ling_model_tmb$fn,
-                 ling_model_tmb$gr,
-                 method = 'BFGS',
-                 control = list(trace = 2,maxit = 1000, reltol = .Machine$double.eps^2))
-if(FALSE){
-fit.nelder <- optim(fit.opt2$par,
+
+if (FALSE){
+  
+  
+  
+  # cl <- parallel::makeCluster(spec=parallel::detectCores(), outfile="")
+  # parallel::setDefaultCluster(cl=cl)
+  #
+  # optimParallel::optimParallel(par=g3_tmb_par(tmb_param),
+  #                              fn=ling_model_tmb$fn,
+  #                              gr=ling_model_tmb$gr),
+  #                              control = list(trace = 2, fnscale = 1e3,maxit = 200, reltol = .Machine$double.eps),
+  #                              parallel=list(loginfo=TRUE))
+  
+  
+  fit.nelder <- optim(fit.opt$par,
+                      ling_model_tmb$fn,
+                      #ling_model_tmb$gr,
+                      method = "Nelder-Mead",
+                      control = list(trace = 2,fnscale = 1e3, maxit = 1000))
+  
+  # fit <- nlminb(g3_tmb_par(tmb_param),
+  #               ling_model_tmb$fn, ling_model_tmb$gr,
+  #              # upper = g3_tmb_upper(tmb_param),
+  #             #  lower = g3_tmb_lower(tmb_param),
+  #               control = list(trace = TRUE, eval.max=200, iter.max=100))
+  
+  
+  
+  fit.opt2 <- optim(fit.nelder$par,
                     ling_model_tmb$fn,
-                    #ling_model_tmb$gr,
-                    method = "Nelder-Mead",
-                    control = list(trace = 2,fnscale = 1e3, maxit = 1000))
-
-# fit <- nlminb(g3_tmb_par(tmb_param),
-#               ling_model_tmb$fn, ling_model_tmb$gr,
-#              # upper = g3_tmb_upper(tmb_param),
-#             #  lower = g3_tmb_lower(tmb_param),
-#               control = list(trace = TRUE, eval.max=200, iter.max=100))
-
-
-
-fit.opt2 <- optim(fit.nelder$par,
-                 ling_model_tmb$fn,
-                 ling_model_tmb$gr,
-                 method = 'BFGS',
-                 control = list(trace = 2,maxit = 1000, reltol = .Machine$double.eps^2))
-
-
-fit.opt3 <- optim(fit.opt2$par,
-                  ling_model_tmb$fn,
-                  ling_model_tmb$gr,
-                  method = 'BFGS',
-                  control = list(trace = 2, maxit = 1000, reltol = .Machine$double.eps))
-
- fit.opt4 <- nlminb(fit.opt3$par,
-                 ling_model_tmb$fn,
-                 ling_model_tmb$gr,
-                 method = 'BFGS',
-                 control = list(trace = TRUE, eval.max = 200, rel.tol = .Machine$double.eps))
-
+                    ling_model_tmb$gr,
+                    method = 'BFGS',
+                    control = list(trace = 2,maxit = 1000, reltol = .Machine$double.eps^2))
+  
+  
+  fit.opt3 <- optim(fit.opt2$par,
+                    ling_model_tmb$fn,
+                    ling_model_tmb$gr,
+                    method = 'BFGS',
+                    control = list(trace = 2, maxit = 1000, reltol = .Machine$double.eps))
+  
+  fit.opt4 <- nlminb(fit.opt$par,
+                     ling_model_tmb$fn,
+                     ling_model_tmb$gr,
+                     method = 'BFGS',
+                     control = list(trace = TRUE, eval.max = 200, rel.tol = .Machine$double.eps))
+  
 }
 #
 # fit.nlminb <- nlminb(fit.opt$par,
@@ -303,7 +315,7 @@ fit.opt3 <- optim(fit.opt2$par,
 #               # upper = g3_tmb_upper(tmb_param),
 #               #  lower = g3_tmb_lower(tmb_param),
 #               control = list(trace = TRUE, eval.max=200, iter.max=100))
-# #
+#
 #
 # fit.sann <- optim(fit.opt$par,
 #                   ling_model_tmb$fn, method = 'SANN',
@@ -321,3 +333,6 @@ fit.opt3 <- optim(fit.opt2$par,
 #
 # # Turn fit parameters back into list, which can be used in table or R function
 # param_list <- g3_tmb_relist(tmb_param, fit$par)
+
+
+

--- a/demo-ling/stock_param_functions.r
+++ b/demo-ling/stock_param_functions.r
@@ -1,0 +1,47 @@
+## ADDITIONAL FUNCTIONS TO HELP WITH THE SETUP SCRIPTS
+
+## Function to insert stock/species name into g3 parameter
+g3_stock_param <- function(sname, param, lower=NULL, upper=NULL, xby=NULL, sep0="."){
+  
+  nullval <- is.null(lower) + is.null(upper)
+  
+  ## No bounds 
+  if (nullval > 0){
+    if (nullval == 1) warning("One bound is NULL & the other is not NULL, assuming unbounded")
+    tmp <- gadget3:::f_substitute(~g3_param(x), list(x=paste(sname, param, sep=sep0)))
+  }
+  ## Bounds
+  else{
+    lb <- as.numeric(min(lower))
+    ub <- as.numeric(max(upper))
+    tmp <- gadget3:::f_substitute(~bounded(g3_param(x), lb, ub), 
+                                  list(x=paste(sname, param, sep=sep0), lb=lb, ub=ub))
+  }
+  if (!is.null(xby)){
+    tmp <- gadget3:::f_substitute(~y * x, list(y=xby, x=tmp))
+  }
+  return(tmp)
+}
+
+## Function to insert stock/species name into g3 param table (just by age)
+g3_stock_param_table <- function(sname, param, lowage, highage, lower=NULL, upper=NULL, sep0="."){
+  
+  nullval <- is.null(lower) + is.null(upper)
+  
+  ## No bounds
+  if (nullval > 0){
+    if (nullval == 1) warning("One bound is NULL & the other is not NULL, assuming unbounded")
+    tmp <- gadget3:::f_substitute(~g3_param_table(nm, data.frame(age=seq(la, ha))),
+                                  list(nm=paste(sname, param, sep=sep0), la=lowage, ha=highage))
+  }
+  ## Bounds
+  else{
+    lb <- as.numeric(min(lower))
+    ub <- as.numeric(max(upper))
+    tmp <- gadget3:::f_substitute(~bounded(g3_param_table(nm, data.frame(age=seq(la, ha))), lb, ub),
+                                  list(nm=paste(sname, param, sep=sep0), 
+                                       la=lowage, ha=highage,
+                                       lb=lb, ub=ub))
+  }
+  return(tmp)
+}


### PR DESCRIPTION
First go at creating a more general set of setup scripts for g3 models. The majority of changes are to make it easier to substitute stock names into parameter references via wrappers for g3_param and g3_param_table (in demo-ling/stock_param_functions.r), e.g.  
current setup: linf <- ~bounded(g3_param("ling.Linf"),150,200) 
proposed setup: linf <- g3_stock_param(species_name, param = "Linf", lower = 150, upper = 200)

The scripts produce the same output as the current setup scripts provided igfs_landings data.frame is taken from demo-ling/igfs_landings.Rdata and not defined at the top of "setup-fleets.R"

