### PR TITLE
parscale updated for auto_exp parameters

### DIFF
--- a/R/init_val.R
+++ b/R/init_val.R
@@ -83,7 +83,11 @@ g3_init_val <- function (
         # NB: Can't set optimise & random
         if (!is.null(random)) param_template[matches, 'random'] <- random
         if (!is.null(optimise)) param_template[matches, 'optimise'] <- optimise & !param_template[matches, 'random']
-        if (!is.null(parscale)) param_template[matches, 'parscale'] <- parscale
+        if (!is.null(parscale)) {
+          param_template[matches, 'parscale'] <- parscale
+          if (any(auto_exp)) param_template[auto_exp, 'parscale'] <- diff(c(param_template[auto_exp, 'lower'],
+                                                                            param_template[auto_exp, 'upper']))
+        }
     } else {  # is.list
         if (!is.null(value)) {
             param_template[matches] <- value

--- a/R/init_val.R
+++ b/R/init_val.R
@@ -85,8 +85,7 @@ g3_init_val <- function (
         if (!is.null(optimise)) param_template[matches, 'optimise'] <- optimise & !param_template[matches, 'random']
         if (!is.null(parscale)) {
           param_template[matches, 'parscale'] <- parscale
-          if (any(auto_exp)) param_template[auto_exp, 'parscale'] <- diff(c(param_template[auto_exp, 'lower'],
-                                                                            param_template[auto_exp, 'upper']))
+          if (any(auto_exp)) param_template[auto_exp, 'parscale'] <- diff(c(log(lower), log(upper)))
         }
     } else {  # is.list
         if (!is.null(value)) {


### PR DESCRIPTION
Parscale for auto-exponentiated parameters should be `log(upper) - log(lower)` (I think) ... have added a line to re-calculate parscale for these instances.