### PR TITLE
create param name from multiple name parts

### DIFF
--- a/R/params.R
+++ b/R/params.R
@@ -30,8 +30,17 @@ g3_parameterized <- function(
             table_defn <- c(table_defn, list(age = quote(seq(stock__minage, stock__maxage))))
         }
 
+        # Define name_part based on input by_stock
+        if (isTRUE(by_stock)) {
+            name_part <- NULL
+        } else if (length(by_stock) > 1) {
+            # Turn a vector into it's c(x, y, ...) language expression
+            name_part <- as.call(c(as.symbol("c"), by_stock))
+        } else {
+            name_part <- by_stock
+        }
+
         # Use stock_param() to do the substitutions later
-        name_part <- if (isTRUE(by_stock)) NULL else by_stock
         if (length(table_defn) > 0) {
             table_defn <- as.call(c(as.symbol('expand.grid'), table_defn))
             out <- substitute(stock_param_table(stock, x, name_part = name_part, table_defn), list(x = name, name_part = name_part, table_defn = table_defn))

--- a/R/step.R
+++ b/R/step.R
@@ -334,7 +334,7 @@ g3_step <- function(step_f, recursing = FALSE, orig_env = environment(step_f)) {
 
             # Use name_part if part of the call
             if (!is.null(rest$name_part)) {
-                param_name <- paste(stock$name_part[rest$name_part], collapse = '_')
+                param_name <- paste(stock$name_part[eval(rest$name_part, envir = baseenv())], collapse = '_')
             } else {
                 param_name <- stock$name
             }

--- a/R/step.R
+++ b/R/step.R
@@ -334,7 +334,7 @@ g3_step <- function(step_f, recursing = FALSE, orig_env = environment(step_f)) {
 
             # Use name_part if part of the call
             if (!is.null(rest$name_part)) {
-                param_name <- stock$name_part[[rest$name_part]]
+                param_name <- paste(stock$name_part[rest$name_part], collapse = '_')
             } else {
                 param_name <- stock$name
             }
@@ -354,7 +354,7 @@ g3_step <- function(step_f, recursing = FALSE, orig_env = environment(step_f)) {
 
             # Use name_part if part of the call
             if (!is.null(rest$name_part)) {
-                param_name <- stock$name_part[[rest$name_part]]
+                param_name <- paste(stock$name_part[rest$name_part], collapse = '_')
             } else {
                 param_name <- stock$name
             }

--- a/man/params.Rd
+++ b/man/params.Rd
@@ -27,7 +27,7 @@ g3_parameterized(
     \describe{
       \item{FALSE}{No}
       \item{TRUE}{Produce a \code{"stock_name.name"} parameter}
-      \item{string}{Select the stock name_part to use, e.g. to produce \code{"stock_species.name"} parameter with "species"}
+      \item{character vector}{Select the stock name_part(s) to use, e.g. to produce \code{"stock_species.name"} parameter with "species"}
       \item{List of \code{\link{g3_stock}} objects}{Produce a parameter that applies to all given stocks}
     }
   }

--- a/man/step.Rd
+++ b/man/step.Rd
@@ -239,17 +239,19 @@
   \code{stock_param(stock, name, name_part = NULL, ...)}
 
   Convert to a call to \link{g3_param}, prefixing the \var{name} with the stock name.
-  If \var{name_part} given, only use that part of the stock name.
+  If \var{name_part} given, only use given part(s) of the stock name.
 
   All other args passed through to \link{g3_param}.
 
   \subsection{Examples}{
 
-\preformatted{> stock <- g3_stock(c(species = 'halibut', 'imm'), 1:10) |> g3s_age(1,10)
+\preformatted{> stock <- g3_stock(c(species = 'halibut', sex = 'm', 'imm'), 1:10) |> g3s_age(1,10)
 > gadget3:::g3_step(~stock_param(stock, 'K'))
-~g3_param("halibut_imm.K")
+~g3_param("halibut_m_imm.K")
 > gadget3:::g3_step(~stock_param(stock, 'K', name_part = 'species'))
-~g3_param("halibut.K")}
+~g3_param("halibut.K")
+> gadget3:::g3_step(~stock_param(stock, 'K', name_part = c('species', 'sex')))
+~g3_param("halibut_m.K")}
   }
 }
 

--- a/tests/test-params.R
+++ b/tests/test-params.R
@@ -13,7 +13,7 @@ stock_fmat <- g3_stock(c(species = 'st', sex = 'f', maturity = 'mat'), seq(10, 3
 pretend_stock_action <- function (x) {
     rlang::f_rhs(gadget3:::g3_step(gadget3:::call_to_formula(
         x,
-        env = as.environment(list(stock = stock_mimm)))))
+        env = list2env(list(stock = stock_mimm), parent = baseenv()))))
 }
 
 ok(cmp_code(
@@ -66,9 +66,11 @@ ok(cmp_code(
 ok(cmp_code(
     pretend_stock_action(call("{",  # }
         g3_parameterized('parp', by_stock = 'species', lower = 3),
+        g3_parameterized('parp', by_stock = c('species', 'sex'), lower = 3),
         g3_parameterized('parp', by_stock = 'sex', by_year = TRUE),
     NULL)), quote({
         g3_param("st.parp", lower = 3)
+        g3_param("st_m.parp", lower = 3)
         g3_param_table("m.parp", expand.grid(cur_year = seq(start_year, end_year)))
     NULL})), "Can specify which name_part should be used in the name")
 

--- a/tests/test-step.R
+++ b/tests/test-step.R
@@ -232,15 +232,15 @@ ok_group("g3_step:dependent_formulas", (function () {
 })())
 
 ok_group("g3_step:stock_param", {
-    stock_a <- g3_stock(c(t = 'stock', 'aaa'), seq(10, 35, 5))
+    stock_a <- g3_stock(c(t = 'stock', q = 'stick', 'aaa'), seq(10, 35, 5))
 
     ok(cmp_code(
         gadget3:::g3_step(~{
             stock_param(stock_a, 'parr', optmise = FALSE)
             stock_param(stock_a, 'parr', optmise = FALSE, upper = 5)
         }), ~{
-            g3_param("stock_aaa.parr", optmise = FALSE)
-            g3_param("stock_aaa.parr", optmise = FALSE, upper = 5)
+            g3_param("stock_stick_aaa.parr", optmise = FALSE)
+            g3_param("stock_stick_aaa.parr", optmise = FALSE, upper = 5)
         }), "Passed through options")
     ok(cmp_code(
         gadget3:::g3_step(~{
@@ -252,6 +252,16 @@ ok_group("g3_step:stock_param", {
             g3_param("stock.parr")
             g3_param("stock.parr", lower = 4, upper = 5)
         }), "name_part can be either beffore or after name, not passed through to g3_param call")
+    ok(cmp_code(
+        gadget3:::g3_step(~{
+            stock_param(stock_a, name_part = c('t', 'q'), 'par1')
+            stock_param(stock_a, name_part = c('q', 't'), 'par1')
+            stock_param(stock_a, name_part = c('t'), 'par1')
+        }), ~{
+            g3_param("stock_stick.par1")
+            g3_param("stick_stock.par1")
+            g3_param("stock.par1")
+        }), "name_part can contain multiple name_parts, get used in order")
 })
 
 ok_group("g3_step:stock_param_table", {


### PR DESCRIPTION
Allows multiple name parts to be used for parameter names, e.g., `g3_parameterized('K', by_stock = c('species', 'sex'))`