### PR TITLE
time lookup formulas working for pseudoyears

### DIFF
--- a/R/stock_time.R
+++ b/R/stock_time.R
@@ -1,97 +1,97 @@
 g3s_time_convert <- function (year, step = NULL) {
   if (any(step > 99)) {
     stop("The number of steps per year cannot exceed 99")
-  }
+}
   if (is.null(step)) {
     as.integer(year) * 100L
-  } else {
+    } else {
     as.integer(year) * 100L + as.integer(step)
-  }
+    }
 }
 
 g3s_time_labels <- function (times) {
   ## Steps are included
   if (any(times %% 100 > 0)) {
-    sprintf("%d-%02d",
+        sprintf("%d-%02d",
             times %/% 100L,
             times %% 100L)
-  } else {
+    } else {
     sprintf("%d", times %/% 100L)
-  }
+    }
 }
 
 # Time dimension, useful for data objects
 # - times: Vector of g3s_time_convert(year, step) for each year/step data applies to
 g3s_time <- function(inner_stock, times, year = NULL, step = NULL) {
-  # If year/step provided, populate times
-  if (!is.null(year)) {
-    if (is.null(step)) {
-      times <- g3s_time_convert(year)
-    } else {
-      # Generate all combinations of year/step, turn into times
-      times <- expand.grid(step = step, year = year)
-      times <- g3s_time_convert(times$year, times$step)
+    # If year/step provided, populate times
+    if (!is.null(year)) {
+        if (is.null(step)) {
+            times <- g3s_time_convert(year)
+        } else {
+            # Generate all combinations of year/step, turn into times
+            times <- expand.grid(step = step, year = year)
+            times <- g3s_time_convert(times$year, times$step)
+        }
     }
-  }
-  
-  # time -> index lookup
-  timelookup <- g3_intlookup(
-    paste0('times_', inner_stock$name),
-    as.integer(times),
-    seq_along(times))
-  
-  idx_f <- timelookup('getdefault', f_substitute(
+
+    # time -> index lookup
+    timelookup <- g3_intlookup(
+        paste0('times_', inner_stock$name),
+        as.integer(times),
+        seq_along(times))
+
+    idx_f <- timelookup('getdefault', f_substitute(
     ~cur_year * 100L + cur_step * step_required,
-    list(
+        list(
       step_required = as.integer(any(times %% 100 > 0)))), -1L)
-  stock__max_time_idx <- f_substitute(~g3_idx(t), list(t = length(times)))
-  
-  structure(list(
-    dim = c(inner_stock$dim,
+    stock__max_time_idx <- f_substitute(~g3_idx(t), list(t = length(times)))
+
+    structure(list(
+        dim = c(inner_stock$dim,
             time = length(times)),
-    dimnames = c(inner_stock$dimnames, list(
-      time = g3s_time_labels(times))),
-    # NB: iterate same as intersect, iterating over all time won't make sense in ~all cases
-    iterate = c(inner_stock$iterate, time = substitute(
-      g3_with(stock__time_idx := g3_idx(idx_f), if (stock__time_idx >= g3_idx(1L)) extension_point)
-      , list(idx_f = rlang::f_rhs(idx_f)))),
-    iter_ss = c(inner_stock$iter_ss, time = as.symbol("stock__time_idx")),
-    intersect = c(inner_stock$intersect, time = substitute(
-      g3_with(stock__time_idx := g3_idx(idx_f), if (stock__time_idx >= g3_idx(1L)) extension_point),
-      list(idx_f = rlang::f_rhs(idx_f)))),
-    interact = c(inner_stock$interact, time = substitute(
-      g3_with(stock__time_idx := g3_idx(idx_f), if (stock__time_idx >= g3_idx(1L)) extension_point)
-      , list(idx_f = rlang::f_rhs(idx_f)))),
-    with = c(inner_stock$with, time = quote(extension_point)),
-    env = as.environment(c(as.list(inner_stock$env), as.list(environment(idx_f)), list(
-      stock__max_time_idx = stock__max_time_idx))),
-    name_parts = inner_stock$name_parts,
-    name = inner_stock$name), class = c("g3_stock", "list"))
+        dimnames = c(inner_stock$dimnames, list(
+            time = g3s_time_labels(times))),
+        # NB: iterate same as intersect, iterating over all time won't make sense in ~all cases
+        iterate = c(inner_stock$iterate, time = substitute(
+                g3_with(stock__time_idx := g3_idx(idx_f), if (stock__time_idx >= g3_idx(1L)) extension_point)
+            , list(idx_f = rlang::f_rhs(idx_f)))),
+        iter_ss = c(inner_stock$iter_ss, time = as.symbol("stock__time_idx")),
+        intersect = c(inner_stock$intersect, time = substitute(
+            g3_with(stock__time_idx := g3_idx(idx_f), if (stock__time_idx >= g3_idx(1L)) extension_point),
+            list(idx_f = rlang::f_rhs(idx_f)))),
+        interact = c(inner_stock$interact, time = substitute(
+                g3_with(stock__time_idx := g3_idx(idx_f), if (stock__time_idx >= g3_idx(1L)) extension_point)
+            , list(idx_f = rlang::f_rhs(idx_f)))),
+        with = c(inner_stock$with, time = quote(extension_point)),
+        env = as.environment(c(as.list(inner_stock$env), as.list(environment(idx_f)), list(
+            stock__max_time_idx = stock__max_time_idx))),
+        name_parts = inner_stock$name_parts,
+        name = inner_stock$name), class = c("g3_stock", "list"))
 }
 
 # Add dimension for model time (i.e. every year/step)
 g3s_modeltime <- function (inner_stock, by_year = FALSE) {
-  # NB: Definitions are quote()d so they are defined at run-time as dynamic_dims (by g3a_time)
-  if (by_year) {
-    new_dims <- list(year = quote(as_integer(total_years)))
-    new_dimnames <- list(year = quote(seq(start_year, start_year + total_years - 1L)))
-    lookup <- list(year = quote(g3_idx(cur_year - start_year + 1L)))
-  } else {
-    new_dims <- list(time = quote(as_integer(total_steps + 1)))
-    new_dimnames <- list(time = quote(sprintf("%d-%02d",
-                                              rep(seq(start_year, start_year + total_years - 1L), each = length(step_lengths)),
-                                              rep(seq_along(step_lengths), times = total_years))))
-    lookup <- list(time = quote(g3_idx(cur_time+1L)))
-  }
-  structure(list(
-    dim = c(inner_stock$dim, new_dims),
-    dimnames = c(inner_stock$dimnames, new_dimnames),
-    iterate = c(inner_stock$iterate, time = quote(extension_point)),
-    iter_ss = c(inner_stock$iter_ss, lookup),
-    intersect = c(inner_stock$intersect, time = quote(extension_point)),
-    interact = c(inner_stock$interact, time = quote(extension_point)),
-    with = c(inner_stock$with, time = quote(extension_point)),
-    env = as.environment(c(as.list(inner_stock$env))),
-    name_parts = inner_stock$name_parts,
-    name = inner_stock$name), class = c("g3_stock", "list"))
+    # NB: Definitions are quote()d so they are defined at run-time as dynamic_dims (by g3a_time)
+    if (by_year) {
+        new_dims <- list(year = quote(as_integer(total_years)))
+        new_dimnames <- list(year = quote(seq(start_year, start_year + total_years - 1L)))
+        lookup <- list(year = quote(g3_idx(cur_year - start_year + 1L)))
+    } else {
+        new_dims <- list(time = quote(as_integer(total_steps + 1)))
+        new_dimnames <- list(time = quote(sprintf("%d-%02d",
+            rep(seq(start_year, start_year + total_years - 1L), each = length(step_lengths)),
+            rep(seq_along(step_lengths), times = total_years))))
+        lookup <- list(time = quote(g3_idx(cur_time+1L)))
+    }
+    structure(list(
+        dim = c(inner_stock$dim, new_dims),
+        dimnames = c(inner_stock$dimnames, new_dimnames),
+        iterate = c(inner_stock$iterate, time = quote(extension_point)),
+        iter_ss = c(inner_stock$iter_ss, lookup),
+        intersect = c(inner_stock$intersect, time = quote(extension_point)),
+        interact = c(inner_stock$interact, time = quote(extension_point)),
+        with = c(inner_stock$with, time = quote(extension_point)),
+        env = as.environment(c(as.list(inner_stock$env))),
+        name_parts = inner_stock$name_parts,
+        name = inner_stock$name), class = c("g3_stock", "list"))
 }

--- a/tests/test-stock_time.R
+++ b/tests/test-stock_time.R
@@ -41,98 +41,98 @@ stock_modelyear__num <- g3_stock_instance(stock_modelyear, 0)
 stock_modeltime_iterator <- 100
 
 actions <- list(
-  g3a_time(2000, 2004, step_lengths = c(6,6), project_years = ~g3_param('projectyears', value = 0)),
-  list(
-    "500:stock_time" = gadget3:::g3_step(~{
-      stock_iterate(stock_timeyear, stock_ss(stock_timeyear__num) <- stock_ss(stock_timeyear__num) + stock_modeltime_iterator)
-      stock_iterate(stock_timestep, stock_ss(stock_timestep__num) <- stock_ss(stock_timestep__num) + stock_modeltime_iterator)
-      stock_iterate(stock_timebigstep, stock_ss(stock_timebigstep__num) <- stock_ss(stock_timebigstep__num) + stock_modeltime_iterator)
-    }),
-    "500:stock_modeltime" = gadget3:::g3_step(~{
-      stock_iterate(stock_modeltime, stock_ss(stock_modeltime__num) <- stock_ss(stock_modeltime__num) + stock_modeltime_iterator)
-      stock_iterate(stock_modelyear, stock_ss(stock_modelyear__num) <- stock_ss(stock_modelyear__num) + stock_modeltime_iterator)
-    }),
-    "999" = ~{
-      stock_modeltime_iterator <- stock_modeltime_iterator + 1
-      nll <- g3_param('nll', value = 1)
-    }))
+    g3a_time(2000, 2004, step_lengths = c(6,6), project_years = ~g3_param('projectyears', value = 0)),
+    list(
+        "500:stock_time" = gadget3:::g3_step(~{
+            stock_iterate(stock_timeyear, stock_ss(stock_timeyear__num) <- stock_ss(stock_timeyear__num) + stock_modeltime_iterator)
+            stock_iterate(stock_timestep, stock_ss(stock_timestep__num) <- stock_ss(stock_timestep__num) + stock_modeltime_iterator)
+            stock_iterate(stock_timebigstep, stock_ss(stock_timebigstep__num) <- stock_ss(stock_timebigstep__num) + stock_modeltime_iterator)
+        }),
+        "500:stock_modeltime" = gadget3:::g3_step(~{
+            stock_iterate(stock_modeltime, stock_ss(stock_modeltime__num) <- stock_ss(stock_modeltime__num) + stock_modeltime_iterator)
+            stock_iterate(stock_modelyear, stock_ss(stock_modelyear__num) <- stock_ss(stock_modelyear__num) + stock_modeltime_iterator)
+        }),
+        "999" = ~{
+            stock_modeltime_iterator <- stock_modeltime_iterator + 1
+            nll <- g3_param('nll', value = 1)
+        }))
 
 # Compile model
 model_fn <- g3_to_r(actions, trace = FALSE)
 # model_fn <- edit(model_fn)
 if (nzchar(Sys.getenv('G3_TEST_TMB'))) {
-  model_cpp <- g3_to_tmb(actions, trace = FALSE)
-  # model_cpp <- edit(model_cpp)
-  model_tmb <- g3_tmb_adfun(model_cpp, compile_flags = c("-O0", "-g"))
+    model_cpp <- g3_to_tmb(actions, trace = FALSE)
+    # model_cpp <- edit(model_cpp)
+    model_tmb <- g3_tmb_adfun(model_cpp, compile_flags = c("-O0", "-g"))
 } else {
-  writeLines("# skip: not compiling TMB model")
+    writeLines("# skip: not compiling TMB model")
 }
 
 ok_group("g3s_modeltime", {
-  params <- attr(model_fn, 'parameter_template')
-  result <- model_fn(params)
-  r <- attributes(result)
-  # str(as.list(r), vec.len = 10000)
-  
-  ok(ut_cmp_identical(
-    r$stock_timeyear__num,
-    structure(
-      c(104 + 105, 108 + 109),
-      .Dim = structure(1:2, .Names = c("length", "time")),
-      .Dimnames = list(length = "1:Inf", time = c("2002", "2004")))), "stock_timeyear__num: 2002, 2004")
-  ok(ut_cmp_identical(
-    r$stock_timestep__num,
-    structure(
-      c(100, 107),
-      .Dim = structure(1:2, .Names = c("length", "time")),
-      .Dimnames = list(length = "1:Inf", time = c("2000-01", "2003-02")))), "stock_timestep__num: 2000-01, 2003-02")
-  ok(ut_cmp_identical(
-    r$stock_timebigstep__num,
-    structure(
-      c(102, 0),
-      .Dim = structure(1:2, .Names = c("length", "time")),
-      .Dimnames = list(length = "1:Inf", time = c("2001-01", "2003-12")))), "stock_timebigstep__num: 2001-01")
-  ok(ut_cmp_identical(
-    r$stock_modeltime__num,
-    structure(
-      c(100, 101, 102, 103, 104, 105, 106, 107, 108, 109),
-      .Dim = c(length = 1L, time = 10L),
-      .Dimnames = list(
-        length = "1:Inf",
-        time = c("2000-01", "2000-02", "2001-01", "2001-02", "2002-01", "2002-02", "2003-01",
-                 "2003-02", "2004-01", "2004-02")))), "stock_modeltime__num: One of each iterator")
-  
-  ok(ut_cmp_identical(
-    r$stock_modelyear__num,
-    structure(
-      c(201, 205, 209, 213, 217),
-      .Dim = c(length = 1L, year = 5L),
-      .Dimnames = list(length = "1:Inf", year = c("2000", "2001", "2002", "2003", "2004")))), "stock_modelyear__num: Aggregated by year")
+    params <- attr(model_fn, 'parameter_template')
+    result <- model_fn(params)
+    r <- attributes(result)
+    # str(as.list(r), vec.len = 10000)
+
+    ok(ut_cmp_identical(
+        r$stock_timeyear__num,
+        structure(
+            c(104 + 105, 108 + 109),
+            .Dim = structure(1:2, .Names = c("length", "time")),
+            .Dimnames = list(length = "1:Inf", time = c("2002", "2004")))), "stock_timeyear__num: 2002, 2004")
+    ok(ut_cmp_identical(
+        r$stock_timestep__num,
+        structure(
+            c(100, 107),
+            .Dim = structure(1:2, .Names = c("length", "time")),
+            .Dimnames = list(length = "1:Inf", time = c("2000-01", "2003-02")))), "stock_timestep__num: 2000-01, 2003-02")
+    ok(ut_cmp_identical(
+        r$stock_timebigstep__num,
+        structure(
+            c(102, 0),
+            .Dim = structure(1:2, .Names = c("length", "time")),
+            .Dimnames = list(length = "1:Inf", time = c("2001-01", "2003-12")))), "stock_timebigstep__num: 2001-01")
+    ok(ut_cmp_identical(
+        r$stock_modeltime__num,
+        structure(
+            c(100, 101, 102, 103, 104, 105, 106, 107, 108, 109),
+            .Dim = c(length = 1L, time = 10L),
+            .Dimnames = list(
+                length = "1:Inf",
+                time = c("2000-01", "2000-02", "2001-01", "2001-02", "2002-01", "2002-02", "2003-01",
+                    "2003-02", "2004-01", "2004-02")))), "stock_modeltime__num: One of each iterator")
+
+    ok(ut_cmp_identical(
+        r$stock_modelyear__num,
+        structure(
+            c(201, 205, 209, 213, 217),
+            .Dim = c(length = 1L, year = 5L),
+            .Dimnames = list(length = "1:Inf", year = c("2000", "2001", "2002", "2003", "2004")))), "stock_modelyear__num: Aggregated by year")
 })
 
 ok_group("g3s_modeltime:project", {
-  params <- attr(model_fn, 'parameter_template')
-  params$projectyears <- 2
-  params$nll <- 1.0
-  
-  result <- model_fn(params)
-  r <- attributes(result)
-  # str(as.list(r), vec.len = 10000)
-  
-  ok(ut_cmp_identical(
-    r$stock_modeltime__num,
-    structure(
-      c(100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113),
-      .Dim = c(length = 1L, time = 14L),
-      .Dimnames = list(
-        length = "1:Inf",
-        time = c("2000-01", "2000-02", "2001-01", "2001-02", "2002-01", "2002-02", "2003-01",
-                 "2003-02", "2004-01", "2004-02", "2005-01", "2005-02", "2006-01", "2006-02")))), "stock_modeltime__num: One of each iterator")
-  
-  ok(ut_cmp_identical(
-    r$stock_modelyear__num,
-    structure(
-      c(201, 205, 209, 213, 217, 221, 225),
-      .Dim = c(length = 1L, year = 7L),
-      .Dimnames = list(length = "1:Inf", year = c("2000", "2001", "2002", "2003", "2004", "2005", "2006")))), "stock_modelyear__num: Aggregated by year")
+    params <- attr(model_fn, 'parameter_template')
+    params$projectyears <- 2
+    params$nll <- 1.0
+
+    result <- model_fn(params)
+    r <- attributes(result)
+    # str(as.list(r), vec.len = 10000)
+
+    ok(ut_cmp_identical(
+        r$stock_modeltime__num,
+        structure(
+            c(100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113),
+            .Dim = c(length = 1L, time = 14L),
+            .Dimnames = list(
+                length = "1:Inf",
+                time = c("2000-01", "2000-02", "2001-01", "2001-02", "2002-01", "2002-02", "2003-01",
+                    "2003-02", "2004-01", "2004-02", "2005-01", "2005-02", "2006-01", "2006-02")))), "stock_modeltime__num: One of each iterator")
+
+    ok(ut_cmp_identical(
+        r$stock_modelyear__num,
+        structure(
+            c(201, 205, 209, 213, 217, 221, 225),
+            .Dim = c(length = 1L, year = 7L),
+            .Dimnames = list(length = "1:Inf", year = c("2000", "2001", "2002", "2003", "2004", "2005", "2006")))), "stock_modelyear__num: Aggregated by year")
 })


### PR DESCRIPTION
If using pseudoyears, the lookup formulas generated in `g3s_time` can be scrambled. For instance, if the year is 40 and the step is 1, `g3s_time_convert` will produce 401, `g3s_time_multiplier` will subsequently produce 1L which removes `cur_step` from the lookup formula. 

The changes make the multiplier (used in `g3_time_convert`) a function of the number of characters in year and step. This means that for `g3s_time`, the `times` argument is replaced with a `time_data` dataframe. This is because  the multiplier is a function of year and step, rather than a lookup function.