### PR TITLE
g3a_report_detail: spawnednum added to default report

### DIFF
--- a/R/action_report.R
+++ b/R/action_report.R
@@ -123,7 +123,7 @@ g3a_report_detail <- function (actions,
             run_at = abundance_run_at),
         g3a_report_history(
             actions = actions,
-            var_re = c('__renewalnum$', '__suit_', '__predby_'),
+            var_re = c('__renewalnum$', '__spawnednum$', '__suit_', '__predby_'),
             out_prefix = "detail_",
             run_f = run_f,
             run_at = run_at),


### PR DESCRIPTION
added `__spawnednum` to default reporting for instances when spawning is used