### PR TITLE
recruitment age added to g3a_renewal_vonb/initabund

### DIFF
--- a/R/action_renewal.R
+++ b/R/action_renewal.R
@@ -9,13 +9,15 @@ g3a_renewal_vonb <- function(
         Linf = g3_parameterized('Linf', by_stock = by_stock),
         K = g3_parameterized('K', by_stock = by_stock, scale = 0.001),
         recl = g3_parameterized('recl', by_stock = by_stock),
+        recage = g3_parameterized('recage', by_stock = FALSE, optimise = FALSE),
         by_stock = TRUE) {
     f_substitute(
-        quote( Linf * (1 - exp(-1 * K * (age - (1 + log(1 - recl/Linf)/K) ))) ),
+        quote( Linf * (1 - exp(-1 * K * (age - (recage + log(1 - recl/Linf)/K) ))) ),
         list(
             Linf = Linf,
             K = K,
-            recl = recl))
+            recl = recl,
+            recage = recage))
 }
 
 g3a_renewal_initabund <- function(
@@ -23,14 +25,18 @@ g3a_renewal_initabund <- function(
     init = g3_parameterized('init', by_stock = by_stock, by_age = TRUE),
     M = g3_parameterized('M', by_stock = by_stock),
     init_F = g3_parameterized('init.F', by_stock = by_stock_f),
+    recage = g3_parameterized('recage', by_stock = FALSE, optimise = FALSE),
+    proportion_f = ~1,
     by_stock = TRUE,
     by_stock_f = FALSE){
   f_substitute(
-    ~scalar * init * exp(-1 * (M + init_F) * age),
+    ~scalar * init * exp(-1 * (M + init_F) * (age - recage)) * proportion_f,
     list(scalar = scalar,
          init = init,
          M = M,
-         init_F = init_F)
+         init_F = init_F,
+         recage = recage,
+         proportion_f = proportion_f)
   )
 }
 

--- a/man/action_renewal.Rd
+++ b/man/action_renewal.Rd
@@ -16,6 +16,7 @@ g3a_renewal_vonb(
         Linf = g3_parameterized('Linf', by_stock = by_stock),
         K = g3_parameterized('K', by_stock = by_stock, scale = 0.001),
         recl = g3_parameterized('recl', by_stock = by_stock),
+        recage = g3_parameterized('recage', by_stock = FALSE, optimise = FALSE),
         by_stock = TRUE)
 
 g3a_renewal_initabund(
@@ -23,6 +24,8 @@ g3a_renewal_initabund(
     init = g3_parameterized('init', by_stock = by_stock, by_age = TRUE),
     M = g3_parameterized('M', by_stock = by_stock),
     init_F = g3_parameterized('init.F', by_stock = by_stock_f),
+    recage = g3_parameterized('recage', by_stock = FALSE, optimise = FALSE),
+    proportion_f = ~1,
     by_stock = TRUE,
     by_stock_f = FALSE)
 
@@ -93,10 +96,12 @@ g3a_renewal_normalparam(
   \item{Linf}{\link{formula} substituted into vonb calcuations, see below.}
   \item{K}{\link{formula} substituted into vonb calcuations, see below.}
   \item{recl}{\link{formula} substituted into vonb calcuations, see below.}
-  \item{scalar}{\link{formula} substituted into vonb calcuations, see below.}
-  \item{init}{\link{formula} substituted into vonb calcuations, see below.}
-  \item{M}{\link{formula} substituted into vonb calcuations, see below.}
-  \item{init_F}{\link{formula} substituted into vonb calcuations, see below.}
+  \item{recage}{\link{formula} substituted into initial abundance and vonb calcuations, see below.}
+  \item{proportion_f}{\link{formula} substituted into initial abundance calcuations, see below.}
+  \item{scalar}{\link{formula} substituted into initial abundance calcuations, see below.}
+  \item{init}{\link{formula} substituted into initial abundance calcuations, see below.}
+  \item{M}{\link{formula} substituted into initial abundance calcuations, see below.}
+  \item{init_F}{\link{formula} substituted into initial abundance calcuations, see below.}
   \item{by_stock}{Controls how parameters are grouped, see \code{\link{g3_parameterized}}}
   \item{wgt_by_stock}{Controls how parameters are grouped, see \code{\link{g3_parameterized}}}
   \item{by_stock_f}{Controls how parameters are grouped, see \code{\link{g3_parameterized}}}
@@ -117,11 +122,11 @@ g3a_renewal_normalparam(
 
 \value{
   \subsection{g3a_renewal_vonb}{A \link{formula} object representing
-    \deqn{ L_{\infty} * {1 - e^{-1 * \kappa * (a - (1 + \frac{\log(1 - r/L_{\infty})}{\kappa}  ))}} }
+    \deqn{ L_{\infty} * {1 - e^{-1 * \kappa * (a - (a_{0} + \frac{\log(1 - L_{0}/L_{\infty})}{\kappa}  ))}} }
 
   }
   \subsection{g3a_renewal_initabund}{A \link{formula} object representing
-    \deqn{ scalar * init * e{-1 * (M + init_F) * age } }
+    \deqn{ scalar * init * e^{-1 * (M + F_{0}) * (a - a_{0}) } * proportion_{a} } 
   }
   \subsection{g3a_initialconditions / g3a_renewal}{
   An action (i.e. list of formula objects) that will, for the given \var{stock}, iterate over each

--- a/man/run_r.Rd
+++ b/man/run_r.Rd
@@ -71,6 +71,7 @@ param$ling.init.F <- 0.4
 param$ling.Linf <- 160
 param$ling.K <- 90
 param$ling.recl <- 12
+param$recage <- g3_stock_def(ling_imm, 'minage')
 param[grepl('^ling.init.sd.', names(param))] <- 50.527220
 param[grepl('^ling_imm.init.\\\\d+', names(param))] <- 1
 param$ling_imm.init.scalar <- 200

--- a/man/run_tmb.Rd
+++ b/man/run_tmb.Rd
@@ -159,6 +159,7 @@ tmb_param$value$ling.init.F <- 0.4
 tmb_param$value$ling.Linf <- 160
 tmb_param$value$ling.K <- 90
 tmb_param$value$ling.recl <- 12
+tmb_param$recage <- g3_stock_def(ling_imm, 'minage')
 tmb_param[grepl('^ling.init.sd.', rownames(tmb_param)), 'value'] <- 50.527220
 tmb_param[grepl('^ling_imm.init.\\\\d+', rownames(tmb_param)), 'value'] <- 1
 tmb_param$value$ling_imm.init.scalar <- 200

--- a/tests/test-action_renewal.R
+++ b/tests/test-action_renewal.R
@@ -18,7 +18,8 @@ ok_group('g3a_renewal_vonb', {
     ok(cmp_formula(g3a_renewal_vonb(), g3_formula(
         stock_param(stock, "Linf", name_part = NULL) * (1 - exp(-1 *
             (0.001 * stock_param(stock, "K", name_part = NULL)) *
-            (age - (1 + log(1 - stock_param(stock, "recl", name_part = NULL) /
+            (age - (stock_param(stock, "recage", name_part = NULL) + 
+                      log(1 - stock_param(stock, "recl", name_part = NULL) /
                 stock_param(stock, "Linf", name_part = NULL)) /
                 (0.001 * stock_param(stock, "K", name_part = NULL))))))
             )), "Default params by stock")
@@ -26,15 +27,17 @@ ok_group('g3a_renewal_vonb', {
     ok(cmp_formula(g3a_renewal_vonb(by_stock = "species"), g3_formula(
         stock_param(stock, "Linf", name_part = "species") * (1 - exp(-1 *
             (0.001 * stock_param(stock, "K", name_part = "species")) *
-            (age - (1 + log(1 - stock_param(stock, "recl", name_part = "species") /
+            (age - (stock_param(stock, "recage", name_part = "species") + 
+                      log(1 - stock_param(stock, "recl", name_part = "species") /
                 stock_param(stock, "Linf", name_part = "species")) /
                 (0.001 * stock_param(stock, "K", name_part = "species"))))))
             )), "by_stock works for all default params")
 
-    ok(cmp_formula(g3a_renewal_vonb(Linf = 'Linf', K = g3_formula( x * 2, x = 10), recl = 'recl'), g3_formula(
-        "Linf" * (1 - exp(-1 * (x * 2) * (age - (1 + log(1 - "recl"/"Linf")/(x * 2))))),
-        x = 10)), "Can override with values, formulas")
-})
+    ok(cmp_formula(g3a_renewal_vonb(Linf = 'Linf', K = g3_formula( x * 2, x = 10), recl = 'recl', recage = 'recage'), 
+                   g3_formula(
+                     "Linf" * (1 - exp(-1 * (x * 2) * (age - ("recage" + log(1 - "recl"/"Linf")/(x * 2))))),
+                     x = 10)), "Can override with values, formulas")
+    })
 
 areas <- list(a=1, b=2, c=3, d=4)
 stock_a <- g3_stock('stock_a', seq(10, 10, 5)) %>% g3s_livesonareas(areas[c('a')])


### PR DESCRIPTION
Three changes: 
(1) a `recage` parameter is added to `g3a_renewal_vonb`, this is the age that corresponds to recruitment length (recl) 
(2) a `recage` parameter is added to `g3a_renewal_initabund` so that, for instance, abundance at age 5 is calculated by accounting for mortality up until (rather than including) age 5. 
(3) a `proportion_f` parameter to `g3a_renewal_initabund` so that an age-based ogive can be applied to split numbers between stocks.  