### PR TITLE
Fix splitting g3a_spawn() offspring over multiple stocks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # gadget3 0.11-1-999:
 
+## Bug fixes
+* ``g3a_spawn()`` splits offspring into multiple stocks correctly
+
 # gadget3 0.11-0:
 
 ## Bug fixes

--- a/R/aab_env.R
+++ b/R/aab_env.R
@@ -114,6 +114,10 @@ g3_env$REprintf <- g3_native(r = function(...) {
     cat(sprintf(...))
 }, cpp = NULL)
 
+# "Rcpp::warning" should be in scope, but on 2024-04-17 r86441 / gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0 :-
+# error: there are no arguments to ‘warning’ that depend on a template parameter, so a declaration of ‘warning’ must be available [-fpermissive]
+g3_env$warning <- g3_native(r = 'warning', cpp = 'Rf_warning')
+
 g3_env$print_array <- g3_native(r = function(ar_name, ar) {
     writeLines(ar_name)
     print(ar)
@@ -129,7 +133,7 @@ g3_env$assert_msg <- g3_native(r = function(expr, message) {
     if (isFALSE(expr)) { warning(message) ; return(TRUE) }
     return(FALSE)
 }, cpp = '[](bool expr, std::string message) -> bool {
-    if (!expr) { warning(message.c_str()); return TRUE; }
+    if (!expr) { Rf_warning(message.c_str()); return TRUE; }
     return FALSE;
 }')
 

--- a/R/action_spawn.R
+++ b/R/action_spawn.R
@@ -135,15 +135,15 @@ g3a_spawn <- function(
 
     # Move spawned fish into their own stock
     out_f <- ~{}
-    sum_all_outputs_f <- ~0
+    actual_sum_all_outputs_f <- ~0  # NB: Give this a different name to it's placeholder, so we don't name-clash when substituting
     for (i in seq_along(output_stocks)) {
         output_stock <- output_stocks[[i]]
         output_ratio <- output_ratios[[i]]
         output_stock__spawnednum <- g3_stock_instance(output_stock, desc = "Individuals spawned")
 
         # Make a formula to sum all our outputs
-        sum_all_outputs_f <- g3_step(f_substitute(~stock_with(output_stock, sum(output_stock__spawnednum)) + sum_all_outputs_f, list(
-            sum_all_outputs_f = sum_all_outputs_f)), recursing = TRUE)
+        actual_sum_all_outputs_f <- g3_step(f_substitute(~stock_with(output_stock, sum(output_stock__spawnednum)) + sum_all_outputs_f, list(
+            sum_all_outputs_f = actual_sum_all_outputs_f)), recursing = TRUE)
 
         out_f <- g3_step(f_substitute(~{
             debug_trace("Generate normal distribution for spawned ", output_stock)
@@ -190,7 +190,7 @@ g3a_spawn <- function(
         }, list(out_f = out_f)), recursing = TRUE)
     }
     out[[step_id(recruit_at, stock, action_name)]] <- g3_step(f_substitute(out_f, list(
-        sum_all_outputs_f = f_optimize(sum_all_outputs_f))))
+        sum_all_outputs_f = f_optimize(actual_sum_all_outputs_f))))
 
     return(out)
 }

--- a/R/action_spawn.R
+++ b/R/action_spawn.R
@@ -70,7 +70,7 @@ g3a_spawn <- function(
     stopifnot(is.list(output_stocks) && all(sapply(output_stocks, g3_is_stock)))
     stopifnot(identical(names(recruitment_f), c('s', 'r')))
     stopifnot(length(output_stocks) == length(output_ratios))
-    stopifnot(abs(sum(output_ratios) - 1) < 0.0001)
+    stopifnot(!is.numeric(output_ratios) || abs(sum(output_ratios) - 1) < 0.0001)
     stock__num <- g3_stock_instance(stock, 0)
     stock__wgt <- g3_stock_instance(stock, 1)
     stock__spawnprop <- g3_stock_instance(stock, desc = "Proportion of parents that are spawning")
@@ -135,28 +135,24 @@ g3a_spawn <- function(
 
     # Move spawned fish into their own stock
     out_f <- ~{}
-    actual_sum_all_outputs_f <- ~0  # NB: Give this a different name to it's placeholder, so we don't name-clash when substituting
     for (i in seq_along(output_stocks)) {
         output_stock <- output_stocks[[i]]
         output_ratio <- output_ratios[[i]]
-        output_stock__spawnednum <- g3_stock_instance(output_stock, desc = "Individuals spawned")
-
-        # Make a formula to sum all our outputs
-        actual_sum_all_outputs_f <- g3_step(f_substitute(~stock_with(output_stock, sum(output_stock__spawnednum)) + sum_all_outputs_f, list(
-            sum_all_outputs_f = actual_sum_all_outputs_f)), recursing = TRUE)
+        output_stock__spawnednum <- g3_stock_instance(output_stock, desc = "Individuals spawned by parent")
 
         out_f <- g3_step(f_substitute(~{
             debug_trace("Generate normal distribution for spawned ", output_stock)
-            # Equivalent to Spawner::Storage, pre-calcRecruitNumber()
             stock_with(output_stock, output_stock__spawnednum[] <- 0)
+            # sum(*__spawnednum) is roughly equivalent to Spawner::Storage
+            # Spawner::Storage spawns into a union of output stocks first, we spawn directly to output stocks
             stock_iterate(output_stock, if (run_f && renew_into_f && output_stock_cond) {
                 stock_ss(output_stock__spawnednum) <- exp(-(((output_stock__midlen - (mean_f)) * (1 / (stddev_f))) ** 2) * 0.5)
             })
             extension_point
             debug_trace("Scale total spawned stock by total to spawn in cycle")
-            # sum_all_outputs_f equivalent to sum in Spawner::addSpawnStock()
+            # __offspringnum eqivalent to calcRecruitNumber()
             stock_with(output_stock, stock_with(stock,
-                output_stock__spawnednum <- (output_stock__spawnednum / avoid_zero(sum_all_outputs_f)) * sum(stock__offspringnum) * output_ratio))
+                output_stock__spawnednum <- (output_stock__spawnednum / avoid_zero(sum(output_stock__spawnednum))) * sum(stock__offspringnum) * output_ratio))
             stock_iterate(output_stock, if (run_f && renew_into_f && output_stock_cond) {
                 stock_ss(output_stock__wgt) <- ratio_add_vec(
                     stock_ss(output_stock__wgt),
@@ -189,8 +185,7 @@ g3a_spawn <- function(
             out_f
         }, list(out_f = out_f)), recursing = TRUE)
     }
-    out[[step_id(recruit_at, stock, action_name)]] <- g3_step(f_substitute(out_f, list(
-        sum_all_outputs_f = f_optimize(actual_sum_all_outputs_f))))
+    out[[step_id(recruit_at, stock, action_name)]] <- g3_step(out_f)
 
     return(out)
 }

--- a/R/run_tmb.R
+++ b/R/run_tmb.R
@@ -911,7 +911,7 @@ Type objective_function<Type>::operator() () {
             try {
                 return *map_in.at(key_in);
             } catch (const std::out_of_range&) {
-                warning(\"No value found in g3_param_table %s, ifmissing not specified\", err.c_str());
+                Rf_warning(\"No value found in g3_param_table %s, ifmissing not specified\", err.c_str());
                 return NAN;
             }
     }

--- a/inttest/codegeneration/ling.R
+++ b/inttest/codegeneration/ling.R
@@ -48,6 +48,7 @@ structure(function (param)
     stopifnot("ling.rec.2017" %in% names(param))
     stopifnot("ling.rec.2018" %in% names(param))
     stopifnot("cdist_sumofsquares_ldist_lln_weight" %in% names(param))
+    as_integer <- as.integer
     normalize_vec <- function(a) {
         a/sum(a)
     }
@@ -162,7 +163,6 @@ structure(function (param)
     retro_years <- param[["retro_years"]]
     start_year <- 1994L
     total_steps <- length(step_lengths) * (end_year - retro_years - start_year + 0L) + length(step_lengths) - 1L
-    as_integer <- as.integer
     nll_understocking__wgt <- array(0, dim = c(time = as_integer(total_steps + 1L)), dimnames = list(time = attributes(gen_dimnames(param))[["time"]]))
     nll <- 0
     cur_year <- 0L
@@ -249,8 +249,8 @@ structure(function (param)
                 {
                   area <- ling_imm__area
                   ling_imm__area_idx <- (1L)
-                  factor <- (param[["lingimm.init.scalar"]] * exp(-1 * (param[["lingimm.M"]] + param[["ling.init.F"]]) * age) * param[["lingimm.init"]][[age - 3 + 1]])
-                  dnorm <- ((ling_imm__midlen - (param[["ling.Linf"]] * (1 - exp(-1 * param[["ling.K"]] * ((age - cur_step_size) - (param[["recage"]] + log(1 - param[["ling.recl"]]/param[["ling.Linf"]])/param[["ling.K"]]))))))/ling_imm_stddev[[(age - cur_step_size) - 3 + 2]])
+                  factor <- (param[["lingimm.init.scalar"]] * exp(-1 * (param[["lingimm.M"]] + param[["ling.init.F"]]) * age) * param[["lingimm.init"]][[as_integer(age) - 3 + 1]])
+                  dnorm <- ((ling_imm__midlen - (param[["ling.Linf"]] * (1 - exp(-1 * param[["ling.K"]] * ((age - cur_step_size) - (param[["recage"]] + log(1 - param[["ling.recl"]]/param[["ling.Linf"]])/param[["ling.K"]]))))))/ling_imm_stddev[[as_integer((age - cur_step_size)) - 3 + 2]])
                   {
                     ling_imm__num[, ling_imm__area_idx, ling_imm__age_idx] <- normalize_vec(exp(-(dnorm^2) * 0.5)) * 10000 * factor
                     ling_imm__wgt[, ling_imm__area_idx, ling_imm__age_idx] <- param[["lingimm.walpha"]] * ling_imm__midlen^param[["lingimm.wbeta"]]
@@ -265,8 +265,8 @@ structure(function (param)
                 {
                   area <- ling_mat__area
                   ling_mat__area_idx <- (1L)
-                  factor <- (param[["lingmat.init.scalar"]] * exp(-1 * (param[["lingmat.M"]] + param[["ling.init.F"]]) * age) * param[["lingmat.init"]][[age - 5 + 1]])
-                  dnorm <- ((ling_mat__midlen - (param[["ling.Linf"]] * (1 - exp(-1 * param[["ling.K"]] * ((age - cur_step_size) - (param[["recage"]] + log(1 - param[["ling.recl"]]/param[["ling.Linf"]])/param[["ling.K"]]))))))/ling_mat_stddev[[(age - cur_step_size) - 5 + 2]])
+                  factor <- (param[["lingmat.init.scalar"]] * exp(-1 * (param[["lingmat.M"]] + param[["ling.init.F"]]) * age) * param[["lingmat.init"]][[as_integer(age) - 5 + 1]])
+                  dnorm <- ((ling_mat__midlen - (param[["ling.Linf"]] * (1 - exp(-1 * param[["ling.K"]] * ((age - cur_step_size) - (param[["recage"]] + log(1 - param[["ling.recl"]]/param[["ling.Linf"]])/param[["ling.K"]]))))))/ling_mat_stddev[[as_integer((age - cur_step_size)) - 5 + 2]])
                   {
                     ling_mat__num[, ling_mat__area_idx, ling_mat__age_idx] <- normalize_vec(exp(-(dnorm^2) * 0.5)) * 10000 * factor
                     ling_mat__wgt[, ling_mat__area_idx, ling_mat__age_idx] <- param[["lingmat.walpha"]] * ling_mat__midlen^param[["lingmat.wbeta"]]
@@ -578,11 +578,11 @@ structure(function (param)
             }))
             {
                 comment("g3a_renewal for ling_imm")
-                for (age in seq(ling_imm__minage, ling_imm__maxage, by = 1)) if (cur_step == 1 && age == 5) {
+                for (age in seq(ling_imm__minage, ling_imm__maxage, by = 1)) if (cur_step == 1 && age == 3) {
                   ling_imm__age_idx <- age - ling_imm__minage + 1L
                   area <- ling_imm__area
                   ling_imm__area_idx <- (1L)
-                  dnorm <- ((ling_imm__midlen - (param[["ling.Linf"]] * (1 - exp(-1 * param[["ling.K"]] * (age - (param[["recage"]] + log(1 - param[["ling.recl"]]/param[["ling.Linf"]])/param[["ling.K"]]))))))/ling_imm_stddev[[age - 3L + 1L]])
+                  dnorm <- ((ling_imm__midlen - (param[["ling.Linf"]] * (1 - exp(-1 * param[["ling.K"]] * (age - (param[["recage"]] + log(1 - param[["ling.recl"]]/param[["ling.Linf"]])/param[["ling.K"]]))))))/ling_imm_stddev[[as_integer(age) - 3 + 1]])
                   {
                     ling_imm__renewalnum[, ling_imm__area_idx, ling_imm__age_idx] <- normalize_vec(exp(-(dnorm^2) * 0.5)) * 10000 * factor
                     ling_imm__renewalwgt[, ling_imm__area_idx, ling_imm__age_idx] <- param[["lingimm.walpha"]] * ling_imm__midlen^param[["lingimm.wbeta"]]
@@ -600,11 +600,11 @@ structure(function (param)
             }))
             {
                 comment("g3a_renewal for ling_imm")
-                for (age in seq(ling_imm__minage, ling_imm__maxage, by = 1)) if (cur_step == 1 && age == 3) {
+                for (age in seq(ling_imm__minage, ling_imm__maxage, by = 1)) if (cur_step == 1 && age == 5) {
                   ling_imm__age_idx <- age - ling_imm__minage + 1L
                   area <- ling_imm__area
                   ling_imm__area_idx <- (1L)
-                  dnorm <- ((ling_imm__midlen - (param[["ling.Linf"]] * (1 - exp(-1 * param[["ling.K"]] * (age - (param[["recage"]] + log(1 - param[["ling.recl"]]/param[["ling.Linf"]])/param[["ling.K"]]))))))/ling_imm_stddev[[age - 3 + 1]])
+                  dnorm <- ((ling_imm__midlen - (param[["ling.Linf"]] * (1 - exp(-1 * param[["ling.K"]] * (age - (param[["recage"]] + log(1 - param[["ling.recl"]]/param[["ling.Linf"]])/param[["ling.K"]]))))))/ling_imm_stddev[[as_integer(age) - 3L + 1L]])
                   {
                     ling_imm__renewalnum[, ling_imm__area_idx, ling_imm__age_idx] <- normalize_vec(exp(-(dnorm^2) * 0.5)) * 10000 * factor
                     ling_imm__renewalwgt[, ling_imm__area_idx, ling_imm__age_idx] <- param[["lingimm.walpha"]] * ling_imm__midlen^param[["lingimm.wbeta"]]

--- a/inttest/codegeneration/ling.cpp
+++ b/inttest/codegeneration/ling.cpp
@@ -88,6 +88,9 @@ Type objective_function<Type>::operator() () {
     PARAMETER(ling__rec__2018);
     std::map<std::tuple<int>, Type*> ling__rec = {{std::make_tuple(1994), &ling__rec__1994}, {std::make_tuple(1995), &ling__rec__1995}, {std::make_tuple(1996), &ling__rec__1996}, {std::make_tuple(1997), &ling__rec__1997}, {std::make_tuple(1998), &ling__rec__1998}, {std::make_tuple(1999), &ling__rec__1999}, {std::make_tuple(2000), &ling__rec__2000}, {std::make_tuple(2001), &ling__rec__2001}, {std::make_tuple(2002), &ling__rec__2002}, {std::make_tuple(2003), &ling__rec__2003}, {std::make_tuple(2004), &ling__rec__2004}, {std::make_tuple(2005), &ling__rec__2005}, {std::make_tuple(2006), &ling__rec__2006}, {std::make_tuple(2007), &ling__rec__2007}, {std::make_tuple(2008), &ling__rec__2008}, {std::make_tuple(2009), &ling__rec__2009}, {std::make_tuple(2010), &ling__rec__2010}, {std::make_tuple(2011), &ling__rec__2011}, {std::make_tuple(2012), &ling__rec__2012}, {std::make_tuple(2013), &ling__rec__2013}, {std::make_tuple(2014), &ling__rec__2014}, {std::make_tuple(2015), &ling__rec__2015}, {std::make_tuple(2016), &ling__rec__2016}, {std::make_tuple(2017), &ling__rec__2017}, {std::make_tuple(2018), &ling__rec__2018}};
     PARAMETER(cdist_sumofsquares_ldist_lln_weight);
+    auto as_integer = [](Type v) -> int {
+    return std::floor(asDouble(v));
+};
     auto normalize_vec = [](vector<Type> a) -> vector<Type> {
     return a / a.sum();
 };
@@ -229,9 +232,6 @@ Type objective_function<Type>::operator() () {
     int end_year = 2018;
     int start_year = 1994;
     auto total_steps = (step_lengths).size()*(end_year - retro_years - start_year + 0) + (step_lengths).size() - 1;
-    auto as_integer = [](Type v) -> int {
-    return std::floor(asDouble(v));
-};
     array<Type> nll_understocking__wgt(as_integer(total_steps + 1)); nll_understocking__wgt.setZero();
     Type nll = (double)(0);
     int cur_year = 0;
@@ -297,9 +297,9 @@ Type objective_function<Type>::operator() () {
 
                     auto ling_imm__area_idx = 0;
 
-                    auto factor = (lingimm__init__scalar*exp(-(double)(1)*(lingimm__M + ling__init__F)*age)*lingimm__init ( age - 3 + 1 - 1 ));
+                    auto factor = (lingimm__init__scalar*exp(-(double)(1)*(lingimm__M + ling__init__F)*age)*lingimm__init ( as_integer(age) - 3 + 1 - 1 ));
 
-                    auto dnorm = ((ling_imm__midlen - (ling__Linf*((double)(1) - exp(-(double)(1)*ling__K*((age - cur_step_size) - (recage + log((double)(1) - ling__recl / ling__Linf) / ling__K)))))) / ling_imm_stddev ( (age - cur_step_size) - 3 + 2 - 1 ));
+                    auto dnorm = ((ling_imm__midlen - (ling__Linf*((double)(1) - exp(-(double)(1)*ling__K*((age - cur_step_size) - (recage + log((double)(1) - ling__recl / ling__Linf) / ling__K)))))) / ling_imm_stddev ( as_integer((age - cur_step_size)) - 3 + 2 - 1 ));
 
                     {
                         ling_imm__num.col(ling_imm__age_idx).col(ling_imm__area_idx) = normalize_vec(exp(-(pow(dnorm, (Type)(double)(2)))*(double)(0.5)))*(double)(10000)*factor;
@@ -318,9 +318,9 @@ Type objective_function<Type>::operator() () {
 
                     auto ling_mat__area_idx = 0;
 
-                    auto factor = (lingmat__init__scalar*exp(-(double)(1)*(lingmat__M + ling__init__F)*age)*lingmat__init ( age - 5 + 1 - 1 ));
+                    auto factor = (lingmat__init__scalar*exp(-(double)(1)*(lingmat__M + ling__init__F)*age)*lingmat__init ( as_integer(age) - 5 + 1 - 1 ));
 
-                    auto dnorm = ((ling_mat__midlen - (ling__Linf*((double)(1) - exp(-(double)(1)*ling__K*((age - cur_step_size) - (recage + log((double)(1) - ling__recl / ling__Linf) / ling__K)))))) / ling_mat_stddev ( (age - cur_step_size) - 5 + 2 - 1 ));
+                    auto dnorm = ((ling_mat__midlen - (ling__Linf*((double)(1) - exp(-(double)(1)*ling__K*((age - cur_step_size) - (recage + log((double)(1) - ling__recl / ling__Linf) / ling__K)))))) / ling_mat_stddev ( as_integer((age - cur_step_size)) - 5 + 2 - 1 ));
 
                     {
                         ling_mat__num.col(ling_mat__age_idx).col(ling_mat__area_idx) = normalize_vec(exp(-(pow(dnorm, (Type)(double)(2)))*(double)(0.5)))*(double)(10000)*factor;
@@ -691,14 +691,14 @@ Type objective_function<Type>::operator() () {
 
             {
                 // g3a_renewal for ling_imm;
-                for (auto age = ling_imm__minage; age <= ling_imm__maxage; age++) if ( cur_step == 1 && age == 5 ) {
+                for (auto age = ling_imm__minage; age <= ling_imm__maxage; age++) if ( cur_step == 1 && age == 3 ) {
                     auto ling_imm__age_idx = age - ling_imm__minage + 1 - 1;
 
                     auto area = ling_imm__area;
 
                     auto ling_imm__area_idx = 0;
 
-                    auto dnorm = ((ling_imm__midlen - (ling__Linf*((double)(1) - exp(-(double)(1)*ling__K*(age - (recage + log((double)(1) - ling__recl / ling__Linf) / ling__K)))))) / ling_imm_stddev ( age - 3 + 1 - 1 ));
+                    auto dnorm = ((ling_imm__midlen - (ling__Linf*((double)(1) - exp(-(double)(1)*ling__K*(age - (recage + log((double)(1) - ling__recl / ling__Linf) / ling__K)))))) / ling_imm_stddev ( as_integer(age) - 3 + 1 - 1 ));
 
                     {
                         ling_imm__renewalnum.col(ling_imm__age_idx).col(ling_imm__area_idx) = normalize_vec(exp(-(pow(dnorm, (Type)(double)(2)))*(double)(0.5)))*(double)(10000)*factor;
@@ -715,14 +715,14 @@ Type objective_function<Type>::operator() () {
 
             {
                 // g3a_renewal for ling_imm;
-                for (auto age = ling_imm__minage; age <= ling_imm__maxage; age++) if ( cur_step == 1 && age == 3 ) {
+                for (auto age = ling_imm__minage; age <= ling_imm__maxage; age++) if ( cur_step == 1 && age == 5 ) {
                     auto ling_imm__age_idx = age - ling_imm__minage + 1 - 1;
 
                     auto area = ling_imm__area;
 
                     auto ling_imm__area_idx = 0;
 
-                    auto dnorm = ((ling_imm__midlen - (ling__Linf*((double)(1) - exp(-(double)(1)*ling__K*(age - (recage + log((double)(1) - ling__recl / ling__Linf) / ling__K)))))) / ling_imm_stddev ( age - 3 + 1 - 1 ));
+                    auto dnorm = ((ling_imm__midlen - (ling__Linf*((double)(1) - exp(-(double)(1)*ling__K*(age - (recage + log((double)(1) - ling__recl / ling__Linf) / ling__K)))))) / ling_imm_stddev ( as_integer(age) - 3 + 1 - 1 ));
 
                     {
                         ling_imm__renewalnum.col(ling_imm__age_idx).col(ling_imm__area_idx) = normalize_vec(exp(-(pow(dnorm, (Type)(double)(2)))*(double)(0.5)))*(double)(10000)*factor;

--- a/tests/test-action_spawn-multipleoutputs.R
+++ b/tests/test-action_spawn-multipleoutputs.R
@@ -1,0 +1,92 @@
+library(unittest)
+if (!interactive()) options(warn=2, error = function() { sink(stderr()) ; traceback(3) ; q(status = 1) })
+
+library(gadget3)
+
+actions <- list()
+area_names <- g3_areas(c('AA', 'BB', 'CC'))
+
+st_imm_f <- g3_stock(c(species = "fish", maturity = 'imm', sex = 'f'), seq(5L, 25L, 5)) |>
+  g3s_livesonareas(area_names["AA"]) |>
+  g3s_age(1L, 5L)
+st_imm_m <- g3_stock(c(species = "fish", maturity = 'imm', sex = 'm'), seq(5L, 25L, 5)) |>
+  g3s_livesonareas(area_names["AA"]) |>
+  g3s_age(1L, 5L)
+st_mat <- g3_stock(c(species = "fish", maturity = 'mat'), seq(5L, 25L, 5)) |>
+  g3s_livesonareas(area_names["AA"]) |>
+  g3s_age(3L, 10L)
+
+actions <- list(
+  g3a_time(
+    1980, 1995,
+    step_lengths = c(6L, 6L)),
+  g3a_initialconditions(st_imm_f, quote( 0 * stock__midlen ), quote( 0 * stock__midlen )),
+  g3a_initialconditions(st_imm_m, quote( 0 * stock__midlen ), quote( 0 * stock__midlen )),
+  g3a_initialconditions_normalcv(st_mat),
+  g3a_spawn(
+    st_mat,
+    recruitment_f = g3a_spawn_recruitment_bevertonholt(
+      mu = g3_parameterized('spawn_mu', value = 5, by_year = TRUE),
+      lambda = g3_parameterized("spawn_lambda", value = 1, by_stock = TRUE) ),
+    proportion_f = g3_suitability_exponentiall50(),
+    output_stocks = list(st_imm_f, st_imm_m),
+    output_ratios = list(
+      st_imm_f = quote( g3_param('spawn_ratio', value = 0.5) ),
+      st_imm_m = quote( 1 - g3_param('spawn_ratio', value = 0.5) )),
+    run_f = quote( cur_step == 1 ) ),
+  g3a_age(st_imm_f),
+  g3a_age(st_imm_m),
+  g3a_age(st_mat) )
+
+# Compile model
+model_fn <- g3_to_r(c(actions, list(
+  g3a_report_history(actions, c(
+      '__offspringnum$',
+      '__num$',
+      '__wgt$' )))))
+if (nzchar(Sys.getenv('G3_TEST_TMB'))) {
+  model_cpp <- g3_to_tmb(c(actions, list(
+    g3a_report_history(actions, c(
+        '__offspringnum$',
+        '__num$',
+        '__wgt$' )))))
+    # model_cpp <- edit(model_cpp)
+    model_tmb <- g3_tmb_adfun(model_cpp, compile_flags = c("-O0", "-g"))
+} else {
+    writeLines("# skip: not compiling TMB model")
+}
+
+estimate_l50 <- g3_stock_def(st_mat, "midlen")[[length(g3_stock_def(st_mat, "midlen")) / 2]]
+estimate_linf <- max(g3_stock_def(st_mat, "midlen"))
+
+for (spawn_ratio in runif(5)) ok_group(paste0("spawn_ratio: ", spawn_ratio), {
+  attr(model_fn, 'parameter_template') |>
+    g3_init_val("*.Linf", estimate_linf, spread = 0.2) |>
+    g3_init_val("*.walpha", 0.01, optimise = FALSE) |>
+    g3_init_val("*.wbeta", 3, optimise = FALSE) |>
+
+    g3_init_val("*.*.l50", estimate_l50, spread = 0.25) |>
+    g3_init_val("spawn_ratio", spawn_ratio) |>
+
+    identity() -> params
+
+  r <- attributes(model_fn(params))
+  num_spawn <- colSums(r$hist_fish_mat__offspringnum, dims = 3)
+  num_m <- colSums(r$hist_fish_imm_m__num, dims = 3)
+  num_f <- colSums(r$hist_fish_imm_f__num, dims = 3)
+
+  ok(ut_cmp_equal(
+    cumsum(num_spawn * (1 - spawn_ratio)),
+    num_m,
+    tolerance = 1e-8), "hist_fish_imm_m__num: Cumulative proportion of __offspringnum")
+  ok(ut_cmp_equal(
+    cumsum(num_spawn * spawn_ratio),
+    num_f,
+    tolerance = 1e-8), "hist_fish_imm_f__num: Cumulatve proportion of __offspringnum")
+
+    if (nzchar(Sys.getenv('G3_TEST_TMB'))) {
+        param_template <- attr(model_cpp, "parameter_template")
+        param_template$value <- params[param_template$switch]
+        gadget3:::ut_tmb_r_compare(model_fn, model_tmb, param_template)
+    }
+})


### PR DESCRIPTION
@bthe @vbartolino this patch should get rid of the warning you're seeing.

My explanation wasn't right. The warning was actually coming from within ``g3a_spawn``(), as when we have multiple output_stocks we redefine ``sum_all_outputs_f``. The following should silence it, by using a different name.

Ideally this needs some tidying up before merging, most importantly a test for multiple output_stocks, since it's obvious it can't be tested, but you can if it helps.

For the problem at hand this is irrelevant noise. Silencing the warning doesn't change the code generated.

Fixes #147 