### PR TITLE
Rework action_age so age re-ordering is possible

### DIFF
--- a/R/action_age.R
+++ b/R/action_age.R
@@ -6,6 +6,8 @@ g3a_age <- function(
         run_f = ~cur_step_final,
         run_at = g3_action_order$age,
         transition_at = g3_action_order$age ) {
+    if (is.null(tryCatch(g3_stock_def(stock, 'minage'), error = function(x) NULL))) stop("stock missing age ", stock$name)
+
     out <- new.env(parent = emptyenv())
 
     stock__num <- g3_stock_instance(stock, 0)

--- a/R/action_age.R
+++ b/R/action_age.R
@@ -8,42 +8,6 @@ g3a_age <- function(
         transition_at = g3_action_order$age ) {
     out <- new.env(parent = emptyenv())
 
-    # Replace anything of form xxx[.[1,2,3]] with xxx[1,2,3]
-    fix_subsets <- function (in_f) {
-        call_replace(in_f, "[" = function (subset_call) {
-            if (!is.call(subset_call)) {
-                # Raw [ symbol, just return it
-                subset_call
-            } else if (length(subset_call) == 3 &&
-                    is.call(subset_call[[3]]) &&
-                    subset_call[[3]][[1]] == as.symbol("[") &&
-                    subset_call[[3]][[2]] == quote(.)) {
-                # Call of form summat[.[1,2, .. ]], remove nesting
-                as.call(c(
-                    head(as.list(subset_call), -1),
-                    tail(as.list(subset_call[[3]]), -2)))
-            } else {
-                # Recurse through subsetting call
-                as.call(lapply(as.list(subset_call), fix_subsets))
-            }
-        })
-    }
-
-    # Convert list of subset args into an actual call
-    to_subset_call <- function (l) {
-        as.call(c(list(as.symbol("["), as.symbol(".")), unname(l)))
-    }
-
-    # Mangle stock_num / stock_wgt to remove non-age parameters
-    age_iter_ss <- to_subset_call(lapply(stock$iter_ss, function (x) {
-        if (as.character(x) %in% c("stock__age_idx")) x
-        else quote(x[,1])[[3]]  # i.e. anything else should be missing
-    }))
-    age_younger_iter_ss <- to_subset_call(lapply(stock$iter_ss, function (x) {
-        if (as.character(x) %in% c("stock__age_idx")) call("-", x, 1L)  # Subtract 1 to age paramter
-        else quote(x[,1])[[3]]  # i.e. anything else should be missing
-    }))
-
     stock__num <- g3_stock_instance(stock, 0)
     stock__wgt <- g3_stock_instance(stock, 1)
     stock_movement <- g3s_age(
@@ -53,11 +17,6 @@ g3a_age <- function(
     stock_movement__transitioning_num <- g3_stock_instance(stock_movement)
     stock_movement__transitioning_wgt <- g3_stock_instance(stock_movement)
 
-    movement_age_iter_ss <- to_subset_call(lapply(stock_movement$iter_ss, function (x) {
-        if (as.character(x) %in% c("stock__age_idx")) quote(g3_idx(1))  # stock_movement only has one age bracket
-        else quote(x[,1])[[3]]  # i.e. anything else should be missing
-    }))
-
     # Handle single-age special case separately
     if (g3_stock_def(stock, 'maxage') == g3_stock_def(stock, 'minage')) {
         if (length(output_stocks) == 0) {
@@ -66,21 +25,19 @@ g3a_age <- function(
         }
 
         # Instead of using the below, just move-and-zero stocks
-        out[[step_id(run_at, 1, stock)]] <- g3_step(fix_subsets(f_substitute(~if (run_f) {
+        out[[step_id(run_at, 1, stock)]] <- g3_step(f_substitute(~if (run_f) {
             debug_label("g3a_age for ", stock)
             stock_with(stock, stock_with(stock_movement, for (age in seq(stock__maxage, stock__minage, by = -1)) g3_with(
                    stock__age_idx := g3_idx(age - stock__minage + 1L), {
                 debug_trace("Move oldest ", stock, " into ", stock_movement)
                 # NB: We should be doing this once in a normal iterate case, but here there's only one loop so doesn't matter
                 # NB: This relies on the dimension ordering between stock_movement & stock matching
-                stock_movement__transitioning_num[movement_age_iter_ss] <- stock_reshape(stock_movement, stock__num[age_iter_ss])
-                stock_movement__transitioning_wgt[movement_age_iter_ss] <- stock_reshape(stock_movement, stock__wgt[age_iter_ss])
-                stock__num[age_iter_ss] <- 0
+                stock_ss(stock_movement__transitioning_num, age = g3_idx(1), vec = age) <- stock_reshape(stock_movement, stock_ss(stock__num, age = default, vec = age))
+                stock_ss(stock_movement__transitioning_wgt, age = g3_idx(1), vec = age) <- stock_reshape(stock_movement, stock_ss(stock__wgt, age = default, vec = age))
+                stock_ss(stock__num, age = default, vec = age) <- 0
             })))
         }, list(
-            run_f = run_f,
-            movement_age_iter_ss = movement_age_iter_ss,
-            age_iter_ss = age_iter_ss))))
+            run_f = run_f )))
 
         # NB: move_remainder = FALSE because it's pointless here (and we can't move back into stock_movement)
         out[[step_id(transition_at, 90, stock)]] <- g3a_step_transition(stock_movement, output_stocks, output_ratios, move_remainder = FALSE, run_f = run_f)
@@ -89,33 +46,28 @@ g3a_age <- function(
 
     # Add transition steps if output_stocks provided
     if (length(output_stocks) == 0) {
-        final_year_f = fix_subsets(f_substitute(~{
+        final_year_f <- ~{
             debug_trace("Oldest ", stock, " is a plus-group, combine with younger individuals")
-            stock__wgt[age_iter_ss] <- ratio_add_vec(
-                stock__wgt[age_iter_ss], stock__num[age_iter_ss],
-                stock__wgt[age_younger_iter_ss], stock__num[age_younger_iter_ss])
-            stock__num[age_iter_ss] <- stock__num[age_iter_ss] + stock__num[age_younger_iter_ss]
-        }, list(
-            age_iter_ss = age_iter_ss,
-            age_younger_iter_ss = age_younger_iter_ss)))
+            stock_ss(stock__wgt, age = default, vec = age) <- ratio_add_vec(
+                stock_ss(stock__wgt, age = default, vec = age), stock_ss(stock__num, age = default, vec = age),
+                stock_ss(stock__wgt, age = default - 1, vec = age), stock_ss(stock__num, age = default - 1, vec = age))
+            stock_ss(stock__num, age = default, vec = age) <- stock_ss(stock__num, age = default, vec = age) + stock_ss(stock__num, age = default - 1, vec = age)
+        }
     } else {
-        final_year_f = fix_subsets(f_substitute(~stock_with(stock_movement, {
+        final_year_f <- ~stock_with(stock_movement, {
             debug_trace("Move oldest ", stock, " into ", stock_movement)
             # NB: We should be doing this once in a normal iterate case, but here there's only one loop so doesn't matter
             # NB: This relies on the dimension ordering between stock_movement & stock matching
-            stock_movement__transitioning_num[movement_age_iter_ss] <- stock_reshape(stock_movement, stock__num[age_iter_ss])
-            stock_movement__transitioning_wgt[movement_age_iter_ss] <- stock_reshape(stock_movement, stock__wgt[age_iter_ss])
-            stock__num[age_iter_ss] <- stock__num[age_younger_iter_ss]
-            stock__wgt[age_iter_ss] <- stock__wgt[age_younger_iter_ss]
-        }), list(
-            movement_age_iter_ss = movement_age_iter_ss,
-            age_iter_ss = age_iter_ss,
-            age_younger_iter_ss = age_younger_iter_ss)))
+            stock_ss(stock_movement__transitioning_num, age = g3_idx(1), vec = age) <- stock_reshape(stock_movement, stock_ss(stock__num, age = default, vec = age))
+            stock_ss(stock_movement__transitioning_wgt, age = g3_idx(1), vec = age) <- stock_reshape(stock_movement, stock_ss(stock__wgt, age = default, vec = age))
+            stock_ss(stock__num, age = default, vec = age) <- stock_ss(stock__num, age = default - 1, vec = age)
+            stock_ss(stock__wgt, age = default, vec = age) <- stock_ss(stock__wgt, age = default - 1, vec = age)
+        })
         # NB: move_remainder = FALSE because it's pointless here (and we can't move back into stock_movement)
         out[[step_id(transition_at, 90, stock)]] <- g3a_step_transition(stock_movement, output_stocks, output_ratios, move_remainder = FALSE, run_f = run_f)
     }
 
-    out[[step_id(run_at, 1, stock)]] <- g3_step(fix_subsets(f_substitute(~if (run_f) {
+    out[[step_id(run_at, 1, stock)]] <- g3_step(f_substitute(~if (run_f) {
         debug_label("g3a_age for ", stock)
 
         stock_with(stock, for (age in seq(stock__maxage, stock__minage, by = -1)) g3_with(
@@ -126,19 +78,17 @@ g3a_age <- function(
                 final_year_f
             } else if (age == stock__minage) {
                 debug_trace("Empty youngest ", stock, " age-group")
-                stock__num[age_iter_ss] <- 0
-                # NB: Leave stock__wgt[age_iter_ss] as-is, it's value is irrelevant with zero stock, and will result in NaN if we zero it.
+                stock_ss(stock__num, age = default, vec = age) <- 0
+                # NB: Leave stock__wgt[age] as-is, it's value is irrelevant with zero stock, and will result in NaN if we zero it.
             } else {
                 debug_trace("Move ", stock, " age-group to next one up")
-                stock__num[age_iter_ss] <- stock__num[age_younger_iter_ss]
-                stock__wgt[age_iter_ss] <- stock__wgt[age_younger_iter_ss]
+                stock_ss(stock__num, age = default, vec = age) <- stock_ss(stock__num, age = default - 1, vec = age)
+                stock_ss(stock__wgt, age = default, vec = age) <- stock_ss(stock__wgt, age = default - 1, vec = age)
             }
         }))
     }, list(
         final_year_f = final_year_f,
-        run_f = run_f,
-        age_iter_ss = age_iter_ss,
-        age_younger_iter_ss = age_younger_iter_ss))))
+        run_f = run_f )))
 
     return(as.list(out))
 }

--- a/inttest/codegeneration-defaults/model.R
+++ b/inttest/codegeneration-defaults/model.R
@@ -564,8 +564,8 @@ structure(function (param)
                   comment("Check stock has remained finite for this step")
                   if (age == fish__maxage) {
                     comment("Oldest fish is a plus-group, combine with younger individuals")
-                    fish__wgt[, , fish__age_idx] <- ratio_add_vec(fish__wgt[, , fish__age_idx], fish__num[, , fish__age_idx], fish__wgt[, , fish__age_idx - 1L], fish__num[, , fish__age_idx - 1L])
-                    fish__num[, , fish__age_idx] <- fish__num[, , fish__age_idx] + fish__num[, , fish__age_idx - 1L]
+                    fish__wgt[, , fish__age_idx] <- ratio_add_vec(fish__wgt[, , fish__age_idx], fish__num[, , fish__age_idx], fish__wgt[, , fish__age_idx - 1], fish__num[, , fish__age_idx - 1])
+                    fish__num[, , fish__age_idx] <- fish__num[, , fish__age_idx] + fish__num[, , fish__age_idx - 1]
                   }
                   else if (age == fish__minage) {
                     comment("Empty youngest fish age-group")
@@ -573,8 +573,8 @@ structure(function (param)
                   }
                   else {
                     comment("Move fish age-group to next one up")
-                    fish__num[, , fish__age_idx] <- fish__num[, , fish__age_idx - 1L]
-                    fish__wgt[, , fish__age_idx] <- fish__wgt[, , fish__age_idx - 1L]
+                    fish__num[, , fish__age_idx] <- fish__num[, , fish__age_idx - 1]
+                    fish__wgt[, , fish__age_idx] <- fish__wgt[, , fish__age_idx - 1]
                   }
                 }
             }

--- a/inttest/codegeneration/ling.R
+++ b/inttest/codegeneration/ling.R
@@ -699,8 +699,8 @@ structure(function (param)
                     comment("Move oldest ling_imm into ling_imm_movement")
                     ling_imm_movement__transitioning_num[, , (1)] <- ling_imm__num[, , ling_imm__age_idx]
                     ling_imm_movement__transitioning_wgt[, , (1)] <- ling_imm__wgt[, , ling_imm__age_idx]
-                    ling_imm__num[, , ling_imm__age_idx] <- ling_imm__num[, , ling_imm__age_idx - 1L]
-                    ling_imm__wgt[, , ling_imm__age_idx] <- ling_imm__wgt[, , ling_imm__age_idx - 1L]
+                    ling_imm__num[, , ling_imm__age_idx] <- ling_imm__num[, , ling_imm__age_idx - 1]
+                    ling_imm__wgt[, , ling_imm__age_idx] <- ling_imm__wgt[, , ling_imm__age_idx - 1]
                   }
                   else if (age == ling_imm__minage) {
                     comment("Empty youngest ling_imm age-group")
@@ -708,8 +708,8 @@ structure(function (param)
                   }
                   else {
                     comment("Move ling_imm age-group to next one up")
-                    ling_imm__num[, , ling_imm__age_idx] <- ling_imm__num[, , ling_imm__age_idx - 1L]
-                    ling_imm__wgt[, , ling_imm__age_idx] <- ling_imm__wgt[, , ling_imm__age_idx - 1L]
+                    ling_imm__num[, , ling_imm__age_idx] <- ling_imm__num[, , ling_imm__age_idx - 1]
+                    ling_imm__wgt[, , ling_imm__age_idx] <- ling_imm__wgt[, , ling_imm__age_idx - 1]
                   }
                 }
             }
@@ -722,8 +722,8 @@ structure(function (param)
                   comment("Check stock has remained finite for this step")
                   if (age == ling_mat__maxage) {
                     comment("Oldest ling_mat is a plus-group, combine with younger individuals")
-                    ling_mat__wgt[, , ling_mat__age_idx] <- ratio_add_vec(ling_mat__wgt[, , ling_mat__age_idx], ling_mat__num[, , ling_mat__age_idx], ling_mat__wgt[, , ling_mat__age_idx - 1L], ling_mat__num[, , ling_mat__age_idx - 1L])
-                    ling_mat__num[, , ling_mat__age_idx] <- ling_mat__num[, , ling_mat__age_idx] + ling_mat__num[, , ling_mat__age_idx - 1L]
+                    ling_mat__wgt[, , ling_mat__age_idx] <- ratio_add_vec(ling_mat__wgt[, , ling_mat__age_idx], ling_mat__num[, , ling_mat__age_idx], ling_mat__wgt[, , ling_mat__age_idx - 1], ling_mat__num[, , ling_mat__age_idx - 1])
+                    ling_mat__num[, , ling_mat__age_idx] <- ling_mat__num[, , ling_mat__age_idx] + ling_mat__num[, , ling_mat__age_idx - 1]
                   }
                   else if (age == ling_mat__minage) {
                     comment("Empty youngest ling_mat age-group")
@@ -731,8 +731,8 @@ structure(function (param)
                   }
                   else {
                     comment("Move ling_mat age-group to next one up")
-                    ling_mat__num[, , ling_mat__age_idx] <- ling_mat__num[, , ling_mat__age_idx - 1L]
-                    ling_mat__wgt[, , ling_mat__age_idx] <- ling_mat__wgt[, , ling_mat__age_idx - 1L]
+                    ling_mat__num[, , ling_mat__age_idx] <- ling_mat__num[, , ling_mat__age_idx - 1]
+                    ling_mat__wgt[, , ling_mat__age_idx] <- ling_mat__wgt[, , ling_mat__age_idx - 1]
                   }
                 }
             }

--- a/inttest/codegeneration/ling.R
+++ b/inttest/codegeneration/ling.R
@@ -144,21 +144,21 @@ structure(function (param)
         (orig_vec * orig_amount + new_vec * new_amount)/avoid_zero_vec(orig_amount + new_amount)
     }
     cur_time <- -1L
+    ling_imm__area <- 1L
     ling_imm__minage <- 3L
     ling_imm__maxage <- 10L
-    ling_imm__area <- 1L
     cur_step_size <- step_lengths[[1]]/12
-    ling_imm__num <- array(0, dim = c(length = 35L, area = 1L, age = 8L), dimnames = list(length = c("20:24", "24:28", "28:32", "32:36", "36:40", "40:44", "44:48", "48:52", "52:56", "56:60", "60:64", "64:68", "68:72", "72:76", "76:80", "80:84", "84:88", "88:92", "92:96", "96:100", "100:104", "104:108", "108:112", "112:116", "116:120", "120:124", "124:128", "128:132", "132:136", "136:140", "140:144", "144:148", "148:152", "152:156", "156:Inf"), area = "area1", age = c("age3", "age4", "age5", "age6", 
-        "age7", "age8", "age9", "age10")))
-    ling_imm__wgt <- array(1, dim = c(length = 35L, area = 1L, age = 8L), dimnames = list(length = c("20:24", "24:28", "28:32", "32:36", "36:40", "40:44", "44:48", "48:52", "52:56", "56:60", "60:64", "64:68", "68:72", "72:76", "76:80", "80:84", "84:88", "88:92", "92:96", "96:100", "100:104", "104:108", "108:112", "112:116", "116:120", "120:124", "124:128", "128:132", "132:136", "136:140", "140:144", "144:148", "148:152", "152:156", "156:Inf"), area = "area1", age = c("age3", "age4", "age5", "age6", 
-        "age7", "age8", "age9", "age10")))
+    ling_imm__num <- array(0, dim = c(length = 35L, age = 8L, area = 1L), dimnames = list(length = c("20:24", "24:28", "28:32", "32:36", "36:40", "40:44", "44:48", "48:52", "52:56", "56:60", "60:64", "64:68", "68:72", "72:76", "76:80", "80:84", "84:88", "88:92", "92:96", "96:100", "100:104", "104:108", "108:112", "112:116", "116:120", "120:124", "124:128", "128:132", "132:136", "136:140", "140:144", "144:148", "148:152", "152:156", "156:Inf"), age = c("age3", "age4", "age5", "age6", "age7", "age8", 
+        "age9", "age10"), area = "area1"))
+    ling_imm__wgt <- array(1, dim = c(length = 35L, age = 8L, area = 1L), dimnames = list(length = c("20:24", "24:28", "28:32", "32:36", "36:40", "40:44", "44:48", "48:52", "52:56", "56:60", "60:64", "64:68", "68:72", "72:76", "76:80", "80:84", "84:88", "88:92", "92:96", "96:100", "100:104", "104:108", "108:112", "112:116", "116:120", "120:124", "124:128", "128:132", "132:136", "136:140", "140:144", "144:148", "148:152", "152:156", "156:Inf"), age = c("age3", "age4", "age5", "age6", "age7", "age8", 
+        "age9", "age10"), area = "area1"))
+    ling_mat__area <- 1L
     ling_mat__minage <- 5L
     ling_mat__maxage <- 15L
-    ling_mat__area <- 1L
-    ling_mat__num <- array(0, dim = c(length = 35L, area = 1L, age = 11L), dimnames = list(length = c("20:24", "24:28", "28:32", "32:36", "36:40", "40:44", "44:48", "48:52", "52:56", "56:60", "60:64", "64:68", "68:72", "72:76", "76:80", "80:84", "84:88", "88:92", "92:96", "96:100", "100:104", "104:108", "108:112", "112:116", "116:120", "120:124", "124:128", "128:132", "132:136", "136:140", "140:144", "144:148", "148:152", "152:156", "156:Inf"), area = "area1", age = c("age5", "age6", "age7", "age8", 
-        "age9", "age10", "age11", "age12", "age13", "age14", "age15")))
-    ling_mat__wgt <- array(1, dim = c(length = 35L, area = 1L, age = 11L), dimnames = list(length = c("20:24", "24:28", "28:32", "32:36", "36:40", "40:44", "44:48", "48:52", "52:56", "56:60", "60:64", "64:68", "68:72", "72:76", "76:80", "80:84", "84:88", "88:92", "92:96", "96:100", "100:104", "104:108", "108:112", "112:116", "116:120", "120:124", "124:128", "128:132", "132:136", "136:140", "140:144", "144:148", "148:152", "152:156", "156:Inf"), area = "area1", age = c("age5", "age6", "age7", "age8", 
-        "age9", "age10", "age11", "age12", "age13", "age14", "age15")))
+    ling_mat__num <- array(0, dim = c(length = 35L, age = 11L, area = 1L), dimnames = list(length = c("20:24", "24:28", "28:32", "32:36", "36:40", "40:44", "44:48", "48:52", "52:56", "56:60", "60:64", "64:68", "68:72", "72:76", "76:80", "80:84", "84:88", "88:92", "92:96", "96:100", "100:104", "104:108", "108:112", "112:116", "116:120", "120:124", "124:128", "128:132", "132:136", "136:140", "140:144", "144:148", "148:152", "152:156", "156:Inf"), age = c("age5", "age6", "age7", "age8", "age9", "age10", 
+        "age11", "age12", "age13", "age14", "age15"), area = "area1"))
+    ling_mat__wgt <- array(1, dim = c(length = 35L, age = 11L, area = 1L), dimnames = list(length = c("20:24", "24:28", "28:32", "32:36", "36:40", "40:44", "44:48", "48:52", "52:56", "56:60", "60:64", "64:68", "68:72", "72:76", "76:80", "80:84", "84:88", "88:92", "92:96", "96:100", "100:104", "104:108", "108:112", "112:116", "116:120", "120:124", "124:128", "128:132", "132:136", "136:140", "140:144", "144:148", "148:152", "152:156", "156:Inf"), age = c("age5", "age6", "age7", "age8", "age9", "age10", 
+        "age11", "age12", "age13", "age14", "age15"), area = "area1"))
     end_year <- 2018L
     retro_years <- param[["retro_years"]]
     start_year <- 1994L
@@ -171,19 +171,19 @@ structure(function (param)
     cur_step <- 0L
     cur_step_final <- FALSE
     igfs__catch <- array(NA, dim = c(area = 1L), dimnames = list(area = "area1"))
-    ling_imm__totalpredate <- array(NA, dim = c(length = 35L, area = 1L, age = 8L), dimnames = list(length = c("20:24", "24:28", "28:32", "32:36", "36:40", "40:44", "44:48", "48:52", "52:56", "56:60", "60:64", "64:68", "68:72", "72:76", "76:80", "80:84", "84:88", "88:92", "92:96", "96:100", "100:104", "104:108", "108:112", "112:116", "116:120", "120:124", "124:128", "128:132", "132:136", "136:140", "140:144", "144:148", "148:152", "152:156", "156:Inf"), area = "area1", age = c("age3", "age4", "age5", 
-        "age6", "age7", "age8", "age9", "age10")))
-    ling_mat__totalpredate <- array(NA, dim = c(length = 35L, area = 1L, age = 11L), dimnames = list(length = c("20:24", "24:28", "28:32", "32:36", "36:40", "40:44", "44:48", "48:52", "52:56", "56:60", "60:64", "64:68", "68:72", "72:76", "76:80", "80:84", "84:88", "88:92", "92:96", "96:100", "100:104", "104:108", "108:112", "112:116", "116:120", "120:124", "124:128", "128:132", "132:136", "136:140", "140:144", "144:148", "148:152", "152:156", "156:Inf"), area = "area1", age = c("age5", "age6", "age7", 
-        "age8", "age9", "age10", "age11", "age12", "age13", "age14", "age15")))
-    ling_imm__predby_igfs <- array(NA, dim = c(length = 35L, area = 1L, age = 8L), dimnames = list(length = c("20:24", "24:28", "28:32", "32:36", "36:40", "40:44", "44:48", "48:52", "52:56", "56:60", "60:64", "64:68", "68:72", "72:76", "76:80", "80:84", "84:88", "88:92", "92:96", "96:100", "100:104", "104:108", "108:112", "112:116", "116:120", "120:124", "124:128", "128:132", "132:136", "136:140", "140:144", "144:148", "148:152", "152:156", "156:Inf"), area = "area1", age = c("age3", "age4", "age5", 
-        "age6", "age7", "age8", "age9", "age10")))
+    ling_imm__totalpredate <- array(NA, dim = c(length = 35L, age = 8L, area = 1L), dimnames = list(length = c("20:24", "24:28", "28:32", "32:36", "36:40", "40:44", "44:48", "48:52", "52:56", "56:60", "60:64", "64:68", "68:72", "72:76", "76:80", "80:84", "84:88", "88:92", "92:96", "96:100", "100:104", "104:108", "108:112", "112:116", "116:120", "120:124", "124:128", "128:132", "132:136", "136:140", "140:144", "144:148", "148:152", "152:156", "156:Inf"), age = c("age3", "age4", "age5", "age6", "age7", 
+        "age8", "age9", "age10"), area = "area1"))
+    ling_mat__totalpredate <- array(NA, dim = c(length = 35L, age = 11L, area = 1L), dimnames = list(length = c("20:24", "24:28", "28:32", "32:36", "36:40", "40:44", "44:48", "48:52", "52:56", "56:60", "60:64", "64:68", "68:72", "72:76", "76:80", "80:84", "84:88", "88:92", "92:96", "96:100", "100:104", "104:108", "108:112", "112:116", "116:120", "120:124", "124:128", "128:132", "132:136", "136:140", "140:144", "144:148", "148:152", "152:156", "156:Inf"), age = c("age5", "age6", "age7", "age8", "age9", 
+        "age10", "age11", "age12", "age13", "age14", "age15"), area = "area1"))
+    ling_imm__predby_igfs <- array(NA, dim = c(length = 35L, age = 8L, area = 1L), dimnames = list(length = c("20:24", "24:28", "28:32", "32:36", "36:40", "40:44", "44:48", "48:52", "52:56", "56:60", "60:64", "64:68", "68:72", "72:76", "76:80", "80:84", "84:88", "88:92", "92:96", "96:100", "100:104", "104:108", "108:112", "112:116", "116:120", "120:124", "124:128", "128:132", "132:136", "136:140", "140:144", "144:148", "148:152", "152:156", "156:Inf"), age = c("age3", "age4", "age5", "age6", "age7", 
+        "age8", "age9", "age10"), area = "area1"))
     igfs__area <- 1L
-    ling_imm__suit_igfs <- array(0, dim = c(length = 35L, area = 1L, age = 8L), dimnames = list(length = c("20:24", "24:28", "28:32", "32:36", "36:40", "40:44", "44:48", "48:52", "52:56", "56:60", "60:64", "64:68", "68:72", "72:76", "76:80", "80:84", "84:88", "88:92", "92:96", "96:100", "100:104", "104:108", "108:112", "112:116", "116:120", "120:124", "124:128", "128:132", "132:136", "136:140", "140:144", "144:148", "148:152", "152:156", "156:Inf"), area = "area1", age = c("age3", "age4", "age5", 
-        "age6", "age7", "age8", "age9", "age10")))
-    ling_mat__predby_igfs <- array(NA, dim = c(length = 35L, area = 1L, age = 11L), dimnames = list(length = c("20:24", "24:28", "28:32", "32:36", "36:40", "40:44", "44:48", "48:52", "52:56", "56:60", "60:64", "64:68", "68:72", "72:76", "76:80", "80:84", "84:88", "88:92", "92:96", "96:100", "100:104", "104:108", "108:112", "112:116", "116:120", "120:124", "124:128", "128:132", "132:136", "136:140", "140:144", "144:148", "148:152", "152:156", "156:Inf"), area = "area1", age = c("age5", "age6", "age7", 
-        "age8", "age9", "age10", "age11", "age12", "age13", "age14", "age15")))
-    ling_mat__suit_igfs <- array(0, dim = c(length = 35L, area = 1L, age = 11L), dimnames = list(length = c("20:24", "24:28", "28:32", "32:36", "36:40", "40:44", "44:48", "48:52", "52:56", "56:60", "60:64", "64:68", "68:72", "72:76", "76:80", "80:84", "84:88", "88:92", "92:96", "96:100", "100:104", "104:108", "108:112", "112:116", "116:120", "120:124", "124:128", "128:132", "132:136", "136:140", "140:144", "144:148", "148:152", "152:156", "156:Inf"), area = "area1", age = c("age5", "age6", "age7", 
-        "age8", "age9", "age10", "age11", "age12", "age13", "age14", "age15")))
+    ling_imm__suit_igfs <- array(0, dim = c(length = 35L, age = 8L, area = 1L), dimnames = list(length = c("20:24", "24:28", "28:32", "32:36", "36:40", "40:44", "44:48", "48:52", "52:56", "56:60", "60:64", "64:68", "68:72", "72:76", "76:80", "80:84", "84:88", "88:92", "92:96", "96:100", "100:104", "104:108", "108:112", "112:116", "116:120", "120:124", "124:128", "128:132", "132:136", "136:140", "140:144", "144:148", "148:152", "152:156", "156:Inf"), age = c("age3", "age4", "age5", "age6", "age7", 
+        "age8", "age9", "age10"), area = "area1"))
+    ling_mat__predby_igfs <- array(NA, dim = c(length = 35L, age = 11L, area = 1L), dimnames = list(length = c("20:24", "24:28", "28:32", "32:36", "36:40", "40:44", "44:48", "48:52", "52:56", "56:60", "60:64", "64:68", "68:72", "72:76", "76:80", "80:84", "84:88", "88:92", "92:96", "96:100", "100:104", "104:108", "108:112", "112:116", "116:120", "120:124", "124:128", "128:132", "132:136", "136:140", "140:144", "144:148", "148:152", "152:156", "156:Inf"), age = c("age5", "age6", "age7", "age8", "age9", 
+        "age10", "age11", "age12", "age13", "age14", "age15"), area = "area1"))
+    ling_mat__suit_igfs <- array(0, dim = c(length = 35L, age = 11L, area = 1L), dimnames = list(length = c("20:24", "24:28", "28:32", "32:36", "36:40", "40:44", "44:48", "48:52", "52:56", "56:60", "60:64", "64:68", "68:72", "72:76", "76:80", "80:84", "84:88", "88:92", "92:96", "96:100", "100:104", "104:108", "108:112", "112:116", "116:120", "120:124", "124:128", "128:132", "132:136", "136:140", "140:144", "144:148", "148:152", "152:156", "156:Inf"), age = c("age5", "age6", "age7", "age8", "age9", 
+        "age10", "age11", "age12", "age13", "age14", "age15"), area = "area1"))
     intlookup_zip <- function(keys, values) {
         if (min(keys) > 0 && max(keys) < 1e+05) {
             out <- list()
@@ -199,16 +199,16 @@ structure(function (param)
         return(out)
     }
     igfs_totaldata__lookup <- intlookup_zip(igfs_totaldata__keys, igfs_totaldata__values)
-    ling_imm__consratio <- array(NA, dim = c(length = 35L, area = 1L, age = 8L), dimnames = list(length = c("20:24", "24:28", "28:32", "32:36", "36:40", "40:44", "44:48", "48:52", "52:56", "56:60", "60:64", "64:68", "68:72", "72:76", "76:80", "80:84", "84:88", "88:92", "92:96", "96:100", "100:104", "104:108", "108:112", "112:116", "116:120", "120:124", "124:128", "128:132", "132:136", "136:140", "140:144", "144:148", "148:152", "152:156", "156:Inf"), area = "area1", age = c("age3", "age4", "age5", 
-        "age6", "age7", "age8", "age9", "age10")))
+    ling_imm__consratio <- array(NA, dim = c(length = 35L, age = 8L, area = 1L), dimnames = list(length = c("20:24", "24:28", "28:32", "32:36", "36:40", "40:44", "44:48", "48:52", "52:56", "56:60", "60:64", "64:68", "68:72", "72:76", "76:80", "80:84", "84:88", "88:92", "92:96", "96:100", "100:104", "104:108", "108:112", "112:116", "116:120", "120:124", "124:128", "128:132", "132:136", "136:140", "140:144", "144:148", "148:152", "152:156", "156:Inf"), age = c("age3", "age4", "age5", "age6", "age7", 
+        "age8", "age9", "age10"), area = "area1"))
     ling_imm__overconsumption <- structure(0, desc = "Total overconsumption of ling_imm")
-    ling_mat__consratio <- array(NA, dim = c(length = 35L, area = 1L, age = 11L), dimnames = list(length = c("20:24", "24:28", "28:32", "32:36", "36:40", "40:44", "44:48", "48:52", "52:56", "56:60", "60:64", "64:68", "68:72", "72:76", "76:80", "80:84", "84:88", "88:92", "92:96", "96:100", "100:104", "104:108", "108:112", "112:116", "116:120", "120:124", "124:128", "128:132", "132:136", "136:140", "140:144", "144:148", "148:152", "152:156", "156:Inf"), area = "area1", age = c("age5", "age6", "age7", 
-        "age8", "age9", "age10", "age11", "age12", "age13", "age14", "age15")))
+    ling_mat__consratio <- array(NA, dim = c(length = 35L, age = 11L, area = 1L), dimnames = list(length = c("20:24", "24:28", "28:32", "32:36", "36:40", "40:44", "44:48", "48:52", "52:56", "56:60", "60:64", "64:68", "68:72", "72:76", "76:80", "80:84", "84:88", "88:92", "92:96", "96:100", "100:104", "104:108", "108:112", "112:116", "116:120", "120:124", "124:128", "128:132", "132:136", "136:140", "140:144", "144:148", "148:152", "152:156", "156:Inf"), age = c("age5", "age6", "age7", "age8", "age9", 
+        "age10", "age11", "age12", "age13", "age14", "age15"), area = "area1"))
     ling_mat__overconsumption <- structure(0, desc = "Total overconsumption of ling_mat")
-    ling_imm__transitioning_num <- array(0, dim = c(length = 35L, area = 1L, age = 8L), dimnames = list(length = c("20:24", "24:28", "28:32", "32:36", "36:40", "40:44", "44:48", "48:52", "52:56", "56:60", "60:64", "64:68", "68:72", "72:76", "76:80", "80:84", "84:88", "88:92", "92:96", "96:100", "100:104", "104:108", "108:112", "112:116", "116:120", "120:124", "124:128", "128:132", "132:136", "136:140", "140:144", "144:148", "148:152", "152:156", "156:Inf"), area = "area1", age = c("age3", "age4", 
-        "age5", "age6", "age7", "age8", "age9", "age10")))
-    ling_imm__transitioning_wgt <- array(NA, dim = c(length = 35L, area = 1L, age = 8L), dimnames = list(length = c("20:24", "24:28", "28:32", "32:36", "36:40", "40:44", "44:48", "48:52", "52:56", "56:60", "60:64", "64:68", "68:72", "72:76", "76:80", "80:84", "84:88", "88:92", "92:96", "96:100", "100:104", "104:108", "108:112", "112:116", "116:120", "120:124", "124:128", "128:132", "132:136", "136:140", "140:144", "144:148", "148:152", "152:156", "156:Inf"), area = "area1", age = c("age3", "age4", 
-        "age5", "age6", "age7", "age8", "age9", "age10")))
+    ling_imm__transitioning_num <- array(0, dim = c(length = 35L, age = 8L, area = 1L), dimnames = list(length = c("20:24", "24:28", "28:32", "32:36", "36:40", "40:44", "44:48", "48:52", "52:56", "56:60", "60:64", "64:68", "68:72", "72:76", "76:80", "80:84", "84:88", "88:92", "92:96", "96:100", "100:104", "104:108", "108:112", "112:116", "116:120", "120:124", "124:128", "128:132", "132:136", "136:140", "140:144", "144:148", "148:152", "152:156", "156:Inf"), age = c("age3", "age4", "age5", "age6", 
+        "age7", "age8", "age9", "age10"), area = "area1"))
+    ling_imm__transitioning_wgt <- array(NA, dim = c(length = 35L, age = 8L, area = 1L), dimnames = list(length = c("20:24", "24:28", "28:32", "32:36", "36:40", "40:44", "44:48", "48:52", "52:56", "56:60", "60:64", "64:68", "68:72", "72:76", "76:80", "80:84", "84:88", "88:92", "92:96", "96:100", "100:104", "104:108", "108:112", "112:116", "116:120", "120:124", "124:128", "128:132", "132:136", "136:140", "140:144", "144:148", "148:152", "152:156", "156:Inf"), age = c("age3", "age4", "age5", "age6", 
+        "age7", "age8", "age9", "age10"), area = "area1"))
     ling_imm__growth_lastcalc <- -1L
     ling_imm__growth_l <- array(NA, dim = c(length = 35L, delta = 16L), dimnames = list(length = c("20:24", "24:28", "28:32", "32:36", "36:40", "40:44", "44:48", "48:52", "52:56", "56:60", "60:64", "64:68", "68:72", "72:76", "76:80", "80:84", "84:88", "88:92", "92:96", "96:100", "100:104", "104:108", "108:112", "112:116", "116:120", "120:124", "124:128", "128:132", "132:136", "136:140", "140:144", "144:148", "148:152", "152:156", "156:Inf"), delta = c("0", "1", "2", "3", "4", "5", "6", "7", "8", 
         "9", "10", "11", "12", "13", "14", "15")))
@@ -223,10 +223,10 @@ structure(function (param)
     ling_mat__growth_w <- array(NA, dim = c(length = 35L, delta = 16L), dimnames = list(length = c("20:24", "24:28", "28:32", "32:36", "36:40", "40:44", "44:48", "48:52", "52:56", "56:60", "60:64", "64:68", "68:72", "72:76", "76:80", "80:84", "84:88", "88:92", "92:96", "96:100", "100:104", "104:108", "108:112", "112:116", "116:120", "120:124", "124:128", "128:132", "132:136", "136:140", "140:144", "144:148", "148:152", "152:156", "156:Inf"), delta = c("0", "1", "2", "3", "4", "5", "6", "7", "8", 
         "9", "10", "11", "12", "13", "14", "15")))
     ling_mat__prevtotal <- 0
-    ling_imm__renewalnum <- array(0, dim = c(length = 35L, area = 1L, age = 8L), dimnames = list(length = c("20:24", "24:28", "28:32", "32:36", "36:40", "40:44", "44:48", "48:52", "52:56", "56:60", "60:64", "64:68", "68:72", "72:76", "76:80", "80:84", "84:88", "88:92", "92:96", "96:100", "100:104", "104:108", "108:112", "112:116", "116:120", "120:124", "124:128", "128:132", "132:136", "136:140", "140:144", "144:148", "148:152", "152:156", "156:Inf"), area = "area1", age = c("age3", "age4", "age5", 
-        "age6", "age7", "age8", "age9", "age10")))
-    ling_imm__renewalwgt <- array(0, dim = c(length = 35L, area = 1L, age = 8L), dimnames = list(length = c("20:24", "24:28", "28:32", "32:36", "36:40", "40:44", "44:48", "48:52", "52:56", "56:60", "60:64", "64:68", "68:72", "72:76", "76:80", "80:84", "84:88", "88:92", "92:96", "96:100", "100:104", "104:108", "108:112", "112:116", "116:120", "120:124", "124:128", "128:132", "132:136", "136:140", "140:144", "144:148", "148:152", "152:156", "156:Inf"), area = "area1", age = c("age3", "age4", "age5", 
-        "age6", "age7", "age8", "age9", "age10")))
+    ling_imm__renewalnum <- array(0, dim = c(length = 35L, age = 8L, area = 1L), dimnames = list(length = c("20:24", "24:28", "28:32", "32:36", "36:40", "40:44", "44:48", "48:52", "52:56", "56:60", "60:64", "64:68", "68:72", "72:76", "76:80", "80:84", "84:88", "88:92", "92:96", "96:100", "100:104", "104:108", "108:112", "112:116", "116:120", "120:124", "124:128", "128:132", "132:136", "136:140", "140:144", "144:148", "148:152", "152:156", "156:Inf"), age = c("age3", "age4", "age5", "age6", "age7", 
+        "age8", "age9", "age10"), area = "area1"))
+    ling_imm__renewalwgt <- array(0, dim = c(length = 35L, age = 8L, area = 1L), dimnames = list(length = c("20:24", "24:28", "28:32", "32:36", "36:40", "40:44", "44:48", "48:52", "52:56", "56:60", "60:64", "64:68", "68:72", "72:76", "76:80", "80:84", "84:88", "88:92", "92:96", "96:100", "100:104", "104:108", "108:112", "112:116", "116:120", "120:124", "124:128", "128:132", "132:136", "136:140", "140:144", "144:148", "148:152", "152:156", "156:Inf"), age = c("age3", "age4", "age5", "age6", "age7", 
+        "age8", "age9", "age10"), area = "area1"))
     cdist_sumofsquares_ldist_lln_model__area <- 1L
     cdist_sumofsquares_ldist_lln_model__num <- array(0, dim = c(length = 35L, area = 1L), dimnames = list(length = c("20:24", "24:28", "28:32", "32:36", "36:40", "40:44", "44:48", "48:52", "52:56", "56:60", "60:64", "64:68", "68:72", "72:76", "76:80", "80:84", "84:88", "88:92", "92:96", "96:100", "100:104", "104:108", "108:112", "112:116", "116:120", "120:124", "124:128", "128:132", "132:136", "136:140", "140:144", "144:148", "148:152", "152:156", "156:Inf"), area = "1"))
     cdist_sumofsquares_ldist_lln_obs__area <- 1L
@@ -235,41 +235,41 @@ structure(function (param)
     nll_cdist_sumofsquares_ldist_lln__weight <- array(0, dim = c(time = as_integer(total_steps + 1L)), dimnames = list(time = attributes(gen_dimnames(param))[["time"]]))
     g3l_understocking_total <- 0
     nll_understocking__weight <- array(0, dim = c(time = as_integer(total_steps + 1L)), dimnames = list(time = attributes(gen_dimnames(param))[["time"]]))
-    ling_imm_movement__transitioning_num <- array(NA, dim = c(length = 35L, area = 1L, age = 1L), dimnames = list(length = c("20:24", "24:28", "28:32", "32:36", "36:40", "40:44", "44:48", "48:52", "52:56", "56:60", "60:64", "64:68", "68:72", "72:76", "76:80", "80:84", "84:88", "88:92", "92:96", "96:100", "100:104", "104:108", "108:112", "112:116", "116:120", "120:124", "124:128", "128:132", "132:136", "136:140", "140:144", "144:148", "148:152", "152:156", "156:Inf"), area = "area1", age = "age11"))
-    ling_imm_movement__transitioning_wgt <- array(NA, dim = c(length = 35L, area = 1L, age = 1L), dimnames = list(length = c("20:24", "24:28", "28:32", "32:36", "36:40", "40:44", "44:48", "48:52", "52:56", "56:60", "60:64", "64:68", "68:72", "72:76", "76:80", "80:84", "84:88", "88:92", "92:96", "96:100", "100:104", "104:108", "108:112", "112:116", "116:120", "120:124", "124:128", "128:132", "132:136", "136:140", "140:144", "144:148", "148:152", "152:156", "156:Inf"), area = "area1", age = "age11"))
+    ling_imm_movement__transitioning_num <- array(NA, dim = c(length = 35L, age = 1L, area = 1L), dimnames = list(length = c("20:24", "24:28", "28:32", "32:36", "36:40", "40:44", "44:48", "48:52", "52:56", "56:60", "60:64", "64:68", "68:72", "72:76", "76:80", "80:84", "84:88", "88:92", "92:96", "96:100", "100:104", "104:108", "108:112", "112:116", "116:120", "120:124", "124:128", "128:132", "132:136", "136:140", "140:144", "144:148", "148:152", "152:156", "156:Inf"), age = "age11", area = "area1"))
+    ling_imm_movement__transitioning_wgt <- array(NA, dim = c(length = 35L, age = 1L, area = 1L), dimnames = list(length = c("20:24", "24:28", "28:32", "32:36", "36:40", "40:44", "44:48", "48:52", "52:56", "56:60", "60:64", "64:68", "68:72", "72:76", "76:80", "80:84", "84:88", "88:92", "92:96", "96:100", "100:104", "104:108", "108:112", "112:116", "116:120", "120:124", "124:128", "128:132", "132:136", "136:140", "140:144", "144:148", "148:152", "152:156", "156:Inf"), age = "age11", area = "area1"))
+    ling_imm_movement__area <- 1L
     ling_imm_movement__minage <- 11L
     ling_imm_movement__maxage <- 11L
-    ling_imm_movement__area <- 1L
     while (TRUE) {
         cur_time <- cur_time + 1L
         {
             comment("g3a_initialconditions for ling_imm")
-            for (age in seq(ling_imm__minage, ling_imm__maxage, by = 1)) if (cur_time == 0L) {
-                ling_imm__age_idx <- age - ling_imm__minage + 1L
-                {
-                  area <- ling_imm__area
-                  ling_imm__area_idx <- (1L)
+            {
+                area <- ling_imm__area
+                ling_imm__area_idx <- (1L)
+                for (age in seq(ling_imm__minage, ling_imm__maxage, by = 1)) if (cur_time == 0L) {
+                  ling_imm__age_idx <- age - ling_imm__minage + 1L
                   factor <- (param[["lingimm.init.scalar"]] * exp(-1 * (param[["lingimm.M"]] + param[["ling.init.F"]]) * age) * param[["lingimm.init"]][[as_integer(age) - 3 + 1]])
                   dnorm <- ((ling_imm__midlen - (param[["ling.Linf"]] * (1 - exp(-1 * param[["ling.K"]] * ((age - cur_step_size) - (param[["recage"]] + log(1 - param[["ling.recl"]]/param[["ling.Linf"]])/param[["ling.K"]]))))))/ling_imm_stddev[[as_integer((age - cur_step_size)) - 3 + 2]])
                   {
-                    ling_imm__num[, ling_imm__area_idx, ling_imm__age_idx] <- normalize_vec(exp(-(dnorm^2) * 0.5)) * 10000 * factor
-                    ling_imm__wgt[, ling_imm__area_idx, ling_imm__age_idx] <- param[["lingimm.walpha"]] * ling_imm__midlen^param[["lingimm.wbeta"]]
+                    ling_imm__num[, ling_imm__age_idx, ling_imm__area_idx] <- normalize_vec(exp(-(dnorm^2) * 0.5)) * 10000 * factor
+                    ling_imm__wgt[, ling_imm__age_idx, ling_imm__area_idx] <- param[["lingimm.walpha"]] * ling_imm__midlen^param[["lingimm.wbeta"]]
                   }
                 }
             }
         }
         {
             comment("g3a_initialconditions for ling_mat")
-            for (age in seq(ling_mat__minage, ling_mat__maxage, by = 1)) if (cur_time == 0L) {
-                ling_mat__age_idx <- age - ling_mat__minage + 1L
-                {
-                  area <- ling_mat__area
-                  ling_mat__area_idx <- (1L)
+            {
+                area <- ling_mat__area
+                ling_mat__area_idx <- (1L)
+                for (age in seq(ling_mat__minage, ling_mat__maxage, by = 1)) if (cur_time == 0L) {
+                  ling_mat__age_idx <- age - ling_mat__minage + 1L
                   factor <- (param[["lingmat.init.scalar"]] * exp(-1 * (param[["lingmat.M"]] + param[["ling.init.F"]]) * age) * param[["lingmat.init"]][[as_integer(age) - 5 + 1]])
                   dnorm <- ((ling_mat__midlen - (param[["ling.Linf"]] * (1 - exp(-1 * param[["ling.K"]] * ((age - cur_step_size) - (param[["recage"]] + log(1 - param[["ling.recl"]]/param[["ling.Linf"]])/param[["ling.K"]]))))))/ling_mat_stddev[[as_integer((age - cur_step_size)) - 5 + 2]])
                   {
-                    ling_mat__num[, ling_mat__area_idx, ling_mat__age_idx] <- normalize_vec(exp(-(dnorm^2) * 0.5)) * 10000 * factor
-                    ling_mat__wgt[, ling_mat__area_idx, ling_mat__age_idx] <- param[["lingmat.walpha"]] * ling_mat__midlen^param[["lingmat.wbeta"]]
+                    ling_mat__num[, ling_mat__age_idx, ling_mat__area_idx] <- normalize_vec(exp(-(dnorm^2) * 0.5)) * 10000 * factor
+                    ling_mat__wgt[, ling_mat__age_idx, ling_mat__area_idx] <- param[["lingmat.walpha"]] * ling_mat__midlen^param[["lingmat.wbeta"]]
                   }
                 }
             }
@@ -303,18 +303,18 @@ structure(function (param)
             comment("g3a_predate_fleet for ling_imm")
             comment("Zero igfs-ling_imm biomass-consuming counter")
             ling_imm__predby_igfs[] <- 0
-            for (age in seq(ling_imm__minage, ling_imm__maxage, by = 1)) {
-                ling_imm__age_idx <- age - ling_imm__minage + 1L
+            {
                 area <- ling_imm__area
                 ling_imm__area_idx <- (1L)
-                if (area == igfs__area) {
+                for (age in seq(ling_imm__minage, ling_imm__maxage, by = 1)) if (area == igfs__area) {
+                  ling_imm__age_idx <- age - ling_imm__minage + 1L
                   igfs__area_idx <- (1L)
                   fleet_area <- area
                   {
                     comment("Collect all suitable ling_imm biomass for igfs")
-                    ling_imm__suit_igfs[, ling_imm__area_idx, ling_imm__age_idx] <- 1/(1 + exp(-param[["ling.igfs.alpha"]] * (ling_imm__midlen - param[["ling.igfs.l50"]])))
-                    ling_imm__predby_igfs[, ling_imm__area_idx, ling_imm__age_idx] <- ling_imm__suit_igfs[, ling_imm__area_idx, ling_imm__age_idx] * ling_imm__num[, ling_imm__area_idx, ling_imm__age_idx] * ling_imm__wgt[, ling_imm__area_idx, ling_imm__age_idx]
-                    igfs__catch[igfs__area_idx] <- igfs__catch[igfs__area_idx] + sum(ling_imm__predby_igfs[, ling_imm__area_idx, ling_imm__age_idx])
+                    ling_imm__suit_igfs[, ling_imm__age_idx, ling_imm__area_idx] <- 1/(1 + exp(-param[["ling.igfs.alpha"]] * (ling_imm__midlen - param[["ling.igfs.l50"]])))
+                    ling_imm__predby_igfs[, ling_imm__age_idx, ling_imm__area_idx] <- ling_imm__suit_igfs[, ling_imm__age_idx, ling_imm__area_idx] * ling_imm__num[, ling_imm__age_idx, ling_imm__area_idx] * ling_imm__wgt[, ling_imm__age_idx, ling_imm__area_idx]
+                    igfs__catch[igfs__area_idx] <- igfs__catch[igfs__area_idx] + sum(ling_imm__predby_igfs[, ling_imm__age_idx, ling_imm__area_idx])
                   }
                 }
             }
@@ -323,54 +323,54 @@ structure(function (param)
             comment("g3a_predate_fleet for ling_mat")
             comment("Zero igfs-ling_mat biomass-consuming counter")
             ling_mat__predby_igfs[] <- 0
-            for (age in seq(ling_mat__minage, ling_mat__maxage, by = 1)) {
-                ling_mat__age_idx <- age - ling_mat__minage + 1L
+            {
                 area <- ling_mat__area
                 ling_mat__area_idx <- (1L)
-                if (area == igfs__area) {
+                for (age in seq(ling_mat__minage, ling_mat__maxage, by = 1)) if (area == igfs__area) {
+                  ling_mat__age_idx <- age - ling_mat__minage + 1L
                   igfs__area_idx <- (1L)
                   fleet_area <- area
                   {
                     comment("Collect all suitable ling_mat biomass for igfs")
-                    ling_mat__suit_igfs[, ling_mat__area_idx, ling_mat__age_idx] <- 1/(1 + exp(-param[["ling.igfs.alpha"]] * (ling_mat__midlen - param[["ling.igfs.l50"]])))
-                    ling_mat__predby_igfs[, ling_mat__area_idx, ling_mat__age_idx] <- ling_mat__suit_igfs[, ling_mat__area_idx, ling_mat__age_idx] * ling_mat__num[, ling_mat__area_idx, ling_mat__age_idx] * ling_mat__wgt[, ling_mat__area_idx, ling_mat__age_idx]
-                    igfs__catch[igfs__area_idx] <- igfs__catch[igfs__area_idx] + sum(ling_mat__predby_igfs[, ling_mat__area_idx, ling_mat__age_idx])
+                    ling_mat__suit_igfs[, ling_mat__age_idx, ling_mat__area_idx] <- 1/(1 + exp(-param[["ling.igfs.alpha"]] * (ling_mat__midlen - param[["ling.igfs.l50"]])))
+                    ling_mat__predby_igfs[, ling_mat__age_idx, ling_mat__area_idx] <- ling_mat__suit_igfs[, ling_mat__age_idx, ling_mat__area_idx] * ling_mat__num[, ling_mat__age_idx, ling_mat__area_idx] * ling_mat__wgt[, ling_mat__age_idx, ling_mat__area_idx]
+                    igfs__catch[igfs__area_idx] <- igfs__catch[igfs__area_idx] + sum(ling_mat__predby_igfs[, ling_mat__age_idx, ling_mat__area_idx])
                   }
                 }
             }
         }
         {
             comment("Scale igfs catch of ling_imm by total expected catch")
-            for (age in seq(ling_imm__minage, ling_imm__maxage, by = 1)) {
-                ling_imm__age_idx <- age - ling_imm__minage + 1L
+            {
                 area <- ling_imm__area
                 ling_imm__area_idx <- (1L)
-                if (area == igfs__area) {
+                for (age in seq(ling_imm__minage, ling_imm__maxage, by = 1)) if (area == igfs__area) {
+                  ling_imm__age_idx <- age - ling_imm__minage + 1L
                   igfs__area_idx <- (1L)
                   fleet_area <- area
                   {
-                    ling_imm__predby_igfs[, ling_imm__area_idx, ling_imm__age_idx] <- ling_imm__predby_igfs[, ling_imm__area_idx, ling_imm__age_idx] * ((if (area != 1) 
+                    ling_imm__predby_igfs[, ling_imm__age_idx, ling_imm__area_idx] <- ling_imm__predby_igfs[, ling_imm__age_idx, ling_imm__area_idx] * ((if (area != 1) 
                       0
                     else intlookup_getdefault(igfs_totaldata__lookup, (cur_year * 100L + cur_step), 0))/igfs__catch[igfs__area_idx])
-                    ling_imm__totalpredate[, ling_imm__area_idx, ling_imm__age_idx] <- ling_imm__totalpredate[, ling_imm__area_idx, ling_imm__age_idx] + ling_imm__predby_igfs[, ling_imm__area_idx, ling_imm__age_idx]
+                    ling_imm__totalpredate[, ling_imm__age_idx, ling_imm__area_idx] <- ling_imm__totalpredate[, ling_imm__age_idx, ling_imm__area_idx] + ling_imm__predby_igfs[, ling_imm__age_idx, ling_imm__area_idx]
                   }
                 }
             }
         }
         {
             comment("Scale igfs catch of ling_mat by total expected catch")
-            for (age in seq(ling_mat__minage, ling_mat__maxage, by = 1)) {
-                ling_mat__age_idx <- age - ling_mat__minage + 1L
+            {
                 area <- ling_mat__area
                 ling_mat__area_idx <- (1L)
-                if (area == igfs__area) {
+                for (age in seq(ling_mat__minage, ling_mat__maxage, by = 1)) if (area == igfs__area) {
+                  ling_mat__age_idx <- age - ling_mat__minage + 1L
                   igfs__area_idx <- (1L)
                   fleet_area <- area
                   {
-                    ling_mat__predby_igfs[, ling_mat__area_idx, ling_mat__age_idx] <- ling_mat__predby_igfs[, ling_mat__area_idx, ling_mat__age_idx] * ((if (area != 1) 
+                    ling_mat__predby_igfs[, ling_mat__age_idx, ling_mat__area_idx] <- ling_mat__predby_igfs[, ling_mat__age_idx, ling_mat__area_idx] * ((if (area != 1) 
                       0
                     else intlookup_getdefault(igfs_totaldata__lookup, (cur_year * 100L + cur_step), 0))/igfs__catch[igfs__area_idx])
-                    ling_mat__totalpredate[, ling_mat__area_idx, ling_mat__age_idx] <- ling_mat__totalpredate[, ling_mat__area_idx, ling_mat__age_idx] + ling_mat__predby_igfs[, ling_mat__area_idx, ling_mat__age_idx]
+                    ling_mat__totalpredate[, ling_mat__age_idx, ling_mat__area_idx] <- ling_mat__totalpredate[, ling_mat__age_idx, ling_mat__area_idx] + ling_mat__predby_igfs[, ling_mat__age_idx, ling_mat__area_idx]
                   }
                 }
             }
@@ -415,14 +415,14 @@ structure(function (param)
             comment("Revert to being total biomass (applying overconsumption in process)")
             ling_imm__predby_igfs <- ling_imm__predby_igfs * ling_imm__totalpredate
             comment("Update total catch")
-            for (age in seq(ling_imm__minage, ling_imm__maxage, by = 1)) {
-                ling_imm__age_idx <- age - ling_imm__minage + 1L
+            {
                 area <- ling_imm__area
                 ling_imm__area_idx <- (1L)
-                if (area == igfs__area) {
+                for (age in seq(ling_imm__minage, ling_imm__maxage, by = 1)) if (area == igfs__area) {
+                  ling_imm__age_idx <- age - ling_imm__minage + 1L
                   igfs__area_idx <- (1L)
                   fleet_area <- area
-                  igfs__catch[igfs__area_idx] <- igfs__catch[igfs__area_idx] + sum(ling_imm__predby_igfs[, ling_imm__area_idx, ling_imm__age_idx])
+                  igfs__catch[igfs__area_idx] <- igfs__catch[igfs__area_idx] + sum(ling_imm__predby_igfs[, ling_imm__age_idx, ling_imm__area_idx])
                 }
             }
         }
@@ -430,33 +430,37 @@ structure(function (param)
             comment("Revert to being total biomass (applying overconsumption in process)")
             ling_mat__predby_igfs <- ling_mat__predby_igfs * ling_mat__totalpredate
             comment("Update total catch")
-            for (age in seq(ling_mat__minage, ling_mat__maxage, by = 1)) {
-                ling_mat__age_idx <- age - ling_mat__minage + 1L
+            {
                 area <- ling_mat__area
                 ling_mat__area_idx <- (1L)
-                if (area == igfs__area) {
+                for (age in seq(ling_mat__minage, ling_mat__maxage, by = 1)) if (area == igfs__area) {
+                  ling_mat__age_idx <- age - ling_mat__minage + 1L
                   igfs__area_idx <- (1L)
                   fleet_area <- area
-                  igfs__catch[igfs__area_idx] <- igfs__catch[igfs__area_idx] + sum(ling_mat__predby_igfs[, ling_mat__area_idx, ling_mat__age_idx])
+                  igfs__catch[igfs__area_idx] <- igfs__catch[igfs__area_idx] + sum(ling_mat__predby_igfs[, ling_mat__age_idx, ling_mat__area_idx])
                 }
             }
         }
         {
             comment("Natural mortality for ling_imm")
-            for (age in seq(ling_imm__minage, ling_imm__maxage, by = 1)) {
-                ling_imm__age_idx <- age - ling_imm__minage + 1L
+            {
                 area <- ling_imm__area
                 ling_imm__area_idx <- (1L)
-                ling_imm__num[, ling_imm__area_idx, ling_imm__age_idx] <- ling_imm__num[, ling_imm__area_idx, ling_imm__age_idx] * exp(-(param[["lingimm.M"]]) * cur_step_size)
+                for (age in seq(ling_imm__minage, ling_imm__maxage, by = 1)) {
+                  ling_imm__age_idx <- age - ling_imm__minage + 1L
+                  ling_imm__num[, ling_imm__age_idx, ling_imm__area_idx] <- ling_imm__num[, ling_imm__age_idx, ling_imm__area_idx] * exp(-(param[["lingimm.M"]]) * cur_step_size)
+                }
             }
         }
         {
             comment("Natural mortality for ling_mat")
-            for (age in seq(ling_mat__minage, ling_mat__maxage, by = 1)) {
-                ling_mat__age_idx <- age - ling_mat__minage + 1L
+            {
                 area <- ling_mat__area
                 ling_mat__area_idx <- (1L)
-                ling_mat__num[, ling_mat__area_idx, ling_mat__age_idx] <- ling_mat__num[, ling_mat__area_idx, ling_mat__age_idx] * exp(-(param[["lingmat.M"]]) * cur_step_size)
+                for (age in seq(ling_mat__minage, ling_mat__maxage, by = 1)) {
+                  ling_mat__age_idx <- age - ling_mat__minage + 1L
+                  ling_mat__num[, ling_mat__age_idx, ling_mat__area_idx] <- ling_mat__num[, ling_mat__age_idx, ling_mat__area_idx] * exp(-(param[["lingmat.M"]]) * cur_step_size)
+                }
             }
         }
         if (cur_step_final) {
@@ -466,106 +470,111 @@ structure(function (param)
         }
         {
             comment("g3a_grow for ling_imm")
-            for (age in seq(ling_imm__minage, ling_imm__maxage, by = 1)) {
-                ling_imm__age_idx <- age - ling_imm__minage + 1L
+            {
                 area <- ling_imm__area
                 ling_imm__area_idx <- (1L)
-                {
-                  if (ling_imm__growth_lastcalc != floor(cur_step_size * 12L)) {
-                    comment("Calculate length/weight delta matrices for current lengthgroups")
-                    ling_imm__growth_l[] <- growth_bbinom(avoid_zero_vec(avoid_zero_vec((param[["ling.Linf"]] - ling_imm__midlen) * (1 - exp(-((param[["ling.K"]] * 0.001)) * cur_step_size)))/ling_imm__plusdl), 15L, avoid_zero((param[["ling.bbin"]] * 10)))
-                    ling_imm__growth_w[] <- (g3a_grow_weightsimple_vec_rotate(pow_vec(ling_imm__midlen, param[["lingimm.wbeta"]]), 15L + 1) - g3a_grow_weightsimple_vec_extrude(pow_vec(ling_imm__midlen, param[["lingimm.wbeta"]]), 15L + 1)) * param[["lingimm.walpha"]]
-                    comment("Don't recalculate until cur_step_size changes")
-                    ling_imm__growth_lastcalc <- floor(cur_step_size * 12L)
-                  }
-                  if (TRUE) 
-                    ling_imm__prevtotal <- sum(ling_imm__num[, ling_imm__area_idx, ling_imm__age_idx])
-                  if (cur_step_final) {
-                    maturity_ratio <- (1/(1 + exp((0 - (0.001 * param[["ling.mat1"]]) * (ling_imm__midlen - param[["ling.mat2"]])))))
-                    {
-                      comment("Grow and separate maturing ling_imm")
+                for (age in seq(ling_imm__minage, ling_imm__maxage, by = 1)) {
+                  ling_imm__age_idx <- age - ling_imm__minage + 1L
+                  {
+                    if (ling_imm__growth_lastcalc != floor(cur_step_size * 12L)) {
+                      comment("Calculate length/weight delta matrices for current lengthgroups")
+                      ling_imm__growth_l[] <- growth_bbinom(avoid_zero_vec(avoid_zero_vec((param[["ling.Linf"]] - ling_imm__midlen) * (1 - exp(-((param[["ling.K"]] * 0.001)) * cur_step_size)))/ling_imm__plusdl), 15L, avoid_zero((param[["ling.bbin"]] * 10)))
+                      ling_imm__growth_w[] <- (g3a_grow_weightsimple_vec_rotate(pow_vec(ling_imm__midlen, param[["lingimm.wbeta"]]), 15L + 1) - g3a_grow_weightsimple_vec_extrude(pow_vec(ling_imm__midlen, param[["lingimm.wbeta"]]), 15L + 1)) * param[["lingimm.walpha"]]
+                      comment("Don't recalculate until cur_step_size changes")
+                      ling_imm__growth_lastcalc <- floor(cur_step_size * 12L)
+                    }
+                    if (TRUE) 
+                      ling_imm__prevtotal <- sum(ling_imm__num[, ling_imm__age_idx, ling_imm__area_idx])
+                    if (cur_step_final) {
+                      maturity_ratio <- (1/(1 + exp((0 - (0.001 * param[["ling.mat1"]]) * (ling_imm__midlen - param[["ling.mat2"]])))))
                       {
-                        growthresult <- g3a_grow_apply(ling_imm__growth_l, ling_imm__growth_w, ling_imm__num[, ling_imm__area_idx, ling_imm__age_idx] * maturity_ratio, ling_imm__wgt[, ling_imm__area_idx, ling_imm__age_idx])
+                        comment("Grow and separate maturing ling_imm")
                         {
-                          ling_imm__transitioning_num[, ling_imm__area_idx, ling_imm__age_idx] <- growthresult[, (1)]
-                          ling_imm__transitioning_wgt[, ling_imm__area_idx, ling_imm__age_idx] <- growthresult[, (2)]
+                          growthresult <- g3a_grow_apply(ling_imm__growth_l, ling_imm__growth_w, ling_imm__num[, ling_imm__age_idx, ling_imm__area_idx] * maturity_ratio, ling_imm__wgt[, ling_imm__age_idx, ling_imm__area_idx])
+                          {
+                            ling_imm__transitioning_num[, ling_imm__age_idx, ling_imm__area_idx] <- growthresult[, (1)]
+                            ling_imm__transitioning_wgt[, ling_imm__age_idx, ling_imm__area_idx] <- growthresult[, (2)]
+                          }
                         }
-                      }
-                      comment("Grow non-maturing ling_imm")
-                      {
-                        growthresult <- g3a_grow_apply(ling_imm__growth_l, ling_imm__growth_w, ling_imm__num[, ling_imm__area_idx, ling_imm__age_idx] * (1 - maturity_ratio), ling_imm__wgt[, ling_imm__area_idx, ling_imm__age_idx])
+                        comment("Grow non-maturing ling_imm")
                         {
-                          ling_imm__num[, ling_imm__area_idx, ling_imm__age_idx] <- growthresult[, (1)]
-                          ling_imm__wgt[, ling_imm__area_idx, ling_imm__age_idx] <- growthresult[, (2)]
+                          growthresult <- g3a_grow_apply(ling_imm__growth_l, ling_imm__growth_w, ling_imm__num[, ling_imm__age_idx, ling_imm__area_idx] * (1 - maturity_ratio), ling_imm__wgt[, ling_imm__age_idx, ling_imm__area_idx])
+                          {
+                            ling_imm__num[, ling_imm__age_idx, ling_imm__area_idx] <- growthresult[, (1)]
+                            ling_imm__wgt[, ling_imm__age_idx, ling_imm__area_idx] <- growthresult[, (2)]
+                          }
                         }
                       }
                     }
-                  }
-                  else {
-                    comment("Update ling_imm using delta matrices")
-                    {
-                      growthresult <- g3a_grow_apply(ling_imm__growth_l, ling_imm__growth_w, ling_imm__num[, ling_imm__area_idx, ling_imm__age_idx], ling_imm__wgt[, ling_imm__area_idx, ling_imm__age_idx])
+                    else {
+                      comment("Update ling_imm using delta matrices")
                       {
-                        ling_imm__num[, ling_imm__area_idx, ling_imm__age_idx] <- growthresult[, (1)]
-                        ling_imm__wgt[, ling_imm__area_idx, ling_imm__age_idx] <- growthresult[, (2)]
+                        growthresult <- g3a_grow_apply(ling_imm__growth_l, ling_imm__growth_w, ling_imm__num[, ling_imm__age_idx, ling_imm__area_idx], ling_imm__wgt[, ling_imm__age_idx, ling_imm__area_idx])
+                        {
+                          ling_imm__num[, ling_imm__age_idx, ling_imm__area_idx] <- growthresult[, (1)]
+                          ling_imm__wgt[, ling_imm__age_idx, ling_imm__area_idx] <- growthresult[, (2)]
+                        }
                       }
                     }
+                    if (TRUE) 
+                      if (cur_step_final) 
+                        assert_msg(~abs(ling_imm__prevtotal - sum(ling_imm__num[, ling_imm__age_idx, ling_imm__area_idx]) - sum(ling_imm__transitioning_num[, ling_imm__age_idx, ling_imm__area_idx])) < 1e-04, "g3a_growmature: ling_imm__num totals are not the same before and after growth (excluding maturation)")
+                      else assert_msg(~abs(ling_imm__prevtotal - sum(ling_imm__num[, ling_imm__age_idx, ling_imm__area_idx])) < 1e-04, "g3a_growmature: ling_imm__num totals are not the same before and after growth")
                   }
-                  if (TRUE) 
-                    if (cur_step_final) 
-                      assert_msg(~abs(ling_imm__prevtotal - sum(ling_imm__num[, ling_imm__area_idx, ling_imm__age_idx]) - sum(ling_imm__transitioning_num[, ling_imm__area_idx, ling_imm__age_idx])) < 1e-04, "g3a_growmature: ling_imm__num totals are not the same before and after growth (excluding maturation)")
-                    else assert_msg(~abs(ling_imm__prevtotal - sum(ling_imm__num[, ling_imm__area_idx, ling_imm__age_idx])) < 1e-04, "g3a_growmature: ling_imm__num totals are not the same before and after growth")
                 }
             }
         }
         {
             comment("g3a_grow for ling_mat")
-            for (age in seq(ling_mat__minage, ling_mat__maxage, by = 1)) {
-                ling_mat__age_idx <- age - ling_mat__minage + 1L
+            {
                 area <- ling_mat__area
                 ling_mat__area_idx <- (1L)
-                {
-                  if (ling_mat__growth_lastcalc != floor(cur_step_size * 12L)) {
-                    comment("Calculate length/weight delta matrices for current lengthgroups")
-                    ling_mat__growth_l[] <- growth_bbinom(avoid_zero_vec(avoid_zero_vec((param[["ling.Linf"]] - ling_mat__midlen) * (1 - exp(-((param[["ling.K"]] * 0.001)) * cur_step_size)))/ling_mat__plusdl), 15L, avoid_zero((param[["ling.bbin"]] * 10)))
-                    ling_mat__growth_w[] <- (g3a_grow_weightsimple_vec_rotate(pow_vec(ling_mat__midlen, param[["lingmat.wbeta"]]), 15L + 1) - g3a_grow_weightsimple_vec_extrude(pow_vec(ling_mat__midlen, param[["lingmat.wbeta"]]), 15L + 1)) * param[["lingmat.walpha"]]
-                    comment("Don't recalculate until cur_step_size changes")
-                    ling_mat__growth_lastcalc <- floor(cur_step_size * 12L)
-                  }
-                  if (TRUE) 
-                    ling_mat__prevtotal <- sum(ling_mat__num[, ling_mat__area_idx, ling_mat__age_idx])
-                  comment("Update ling_mat using delta matrices")
+                for (age in seq(ling_mat__minage, ling_mat__maxage, by = 1)) {
+                  ling_mat__age_idx <- age - ling_mat__minage + 1L
                   {
-                    growthresult <- g3a_grow_apply(ling_mat__growth_l, ling_mat__growth_w, ling_mat__num[, ling_mat__area_idx, ling_mat__age_idx], ling_mat__wgt[, ling_mat__area_idx, ling_mat__age_idx])
-                    {
-                      ling_mat__num[, ling_mat__area_idx, ling_mat__age_idx] <- growthresult[, (1)]
-                      ling_mat__wgt[, ling_mat__area_idx, ling_mat__age_idx] <- growthresult[, (2)]
+                    if (ling_mat__growth_lastcalc != floor(cur_step_size * 12L)) {
+                      comment("Calculate length/weight delta matrices for current lengthgroups")
+                      ling_mat__growth_l[] <- growth_bbinom(avoid_zero_vec(avoid_zero_vec((param[["ling.Linf"]] - ling_mat__midlen) * (1 - exp(-((param[["ling.K"]] * 0.001)) * cur_step_size)))/ling_mat__plusdl), 15L, avoid_zero((param[["ling.bbin"]] * 10)))
+                      ling_mat__growth_w[] <- (g3a_grow_weightsimple_vec_rotate(pow_vec(ling_mat__midlen, param[["lingmat.wbeta"]]), 15L + 1) - g3a_grow_weightsimple_vec_extrude(pow_vec(ling_mat__midlen, param[["lingmat.wbeta"]]), 15L + 1)) * param[["lingmat.walpha"]]
+                      comment("Don't recalculate until cur_step_size changes")
+                      ling_mat__growth_lastcalc <- floor(cur_step_size * 12L)
                     }
+                    if (TRUE) 
+                      ling_mat__prevtotal <- sum(ling_mat__num[, ling_mat__age_idx, ling_mat__area_idx])
+                    comment("Update ling_mat using delta matrices")
+                    {
+                      growthresult <- g3a_grow_apply(ling_mat__growth_l, ling_mat__growth_w, ling_mat__num[, ling_mat__age_idx, ling_mat__area_idx], ling_mat__wgt[, ling_mat__age_idx, ling_mat__area_idx])
+                      {
+                        ling_mat__num[, ling_mat__age_idx, ling_mat__area_idx] <- growthresult[, (1)]
+                        ling_mat__wgt[, ling_mat__age_idx, ling_mat__area_idx] <- growthresult[, (2)]
+                      }
+                    }
+                    if (TRUE) 
+                      assert_msg(~abs(ling_mat__prevtotal - sum(ling_mat__num[, ling_mat__age_idx, ling_mat__area_idx])) < 1e-04, "g3a_growmature: ling_mat__num totals are not the same before and after growth")
                   }
-                  if (TRUE) 
-                    assert_msg(~abs(ling_mat__prevtotal - sum(ling_mat__num[, ling_mat__area_idx, ling_mat__age_idx])) < 1e-04, "g3a_growmature: ling_mat__num totals are not the same before and after growth")
                 }
             }
         }
         {
             comment("Move ling_imm to ling_mat")
-            for (age in seq(ling_mat__minage, ling_mat__maxage, by = 1)) if (age >= ling_imm__minage && age <= ling_imm__maxage) {
-                ling_mat__age_idx <- age - ling_mat__minage + 1L
+            {
                 area <- ling_mat__area
                 ling_mat__area_idx <- (1L)
-                if (area == ling_imm__area) 
-                  if (cur_step_final) {
-                    ling_imm__age_idx <- age - ling_imm__minage + 1L
-                    {
+                for (age in seq(ling_mat__minage, ling_mat__maxage, by = 1)) if (area == ling_imm__area) 
+                  if (age >= ling_imm__minage && age <= ling_imm__maxage) 
+                    if (cur_step_final) {
+                      ling_mat__age_idx <- age - ling_mat__minage + 1L
                       ling_imm__area_idx <- (1L)
                       {
-                        ling_mat__wgt[, ling_mat__area_idx, ling_mat__age_idx] <- (ling_mat__wgt[, ling_mat__area_idx, ling_mat__age_idx] * ling_mat__num[, ling_mat__area_idx, ling_mat__age_idx]) + ling_imm__transitioning_wgt[, ling_imm__area_idx, ling_imm__age_idx] * ling_imm__transitioning_num[, ling_imm__area_idx, ling_imm__age_idx]
-                        ling_mat__num[, ling_mat__area_idx, ling_mat__age_idx] <- ling_mat__num[, ling_mat__area_idx, ling_mat__age_idx] + ling_imm__transitioning_num[, ling_imm__area_idx, ling_imm__age_idx]
-                        ling_imm__transitioning_num[, ling_imm__area_idx, ling_imm__age_idx] <- ling_imm__transitioning_num[, ling_imm__area_idx, ling_imm__age_idx] - ling_imm__transitioning_num[, ling_imm__area_idx, ling_imm__age_idx]
-                        ling_mat__wgt[, ling_mat__area_idx, ling_mat__age_idx] <- ling_mat__wgt[, ling_mat__area_idx, ling_mat__age_idx]/avoid_zero_vec(ling_mat__num[, ling_mat__area_idx, ling_mat__age_idx])
+                        ling_imm__age_idx <- age - ling_imm__minage + 1L
+                        {
+                          ling_mat__wgt[, ling_mat__age_idx, ling_mat__area_idx] <- (ling_mat__wgt[, ling_mat__age_idx, ling_mat__area_idx] * ling_mat__num[, ling_mat__age_idx, ling_mat__area_idx]) + ling_imm__transitioning_wgt[, ling_imm__age_idx, ling_imm__area_idx] * ling_imm__transitioning_num[, ling_imm__age_idx, ling_imm__area_idx]
+                          ling_mat__num[, ling_mat__age_idx, ling_mat__area_idx] <- ling_mat__num[, ling_mat__age_idx, ling_mat__area_idx] + ling_imm__transitioning_num[, ling_imm__age_idx, ling_imm__area_idx]
+                          ling_imm__transitioning_num[, ling_imm__age_idx, ling_imm__area_idx] <- ling_imm__transitioning_num[, ling_imm__age_idx, ling_imm__area_idx] - ling_imm__transitioning_num[, ling_imm__age_idx, ling_imm__area_idx]
+                          ling_mat__wgt[, ling_mat__age_idx, ling_mat__area_idx] <- ling_mat__wgt[, ling_mat__age_idx, ling_mat__area_idx]/avoid_zero_vec(ling_mat__num[, ling_mat__age_idx, ling_mat__area_idx])
+                        }
                       }
                     }
-                  }
             }
             comment("Move any unclaimed stock back to ling_imm")
             if (cur_step_final) 
@@ -578,17 +587,19 @@ structure(function (param)
             }))
             {
                 comment("g3a_renewal for ling_imm")
-                for (age in seq(ling_imm__minage, ling_imm__maxage, by = 1)) if (cur_step == 1 && age == 3) {
-                  ling_imm__age_idx <- age - ling_imm__minage + 1L
+                {
                   area <- ling_imm__area
                   ling_imm__area_idx <- (1L)
-                  dnorm <- ((ling_imm__midlen - (param[["ling.Linf"]] * (1 - exp(-1 * param[["ling.K"]] * (age - (param[["recage"]] + log(1 - param[["ling.recl"]]/param[["ling.Linf"]])/param[["ling.K"]]))))))/ling_imm_stddev[[as_integer(age) - 3 + 1]])
-                  {
-                    ling_imm__renewalnum[, ling_imm__area_idx, ling_imm__age_idx] <- normalize_vec(exp(-(dnorm^2) * 0.5)) * 10000 * factor
-                    ling_imm__renewalwgt[, ling_imm__area_idx, ling_imm__age_idx] <- param[["lingimm.walpha"]] * ling_imm__midlen^param[["lingimm.wbeta"]]
-                    comment("Add result to ling_imm")
-                    ling_imm__wgt[, ling_imm__area_idx, ling_imm__age_idx] <- ratio_add_vec(ling_imm__wgt[, ling_imm__area_idx, ling_imm__age_idx], ling_imm__num[, ling_imm__area_idx, ling_imm__age_idx], ling_imm__renewalwgt[, ling_imm__area_idx, ling_imm__age_idx], ling_imm__renewalnum[, ling_imm__area_idx, ling_imm__age_idx])
-                    ling_imm__num[, ling_imm__area_idx, ling_imm__age_idx] <- ling_imm__num[, ling_imm__area_idx, ling_imm__age_idx] + ling_imm__renewalnum[, ling_imm__area_idx, ling_imm__age_idx]
+                  for (age in seq(ling_imm__minage, ling_imm__maxage, by = 1)) if (cur_step == 1 && age == 3) {
+                    ling_imm__age_idx <- age - ling_imm__minage + 1L
+                    dnorm <- ((ling_imm__midlen - (param[["ling.Linf"]] * (1 - exp(-1 * param[["ling.K"]] * (age - (param[["recage"]] + log(1 - param[["ling.recl"]]/param[["ling.Linf"]])/param[["ling.K"]]))))))/ling_imm_stddev[[as_integer(age) - 3 + 1]])
+                    {
+                      ling_imm__renewalnum[, ling_imm__age_idx, ling_imm__area_idx] <- normalize_vec(exp(-(dnorm^2) * 0.5)) * 10000 * factor
+                      ling_imm__renewalwgt[, ling_imm__age_idx, ling_imm__area_idx] <- param[["lingimm.walpha"]] * ling_imm__midlen^param[["lingimm.wbeta"]]
+                      comment("Add result to ling_imm")
+                      ling_imm__wgt[, ling_imm__age_idx, ling_imm__area_idx] <- ratio_add_vec(ling_imm__wgt[, ling_imm__age_idx, ling_imm__area_idx], ling_imm__num[, ling_imm__age_idx, ling_imm__area_idx], ling_imm__renewalwgt[, ling_imm__age_idx, ling_imm__area_idx], ling_imm__renewalnum[, ling_imm__age_idx, ling_imm__area_idx])
+                      ling_imm__num[, ling_imm__age_idx, ling_imm__area_idx] <- ling_imm__num[, ling_imm__age_idx, ling_imm__area_idx] + ling_imm__renewalnum[, ling_imm__age_idx, ling_imm__area_idx]
+                    }
                   }
                 }
             }
@@ -600,47 +611,49 @@ structure(function (param)
             }))
             {
                 comment("g3a_renewal for ling_imm")
-                for (age in seq(ling_imm__minage, ling_imm__maxage, by = 1)) if (cur_step == 1 && age == 5) {
-                  ling_imm__age_idx <- age - ling_imm__minage + 1L
+                {
                   area <- ling_imm__area
                   ling_imm__area_idx <- (1L)
-                  dnorm <- ((ling_imm__midlen - (param[["ling.Linf"]] * (1 - exp(-1 * param[["ling.K"]] * (age - (param[["recage"]] + log(1 - param[["ling.recl"]]/param[["ling.Linf"]])/param[["ling.K"]]))))))/ling_imm_stddev[[as_integer(age) - 3L + 1L]])
-                  {
-                    ling_imm__renewalnum[, ling_imm__area_idx, ling_imm__age_idx] <- normalize_vec(exp(-(dnorm^2) * 0.5)) * 10000 * factor
-                    ling_imm__renewalwgt[, ling_imm__area_idx, ling_imm__age_idx] <- param[["lingimm.walpha"]] * ling_imm__midlen^param[["lingimm.wbeta"]]
-                    comment("Add result to ling_imm")
-                    ling_imm__wgt[, ling_imm__area_idx, ling_imm__age_idx] <- ratio_add_vec(ling_imm__wgt[, ling_imm__area_idx, ling_imm__age_idx], ling_imm__num[, ling_imm__area_idx, ling_imm__age_idx], ling_imm__renewalwgt[, ling_imm__area_idx, ling_imm__age_idx], ling_imm__renewalnum[, ling_imm__area_idx, ling_imm__age_idx])
-                    ling_imm__num[, ling_imm__area_idx, ling_imm__age_idx] <- ling_imm__num[, ling_imm__area_idx, ling_imm__age_idx] + ling_imm__renewalnum[, ling_imm__area_idx, ling_imm__age_idx]
+                  for (age in seq(ling_imm__minage, ling_imm__maxage, by = 1)) if (cur_step == 1 && age == 5) {
+                    ling_imm__age_idx <- age - ling_imm__minage + 1L
+                    dnorm <- ((ling_imm__midlen - (param[["ling.Linf"]] * (1 - exp(-1 * param[["ling.K"]] * (age - (param[["recage"]] + log(1 - param[["ling.recl"]]/param[["ling.Linf"]])/param[["ling.K"]]))))))/ling_imm_stddev[[as_integer(age) - 3L + 1L]])
+                    {
+                      ling_imm__renewalnum[, ling_imm__age_idx, ling_imm__area_idx] <- normalize_vec(exp(-(dnorm^2) * 0.5)) * 10000 * factor
+                      ling_imm__renewalwgt[, ling_imm__age_idx, ling_imm__area_idx] <- param[["lingimm.walpha"]] * ling_imm__midlen^param[["lingimm.wbeta"]]
+                      comment("Add result to ling_imm")
+                      ling_imm__wgt[, ling_imm__age_idx, ling_imm__area_idx] <- ratio_add_vec(ling_imm__wgt[, ling_imm__age_idx, ling_imm__area_idx], ling_imm__num[, ling_imm__age_idx, ling_imm__area_idx], ling_imm__renewalwgt[, ling_imm__age_idx, ling_imm__area_idx], ling_imm__renewalnum[, ling_imm__age_idx, ling_imm__area_idx])
+                      ling_imm__num[, ling_imm__age_idx, ling_imm__area_idx] <- ling_imm__num[, ling_imm__age_idx, ling_imm__area_idx] + ling_imm__renewalnum[, ling_imm__age_idx, ling_imm__area_idx]
+                    }
                   }
                 }
             }
         }
         {
             comment("g3l_catchdistribution_sumofsquares: Collect catch from igfs/ling_imm for cdist_sumofsquares_ldist_lln")
-            for (age in seq(ling_imm__minage, ling_imm__maxage, by = 1)) {
-                ling_imm__age_idx <- age - ling_imm__minage + 1L
+            {
                 area <- ling_imm__area
                 ling_imm__area_idx <- (1L)
-                if (area == cdist_sumofsquares_ldist_lln_model__area) {
+                for (age in seq(ling_imm__minage, ling_imm__maxage, by = 1)) if (area == cdist_sumofsquares_ldist_lln_model__area) {
+                  ling_imm__age_idx <- age - ling_imm__minage + 1L
                   cdist_sumofsquares_ldist_lln_model__area_idx <- (1L)
                   {
                     comment("Take prey_stock__predby_predstock weight, convert to individuals, add to our count")
-                    cdist_sumofsquares_ldist_lln_model__num[, cdist_sumofsquares_ldist_lln_model__area_idx] <- cdist_sumofsquares_ldist_lln_model__num[, cdist_sumofsquares_ldist_lln_model__area_idx] + ling_imm__predby_igfs[, ling_imm__area_idx, ling_imm__age_idx]/avoid_zero_vec(ling_imm__wgt[, ling_imm__area_idx, ling_imm__age_idx])
+                    cdist_sumofsquares_ldist_lln_model__num[, cdist_sumofsquares_ldist_lln_model__area_idx] <- cdist_sumofsquares_ldist_lln_model__num[, cdist_sumofsquares_ldist_lln_model__area_idx] + ling_imm__predby_igfs[, ling_imm__age_idx, ling_imm__area_idx]/avoid_zero_vec(ling_imm__wgt[, ling_imm__age_idx, ling_imm__area_idx])
                   }
                 }
             }
         }
         {
             comment("g3l_catchdistribution_sumofsquares: Collect catch from igfs/ling_mat for cdist_sumofsquares_ldist_lln")
-            for (age in seq(ling_mat__minage, ling_mat__maxage, by = 1)) {
-                ling_mat__age_idx <- age - ling_mat__minage + 1L
+            {
                 area <- ling_mat__area
                 ling_mat__area_idx <- (1L)
-                if (area == cdist_sumofsquares_ldist_lln_model__area) {
+                for (age in seq(ling_mat__minage, ling_mat__maxage, by = 1)) if (area == cdist_sumofsquares_ldist_lln_model__area) {
+                  ling_mat__age_idx <- age - ling_mat__minage + 1L
                   cdist_sumofsquares_ldist_lln_model__area_idx <- (1L)
                   {
                     comment("Take prey_stock__predby_predstock weight, convert to individuals, add to our count")
-                    cdist_sumofsquares_ldist_lln_model__num[, cdist_sumofsquares_ldist_lln_model__area_idx] <- cdist_sumofsquares_ldist_lln_model__num[, cdist_sumofsquares_ldist_lln_model__area_idx] + ling_mat__predby_igfs[, ling_mat__area_idx, ling_mat__age_idx]/avoid_zero_vec(ling_mat__wgt[, ling_mat__area_idx, ling_mat__age_idx])
+                    cdist_sumofsquares_ldist_lln_model__num[, cdist_sumofsquares_ldist_lln_model__area_idx] <- cdist_sumofsquares_ldist_lln_model__num[, cdist_sumofsquares_ldist_lln_model__area_idx] + ling_mat__predby_igfs[, ling_mat__age_idx, ling_mat__area_idx]/avoid_zero_vec(ling_mat__wgt[, ling_mat__age_idx, ling_mat__area_idx])
                   }
                 }
             }
@@ -690,71 +703,81 @@ structure(function (param)
             nll_understocking__weight[cur_time + 1L] <- 1e+08
         }
         if (cur_step_final) {
-            comment("g3a_age for ling_imm")
-            for (age in seq(ling_imm__maxage, ling_imm__minage, by = -1)) {
-                ling_imm__age_idx <- age - ling_imm__minage + 1L
+            ling_imm__area_idx <- (1)
+            {
+                ling_imm_movement__area_idx <- (1)
                 {
-                  comment("Check stock has remained finite for this step")
-                  if (age == ling_imm__maxage) {
-                    comment("Move oldest ling_imm into ling_imm_movement")
-                    ling_imm_movement__transitioning_num[, , (1)] <- ling_imm__num[, , ling_imm__age_idx]
-                    ling_imm_movement__transitioning_wgt[, , (1)] <- ling_imm__wgt[, , ling_imm__age_idx]
-                    ling_imm__num[, , ling_imm__age_idx] <- ling_imm__num[, , ling_imm__age_idx - 1]
-                    ling_imm__wgt[, , ling_imm__age_idx] <- ling_imm__wgt[, , ling_imm__age_idx - 1]
-                  }
-                  else if (age == ling_imm__minage) {
-                    comment("Empty youngest ling_imm age-group")
-                    ling_imm__num[, , ling_imm__age_idx] <- 0
-                  }
-                  else {
-                    comment("Move ling_imm age-group to next one up")
-                    ling_imm__num[, , ling_imm__age_idx] <- ling_imm__num[, , ling_imm__age_idx - 1]
-                    ling_imm__wgt[, , ling_imm__age_idx] <- ling_imm__wgt[, , ling_imm__age_idx - 1]
+                  comment("g3a_age for ling_imm")
+                  for (age in seq(ling_imm__maxage, ling_imm__minage, by = -1)) {
+                    ling_imm__age_idx <- age - ling_imm__minage + 1L
+                    {
+                      comment("Check stock has remained finite for this step")
+                      if (age == ling_imm__maxage) {
+                        comment("Move oldest ling_imm into ling_imm_movement")
+                        ling_imm_movement__transitioning_num[, (1), ling_imm_movement__area_idx] <- ling_imm__num[, ling_imm__age_idx, ling_imm__area_idx]
+                        ling_imm_movement__transitioning_wgt[, (1), ling_imm_movement__area_idx] <- ling_imm__wgt[, ling_imm__age_idx, ling_imm__area_idx]
+                        ling_imm__num[, ling_imm__age_idx, ling_imm__area_idx] <- ling_imm__num[, ling_imm__age_idx - 1, ling_imm__area_idx]
+                        ling_imm__wgt[, ling_imm__age_idx, ling_imm__area_idx] <- ling_imm__wgt[, ling_imm__age_idx - 1, ling_imm__area_idx]
+                      }
+                      else if (age == ling_imm__minage) {
+                        comment("Empty youngest ling_imm age-group")
+                        ling_imm__num[, ling_imm__age_idx, ling_imm__area_idx] <- 0
+                      }
+                      else {
+                        comment("Move ling_imm age-group to next one up")
+                        ling_imm__num[, ling_imm__age_idx, ling_imm__area_idx] <- ling_imm__num[, ling_imm__age_idx - 1, ling_imm__area_idx]
+                        ling_imm__wgt[, ling_imm__age_idx, ling_imm__area_idx] <- ling_imm__wgt[, ling_imm__age_idx - 1, ling_imm__area_idx]
+                      }
+                    }
                   }
                 }
             }
         }
         if (cur_step_final) {
-            comment("g3a_age for ling_mat")
-            for (age in seq(ling_mat__maxage, ling_mat__minage, by = -1)) {
-                ling_mat__age_idx <- age - ling_mat__minage + 1L
-                {
-                  comment("Check stock has remained finite for this step")
-                  if (age == ling_mat__maxage) {
-                    comment("Oldest ling_mat is a plus-group, combine with younger individuals")
-                    ling_mat__wgt[, , ling_mat__age_idx] <- ratio_add_vec(ling_mat__wgt[, , ling_mat__age_idx], ling_mat__num[, , ling_mat__age_idx], ling_mat__wgt[, , ling_mat__age_idx - 1], ling_mat__num[, , ling_mat__age_idx - 1])
-                    ling_mat__num[, , ling_mat__age_idx] <- ling_mat__num[, , ling_mat__age_idx] + ling_mat__num[, , ling_mat__age_idx - 1]
-                  }
-                  else if (age == ling_mat__minage) {
-                    comment("Empty youngest ling_mat age-group")
-                    ling_mat__num[, , ling_mat__age_idx] <- 0
-                  }
-                  else {
-                    comment("Move ling_mat age-group to next one up")
-                    ling_mat__num[, , ling_mat__age_idx] <- ling_mat__num[, , ling_mat__age_idx - 1]
-                    ling_mat__wgt[, , ling_mat__age_idx] <- ling_mat__wgt[, , ling_mat__age_idx - 1]
+            ling_mat__area_idx <- (1)
+            {
+                comment("g3a_age for ling_mat")
+                for (age in seq(ling_mat__maxage, ling_mat__minage, by = -1)) {
+                  ling_mat__age_idx <- age - ling_mat__minage + 1L
+                  {
+                    comment("Check stock has remained finite for this step")
+                    if (age == ling_mat__maxage) {
+                      comment("Oldest ling_mat is a plus-group, combine with younger individuals")
+                      ling_mat__wgt[, ling_mat__age_idx, ling_mat__area_idx] <- ratio_add_vec(ling_mat__wgt[, ling_mat__age_idx, ling_mat__area_idx], ling_mat__num[, ling_mat__age_idx, ling_mat__area_idx], ling_mat__wgt[, ling_mat__age_idx - 1, ling_mat__area_idx], ling_mat__num[, ling_mat__age_idx - 1, ling_mat__area_idx])
+                      ling_mat__num[, ling_mat__age_idx, ling_mat__area_idx] <- ling_mat__num[, ling_mat__age_idx, ling_mat__area_idx] + ling_mat__num[, ling_mat__age_idx - 1, ling_mat__area_idx]
+                    }
+                    else if (age == ling_mat__minage) {
+                      comment("Empty youngest ling_mat age-group")
+                      ling_mat__num[, ling_mat__age_idx, ling_mat__area_idx] <- 0
+                    }
+                    else {
+                      comment("Move ling_mat age-group to next one up")
+                      ling_mat__num[, ling_mat__age_idx, ling_mat__area_idx] <- ling_mat__num[, ling_mat__age_idx - 1, ling_mat__area_idx]
+                      ling_mat__wgt[, ling_mat__age_idx, ling_mat__area_idx] <- ling_mat__wgt[, ling_mat__age_idx - 1, ling_mat__area_idx]
+                    }
                   }
                 }
             }
         }
         {
             comment("Move ling_imm_movement to ling_mat")
-            for (age in seq(ling_mat__minage, ling_mat__maxage, by = 1)) if (age >= ling_imm_movement__minage && age <= ling_imm_movement__maxage) {
-                ling_mat__age_idx <- age - ling_mat__minage + 1L
+            {
                 area <- ling_mat__area
                 ling_mat__area_idx <- (1L)
-                if (area == ling_imm_movement__area) 
-                  if (cur_step_final) {
-                    ling_imm_movement__age_idx <- age - ling_imm_movement__minage + 1L
-                    {
+                for (age in seq(ling_mat__minage, ling_mat__maxage, by = 1)) if (area == ling_imm_movement__area) 
+                  if (age >= ling_imm_movement__minage && age <= ling_imm_movement__maxage) 
+                    if (cur_step_final) {
+                      ling_mat__age_idx <- age - ling_mat__minage + 1L
                       ling_imm_movement__area_idx <- (1L)
                       {
-                        ling_mat__wgt[, ling_mat__area_idx, ling_mat__age_idx] <- (ling_mat__wgt[, ling_mat__area_idx, ling_mat__age_idx] * ling_mat__num[, ling_mat__area_idx, ling_mat__age_idx]) + ling_imm_movement__transitioning_wgt[, ling_imm_movement__area_idx, ling_imm_movement__age_idx] * ling_imm_movement__transitioning_num[, ling_imm_movement__area_idx, ling_imm_movement__age_idx]
-                        ling_mat__num[, ling_mat__area_idx, ling_mat__age_idx] <- ling_mat__num[, ling_mat__area_idx, ling_mat__age_idx] + ling_imm_movement__transitioning_num[, ling_imm_movement__area_idx, ling_imm_movement__age_idx]
-                        ling_mat__wgt[, ling_mat__area_idx, ling_mat__age_idx] <- ling_mat__wgt[, ling_mat__area_idx, ling_mat__age_idx]/avoid_zero_vec(ling_mat__num[, ling_mat__area_idx, ling_mat__age_idx])
+                        ling_imm_movement__age_idx <- age - ling_imm_movement__minage + 1L
+                        {
+                          ling_mat__wgt[, ling_mat__age_idx, ling_mat__area_idx] <- (ling_mat__wgt[, ling_mat__age_idx, ling_mat__area_idx] * ling_mat__num[, ling_mat__age_idx, ling_mat__area_idx]) + ling_imm_movement__transitioning_wgt[, ling_imm_movement__age_idx, ling_imm_movement__area_idx] * ling_imm_movement__transitioning_num[, ling_imm_movement__age_idx, ling_imm_movement__area_idx]
+                          ling_mat__num[, ling_mat__age_idx, ling_mat__area_idx] <- ling_mat__num[, ling_mat__age_idx, ling_mat__area_idx] + ling_imm_movement__transitioning_num[, ling_imm_movement__age_idx, ling_imm_movement__area_idx]
+                          ling_mat__wgt[, ling_mat__age_idx, ling_mat__area_idx] <- ling_mat__wgt[, ling_mat__age_idx, ling_mat__area_idx]/avoid_zero_vec(ling_mat__num[, ling_mat__age_idx, ling_mat__area_idx])
+                        }
                       }
                     }
-                  }
             }
         }
     }

--- a/inttest/codegeneration/ling.cpp
+++ b/inttest/codegeneration/ling.cpp
@@ -213,22 +213,22 @@ Type objective_function<Type>::operator() () {
     return (orig_vec * orig_amount + new_vec * new_amount) / avoid_zero_vec(orig_amount + new_amount);
 };
     int cur_time = -1;
+    int ling_imm__area = 1;
     int ling_imm__minage = 3;
     int ling_imm__maxage = 10;
-    int ling_imm__area = 1;
     DATA_VECTOR(ling_imm__midlen)
     vector<int> step_lengths(4); step_lengths.setConstant(3);
     auto cur_step_size = step_lengths ( 0 ) / (double)(12);
     DATA_VECTOR(ling_imm_stddev)
-    array<Type> ling_imm__num(35,1,8); ling_imm__num.setZero();
-    array<Type> ling_imm__wgt(35,1,8); ling_imm__wgt.setConstant((double)(1));
+    array<Type> ling_imm__num(35,8,1); ling_imm__num.setZero();
+    array<Type> ling_imm__wgt(35,8,1); ling_imm__wgt.setConstant((double)(1));
+    int ling_mat__area = 1;
     int ling_mat__minage = 5;
     int ling_mat__maxage = 15;
-    int ling_mat__area = 1;
     DATA_VECTOR(ling_mat__midlen)
     DATA_VECTOR(ling_mat_stddev)
-    array<Type> ling_mat__num(35,1,11); ling_mat__num.setZero();
-    array<Type> ling_mat__wgt(35,1,11); ling_mat__wgt.setConstant((double)(1));
+    array<Type> ling_mat__num(35,11,1); ling_mat__num.setZero();
+    array<Type> ling_mat__wgt(35,11,1); ling_mat__wgt.setConstant((double)(1));
     int end_year = 2018;
     int start_year = 1994;
     auto total_steps = (step_lengths).size()*(end_year - retro_years - start_year + 0) + (step_lengths).size() - 1;
@@ -240,22 +240,22 @@ Type objective_function<Type>::operator() () {
     int cur_step = 0;
     int cur_step_final = false;
     array<Type> igfs__catch(1);
-    array<Type> ling_imm__totalpredate(35,1,8);
-    array<Type> ling_mat__totalpredate(35,1,11);
-    array<Type> ling_imm__predby_igfs(35,1,8);
+    array<Type> ling_imm__totalpredate(35,8,1);
+    array<Type> ling_mat__totalpredate(35,11,1);
+    array<Type> ling_imm__predby_igfs(35,8,1);
     int igfs__area = 1;
-    array<Type> ling_imm__suit_igfs(35,1,8); ling_imm__suit_igfs.setZero();
-    array<Type> ling_mat__predby_igfs(35,1,11);
-    array<Type> ling_mat__suit_igfs(35,1,11); ling_mat__suit_igfs.setZero();
+    array<Type> ling_imm__suit_igfs(35,8,1); ling_imm__suit_igfs.setZero();
+    array<Type> ling_mat__predby_igfs(35,11,1);
+    array<Type> ling_mat__suit_igfs(35,11,1); ling_mat__suit_igfs.setZero();
     DATA_IVECTOR(igfs_totaldata__keys)
     DATA_IVECTOR(igfs_totaldata__values)
     auto igfs_totaldata__lookup = intlookup_zip(igfs_totaldata__keys, igfs_totaldata__values);
-    array<Type> ling_imm__consratio(35,1,8);
+    array<Type> ling_imm__consratio(35,8,1);
     Type ling_imm__overconsumption = (double)(0);
-    array<Type> ling_mat__consratio(35,1,11);
+    array<Type> ling_mat__consratio(35,11,1);
     Type ling_mat__overconsumption = (double)(0);
-    array<Type> ling_imm__transitioning_num(35,1,8); ling_imm__transitioning_num.setZero();
-    array<Type> ling_imm__transitioning_wgt(35,1,8);
+    array<Type> ling_imm__transitioning_num(35,8,1); ling_imm__transitioning_num.setZero();
+    array<Type> ling_imm__transitioning_wgt(35,8,1);
     int ling_imm__growth_lastcalc = -1;
     array<Type> ling_imm__growth_l(35,16);
     Type ling_imm__plusdl = (double)(4);
@@ -266,8 +266,8 @@ Type objective_function<Type>::operator() () {
     Type ling_mat__plusdl = (double)(4);
     array<Type> ling_mat__growth_w(35,16);
     Type ling_mat__prevtotal = (double)(0);
-    array<Type> ling_imm__renewalnum(35,1,8); ling_imm__renewalnum.setZero();
-    array<Type> ling_imm__renewalwgt(35,1,8); ling_imm__renewalwgt.setZero();
+    array<Type> ling_imm__renewalnum(35,8,1); ling_imm__renewalnum.setZero();
+    array<Type> ling_imm__renewalwgt(35,8,1); ling_imm__renewalwgt.setZero();
     int cdist_sumofsquares_ldist_lln_model__area = 1;
     array<Type> cdist_sumofsquares_ldist_lln_model__num(35,1); cdist_sumofsquares_ldist_lln_model__num.setZero();
     int cdist_sumofsquares_ldist_lln_obs__area = 1;
@@ -281,50 +281,50 @@ Type objective_function<Type>::operator() () {
     array<Type> nll_understocking__weight(as_integer(total_steps + 1)); nll_understocking__weight.setZero();
     array<Type> ling_imm_movement__transitioning_num(35,1,1);
     array<Type> ling_imm_movement__transitioning_wgt(35,1,1);
+    int ling_imm_movement__area = 1;
     int ling_imm_movement__minage = 11;
     int ling_imm_movement__maxage = 11;
-    int ling_imm_movement__area = 1;
 
     while (true) {
         cur_time += 1;
         {
             // g3a_initialconditions for ling_imm;
-            for (auto age = ling_imm__minage; age <= ling_imm__maxage; age++) if ( cur_time == 0 ) {
-                auto ling_imm__age_idx = age - ling_imm__minage + 1 - 1;
+            {
+                auto area = ling_imm__area;
 
-                {
-                    auto area = ling_imm__area;
+                auto ling_imm__area_idx = 0;
 
-                    auto ling_imm__area_idx = 0;
+                for (auto age = ling_imm__minage; age <= ling_imm__maxage; age++) if ( cur_time == 0 ) {
+                    auto ling_imm__age_idx = age - ling_imm__minage + 1 - 1;
 
                     auto factor = (lingimm__init__scalar*exp(-(double)(1)*(lingimm__M + ling__init__F)*age)*lingimm__init ( as_integer(age) - 3 + 1 - 1 ));
 
                     auto dnorm = ((ling_imm__midlen - (ling__Linf*((double)(1) - exp(-(double)(1)*ling__K*((age - cur_step_size) - (recage + log((double)(1) - ling__recl / ling__Linf) / ling__K)))))) / ling_imm_stddev ( as_integer((age - cur_step_size)) - 3 + 2 - 1 ));
 
                     {
-                        ling_imm__num.col(ling_imm__age_idx).col(ling_imm__area_idx) = normalize_vec(exp(-(pow(dnorm, (Type)(double)(2)))*(double)(0.5)))*(double)(10000)*factor;
-                        ling_imm__wgt.col(ling_imm__age_idx).col(ling_imm__area_idx) = lingimm__walpha*pow(ling_imm__midlen, (Type)lingimm__wbeta);
+                        ling_imm__num.col(ling_imm__area_idx).col(ling_imm__age_idx) = normalize_vec(exp(-(pow(dnorm, (Type)(double)(2)))*(double)(0.5)))*(double)(10000)*factor;
+                        ling_imm__wgt.col(ling_imm__area_idx).col(ling_imm__age_idx) = lingimm__walpha*pow(ling_imm__midlen, (Type)lingimm__wbeta);
                     }
                 }
             }
         }
         {
             // g3a_initialconditions for ling_mat;
-            for (auto age = ling_mat__minage; age <= ling_mat__maxage; age++) if ( cur_time == 0 ) {
-                auto ling_mat__age_idx = age - ling_mat__minage + 1 - 1;
+            {
+                auto area = ling_mat__area;
 
-                {
-                    auto area = ling_mat__area;
+                auto ling_mat__area_idx = 0;
 
-                    auto ling_mat__area_idx = 0;
+                for (auto age = ling_mat__minage; age <= ling_mat__maxage; age++) if ( cur_time == 0 ) {
+                    auto ling_mat__age_idx = age - ling_mat__minage + 1 - 1;
 
                     auto factor = (lingmat__init__scalar*exp(-(double)(1)*(lingmat__M + ling__init__F)*age)*lingmat__init ( as_integer(age) - 5 + 1 - 1 ));
 
                     auto dnorm = ((ling_mat__midlen - (ling__Linf*((double)(1) - exp(-(double)(1)*ling__K*((age - cur_step_size) - (recage + log((double)(1) - ling__recl / ling__Linf) / ling__K)))))) / ling_mat_stddev ( as_integer((age - cur_step_size)) - 5 + 2 - 1 ));
 
                     {
-                        ling_mat__num.col(ling_mat__age_idx).col(ling_mat__area_idx) = normalize_vec(exp(-(pow(dnorm, (Type)(double)(2)))*(double)(0.5)))*(double)(10000)*factor;
-                        ling_mat__wgt.col(ling_mat__age_idx).col(ling_mat__area_idx) = lingmat__walpha*pow(ling_mat__midlen, (Type)lingmat__wbeta);
+                        ling_mat__num.col(ling_mat__area_idx).col(ling_mat__age_idx) = normalize_vec(exp(-(pow(dnorm, (Type)(double)(2)))*(double)(0.5)))*(double)(10000)*factor;
+                        ling_mat__wgt.col(ling_mat__area_idx).col(ling_mat__age_idx) = lingmat__walpha*pow(ling_mat__midlen, (Type)lingmat__wbeta);
                     }
                 }
             }
@@ -361,23 +361,23 @@ Type objective_function<Type>::operator() () {
             // g3a_predate_fleet for ling_imm;
             // Zero igfs-ling_imm biomass-consuming counter;
             ling_imm__predby_igfs.setZero();
-            for (auto age = ling_imm__minage; age <= ling_imm__maxage; age++) {
-                auto ling_imm__age_idx = age - ling_imm__minage + 1 - 1;
-
+            {
                 auto area = ling_imm__area;
 
                 auto ling_imm__area_idx = 0;
 
-                if ( area == igfs__area ) {
+                for (auto age = ling_imm__minage; age <= ling_imm__maxage; age++) if ( area == igfs__area ) {
+                    auto ling_imm__age_idx = age - ling_imm__minage + 1 - 1;
+
                     auto igfs__area_idx = 0;
 
                     auto fleet_area = area;
 
                     {
                         // Collect all suitable ling_imm biomass for igfs;
-                        ling_imm__suit_igfs.col(ling_imm__age_idx).col(ling_imm__area_idx) = (double)(1) / ((double)(1) + exp(-ling__igfs__alpha*(ling_imm__midlen - ling__igfs__l50)));
-                        ling_imm__predby_igfs.col(ling_imm__age_idx).col(ling_imm__area_idx) = ling_imm__suit_igfs.col(ling_imm__age_idx).col(ling_imm__area_idx)*ling_imm__num.col(ling_imm__age_idx).col(ling_imm__area_idx)*ling_imm__wgt.col(ling_imm__age_idx).col(ling_imm__area_idx);
-                        igfs__catch(igfs__area_idx) += (ling_imm__predby_igfs.col(ling_imm__age_idx).col(ling_imm__area_idx)).sum();
+                        ling_imm__suit_igfs.col(ling_imm__area_idx).col(ling_imm__age_idx) = (double)(1) / ((double)(1) + exp(-ling__igfs__alpha*(ling_imm__midlen - ling__igfs__l50)));
+                        ling_imm__predby_igfs.col(ling_imm__area_idx).col(ling_imm__age_idx) = ling_imm__suit_igfs.col(ling_imm__area_idx).col(ling_imm__age_idx)*ling_imm__num.col(ling_imm__area_idx).col(ling_imm__age_idx)*ling_imm__wgt.col(ling_imm__area_idx).col(ling_imm__age_idx);
+                        igfs__catch(igfs__area_idx) += (ling_imm__predby_igfs.col(ling_imm__area_idx).col(ling_imm__age_idx)).sum();
                     }
                 }
             }
@@ -386,65 +386,65 @@ Type objective_function<Type>::operator() () {
             // g3a_predate_fleet for ling_mat;
             // Zero igfs-ling_mat biomass-consuming counter;
             ling_mat__predby_igfs.setZero();
-            for (auto age = ling_mat__minage; age <= ling_mat__maxage; age++) {
-                auto ling_mat__age_idx = age - ling_mat__minage + 1 - 1;
-
+            {
                 auto area = ling_mat__area;
 
                 auto ling_mat__area_idx = 0;
 
-                if ( area == igfs__area ) {
+                for (auto age = ling_mat__minage; age <= ling_mat__maxage; age++) if ( area == igfs__area ) {
+                    auto ling_mat__age_idx = age - ling_mat__minage + 1 - 1;
+
                     auto igfs__area_idx = 0;
 
                     auto fleet_area = area;
 
                     {
                         // Collect all suitable ling_mat biomass for igfs;
-                        ling_mat__suit_igfs.col(ling_mat__age_idx).col(ling_mat__area_idx) = (double)(1) / ((double)(1) + exp(-ling__igfs__alpha*(ling_mat__midlen - ling__igfs__l50)));
-                        ling_mat__predby_igfs.col(ling_mat__age_idx).col(ling_mat__area_idx) = ling_mat__suit_igfs.col(ling_mat__age_idx).col(ling_mat__area_idx)*ling_mat__num.col(ling_mat__age_idx).col(ling_mat__area_idx)*ling_mat__wgt.col(ling_mat__age_idx).col(ling_mat__area_idx);
-                        igfs__catch(igfs__area_idx) += (ling_mat__predby_igfs.col(ling_mat__age_idx).col(ling_mat__area_idx)).sum();
+                        ling_mat__suit_igfs.col(ling_mat__area_idx).col(ling_mat__age_idx) = (double)(1) / ((double)(1) + exp(-ling__igfs__alpha*(ling_mat__midlen - ling__igfs__l50)));
+                        ling_mat__predby_igfs.col(ling_mat__area_idx).col(ling_mat__age_idx) = ling_mat__suit_igfs.col(ling_mat__area_idx).col(ling_mat__age_idx)*ling_mat__num.col(ling_mat__area_idx).col(ling_mat__age_idx)*ling_mat__wgt.col(ling_mat__area_idx).col(ling_mat__age_idx);
+                        igfs__catch(igfs__area_idx) += (ling_mat__predby_igfs.col(ling_mat__area_idx).col(ling_mat__age_idx)).sum();
                     }
                 }
             }
         }
         {
             // Scale igfs catch of ling_imm by total expected catch;
-            for (auto age = ling_imm__minage; age <= ling_imm__maxage; age++) {
-                auto ling_imm__age_idx = age - ling_imm__minage + 1 - 1;
-
+            {
                 auto area = ling_imm__area;
 
                 auto ling_imm__area_idx = 0;
 
-                if ( area == igfs__area ) {
+                for (auto age = ling_imm__minage; age <= ling_imm__maxage; age++) if ( area == igfs__area ) {
+                    auto ling_imm__age_idx = age - ling_imm__minage + 1 - 1;
+
                     auto igfs__area_idx = 0;
 
                     auto fleet_area = area;
 
                     {
-                        ling_imm__predby_igfs.col(ling_imm__age_idx).col(ling_imm__area_idx) *= ((area != 1 ? (double)(0) : intlookup_getdefault(igfs_totaldata__lookup, (cur_year*100 + cur_step), (double)(0))) / igfs__catch(igfs__area_idx));
-                        ling_imm__totalpredate.col(ling_imm__age_idx).col(ling_imm__area_idx) += ling_imm__predby_igfs.col(ling_imm__age_idx).col(ling_imm__area_idx);
+                        ling_imm__predby_igfs.col(ling_imm__area_idx).col(ling_imm__age_idx) *= ((area != 1 ? (double)(0) : intlookup_getdefault(igfs_totaldata__lookup, (cur_year*100 + cur_step), (double)(0))) / igfs__catch(igfs__area_idx));
+                        ling_imm__totalpredate.col(ling_imm__area_idx).col(ling_imm__age_idx) += ling_imm__predby_igfs.col(ling_imm__area_idx).col(ling_imm__age_idx);
                     }
                 }
             }
         }
         {
             // Scale igfs catch of ling_mat by total expected catch;
-            for (auto age = ling_mat__minage; age <= ling_mat__maxage; age++) {
-                auto ling_mat__age_idx = age - ling_mat__minage + 1 - 1;
-
+            {
                 auto area = ling_mat__area;
 
                 auto ling_mat__area_idx = 0;
 
-                if ( area == igfs__area ) {
+                for (auto age = ling_mat__minage; age <= ling_mat__maxage; age++) if ( area == igfs__area ) {
+                    auto ling_mat__age_idx = age - ling_mat__minage + 1 - 1;
+
                     auto igfs__area_idx = 0;
 
                     auto fleet_area = area;
 
                     {
-                        ling_mat__predby_igfs.col(ling_mat__age_idx).col(ling_mat__area_idx) *= ((area != 1 ? (double)(0) : intlookup_getdefault(igfs_totaldata__lookup, (cur_year*100 + cur_step), (double)(0))) / igfs__catch(igfs__area_idx));
-                        ling_mat__totalpredate.col(ling_mat__age_idx).col(ling_mat__area_idx) += ling_mat__predby_igfs.col(ling_mat__age_idx).col(ling_mat__area_idx);
+                        ling_mat__predby_igfs.col(ling_mat__area_idx).col(ling_mat__age_idx) *= ((area != 1 ? (double)(0) : intlookup_getdefault(igfs_totaldata__lookup, (cur_year*100 + cur_step), (double)(0))) / igfs__catch(igfs__area_idx));
+                        ling_mat__totalpredate.col(ling_mat__area_idx).col(ling_mat__age_idx) += ling_mat__predby_igfs.col(ling_mat__area_idx).col(ling_mat__age_idx);
                     }
                 }
             }
@@ -491,19 +491,19 @@ Type objective_function<Type>::operator() () {
             // Revert to being total biomass (applying overconsumption in process);
             ling_imm__predby_igfs *= ling_imm__totalpredate;
             // Update total catch;
-            for (auto age = ling_imm__minage; age <= ling_imm__maxage; age++) {
-                auto ling_imm__age_idx = age - ling_imm__minage + 1 - 1;
-
+            {
                 auto area = ling_imm__area;
 
                 auto ling_imm__area_idx = 0;
 
-                if ( area == igfs__area ) {
+                for (auto age = ling_imm__minage; age <= ling_imm__maxage; age++) if ( area == igfs__area ) {
+                    auto ling_imm__age_idx = age - ling_imm__minage + 1 - 1;
+
                     auto igfs__area_idx = 0;
 
                     auto fleet_area = area;
 
-                    igfs__catch(igfs__area_idx) += (ling_imm__predby_igfs.col(ling_imm__age_idx).col(ling_imm__area_idx)).sum();
+                    igfs__catch(igfs__area_idx) += (ling_imm__predby_igfs.col(ling_imm__area_idx).col(ling_imm__age_idx)).sum();
                 }
             }
         }
@@ -511,44 +511,48 @@ Type objective_function<Type>::operator() () {
             // Revert to being total biomass (applying overconsumption in process);
             ling_mat__predby_igfs *= ling_mat__totalpredate;
             // Update total catch;
-            for (auto age = ling_mat__minage; age <= ling_mat__maxage; age++) {
-                auto ling_mat__age_idx = age - ling_mat__minage + 1 - 1;
-
+            {
                 auto area = ling_mat__area;
 
                 auto ling_mat__area_idx = 0;
 
-                if ( area == igfs__area ) {
+                for (auto age = ling_mat__minage; age <= ling_mat__maxage; age++) if ( area == igfs__area ) {
+                    auto ling_mat__age_idx = age - ling_mat__minage + 1 - 1;
+
                     auto igfs__area_idx = 0;
 
                     auto fleet_area = area;
 
-                    igfs__catch(igfs__area_idx) += (ling_mat__predby_igfs.col(ling_mat__age_idx).col(ling_mat__area_idx)).sum();
+                    igfs__catch(igfs__area_idx) += (ling_mat__predby_igfs.col(ling_mat__area_idx).col(ling_mat__age_idx)).sum();
                 }
             }
         }
         {
             // Natural mortality for ling_imm;
-            for (auto age = ling_imm__minage; age <= ling_imm__maxage; age++) {
-                auto ling_imm__age_idx = age - ling_imm__minage + 1 - 1;
-
+            {
                 auto area = ling_imm__area;
 
                 auto ling_imm__area_idx = 0;
 
-                ling_imm__num.col(ling_imm__age_idx).col(ling_imm__area_idx) *= exp(-(lingimm__M)*cur_step_size);
+                for (auto age = ling_imm__minage; age <= ling_imm__maxage; age++) {
+                    auto ling_imm__age_idx = age - ling_imm__minage + 1 - 1;
+
+                    ling_imm__num.col(ling_imm__area_idx).col(ling_imm__age_idx) *= exp(-(lingimm__M)*cur_step_size);
+                }
             }
         }
         {
             // Natural mortality for ling_mat;
-            for (auto age = ling_mat__minage; age <= ling_mat__maxage; age++) {
-                auto ling_mat__age_idx = age - ling_mat__minage + 1 - 1;
-
+            {
                 auto area = ling_mat__area;
 
                 auto ling_mat__area_idx = 0;
 
-                ling_mat__num.col(ling_mat__age_idx).col(ling_mat__area_idx) *= exp(-(lingmat__M)*cur_step_size);
+                for (auto age = ling_mat__minage; age <= ling_mat__maxage; age++) {
+                    auto ling_mat__age_idx = age - ling_mat__minage + 1 - 1;
+
+                    ling_mat__num.col(ling_mat__area_idx).col(ling_mat__age_idx) *= exp(-(lingmat__M)*cur_step_size);
+                }
             }
         }
         if ( cur_step_final ) {
@@ -558,63 +562,65 @@ Type objective_function<Type>::operator() () {
         }
         {
             // g3a_grow for ling_imm;
-            for (auto age = ling_imm__minage; age <= ling_imm__maxage; age++) {
-                auto ling_imm__age_idx = age - ling_imm__minage + 1 - 1;
-
+            {
                 auto area = ling_imm__area;
 
                 auto ling_imm__area_idx = 0;
 
-                {
-                    if ( ling_imm__growth_lastcalc != std::floor(cur_step_size*12) ) {
-                        // Calculate length/weight delta matrices for current lengthgroups;
-                        ling_imm__growth_l = growth_bbinom(avoid_zero_vec(avoid_zero_vec((ling__Linf - ling_imm__midlen)*((double)(1) - exp(-((ling__K*(double)(0.001)))*cur_step_size))) / ling_imm__plusdl), 15, avoid_zero((ling__bbin*(double)(10))));
-                        ling_imm__growth_w = (g3a_grow_weightsimple_vec_rotate(pow((vector<Type>)(ling_imm__midlen), lingimm__wbeta), 15 + (double)(1)) - g3a_grow_weightsimple_vec_extrude(pow((vector<Type>)(ling_imm__midlen), lingimm__wbeta), 15 + (double)(1)))*lingimm__walpha;
-                        // Don't recalculate until cur_step_size changes;
-                        ling_imm__growth_lastcalc = std::floor(cur_step_size*12);
-                    }
-                    if ( true ) {
-                        ling_imm__prevtotal = (ling_imm__num.col(ling_imm__age_idx).col(ling_imm__area_idx)).sum();
-                    }
-                    if (cur_step_final) {
-                        auto maturity_ratio = ((double)(1) / ((double)(1) + exp(((double)(0) - ((double)(0.001)*ling__mat1)*(ling_imm__midlen - ling__mat2)))));
+                for (auto age = ling_imm__minage; age <= ling_imm__maxage; age++) {
+                    auto ling_imm__age_idx = age - ling_imm__minage + 1 - 1;
 
-                        {
-                            // Grow and separate maturing ling_imm;
-                            {
-                                auto growthresult = g3a_grow_apply(ling_imm__growth_l, ling_imm__growth_w, ling_imm__num.col(ling_imm__age_idx).col(ling_imm__area_idx)*maturity_ratio, ling_imm__wgt.col(ling_imm__age_idx).col(ling_imm__area_idx));
-
-                                {
-                                    ling_imm__transitioning_num.col(ling_imm__age_idx).col(ling_imm__area_idx) = growthresult.col(0);
-                                    ling_imm__transitioning_wgt.col(ling_imm__age_idx).col(ling_imm__area_idx) = growthresult.col(1);
-                                }
-                            }
-                            // Grow non-maturing ling_imm;
-                            {
-                                auto growthresult = g3a_grow_apply(ling_imm__growth_l, ling_imm__growth_w, ling_imm__num.col(ling_imm__age_idx).col(ling_imm__area_idx)*((double)(1) - maturity_ratio), ling_imm__wgt.col(ling_imm__age_idx).col(ling_imm__area_idx));
-
-                                {
-                                    ling_imm__num.col(ling_imm__age_idx).col(ling_imm__area_idx) = growthresult.col(0);
-                                    ling_imm__wgt.col(ling_imm__age_idx).col(ling_imm__area_idx) = growthresult.col(1);
-                                }
-                            }
+                    {
+                        if ( ling_imm__growth_lastcalc != std::floor(cur_step_size*12) ) {
+                            // Calculate length/weight delta matrices for current lengthgroups;
+                            ling_imm__growth_l = growth_bbinom(avoid_zero_vec(avoid_zero_vec((ling__Linf - ling_imm__midlen)*((double)(1) - exp(-((ling__K*(double)(0.001)))*cur_step_size))) / ling_imm__plusdl), 15, avoid_zero((ling__bbin*(double)(10))));
+                            ling_imm__growth_w = (g3a_grow_weightsimple_vec_rotate(pow((vector<Type>)(ling_imm__midlen), lingimm__wbeta), 15 + (double)(1)) - g3a_grow_weightsimple_vec_extrude(pow((vector<Type>)(ling_imm__midlen), lingimm__wbeta), 15 + (double)(1)))*lingimm__walpha;
+                            // Don't recalculate until cur_step_size changes;
+                            ling_imm__growth_lastcalc = std::floor(cur_step_size*12);
                         }
-                    } else {
-                        // Update ling_imm using delta matrices;
-                        {
-                            auto growthresult = g3a_grow_apply(ling_imm__growth_l, ling_imm__growth_w, ling_imm__num.col(ling_imm__age_idx).col(ling_imm__area_idx), ling_imm__wgt.col(ling_imm__age_idx).col(ling_imm__area_idx));
-
-                            {
-                                ling_imm__num.col(ling_imm__age_idx).col(ling_imm__area_idx) = growthresult.col(0);
-                                ling_imm__wgt.col(ling_imm__age_idx).col(ling_imm__area_idx) = growthresult.col(1);
-                            }
+                        if ( true ) {
+                            ling_imm__prevtotal = (ling_imm__num.col(ling_imm__area_idx).col(ling_imm__age_idx)).sum();
                         }
-                    }
-                    if ( true ) {
                         if (cur_step_final) {
-                            assert_msg(CppAD::abs(ling_imm__prevtotal - (ling_imm__num.col(ling_imm__age_idx).col(ling_imm__area_idx)).sum() - (ling_imm__transitioning_num.col(ling_imm__age_idx).col(ling_imm__area_idx)).sum()) < (double)(1e-04), "g3a_growmature: ling_imm__num totals are not the same before and after growth (excluding maturation)");
+                            auto maturity_ratio = ((double)(1) / ((double)(1) + exp(((double)(0) - ((double)(0.001)*ling__mat1)*(ling_imm__midlen - ling__mat2)))));
+
+                            {
+                                // Grow and separate maturing ling_imm;
+                                {
+                                    auto growthresult = g3a_grow_apply(ling_imm__growth_l, ling_imm__growth_w, ling_imm__num.col(ling_imm__area_idx).col(ling_imm__age_idx)*maturity_ratio, ling_imm__wgt.col(ling_imm__area_idx).col(ling_imm__age_idx));
+
+                                    {
+                                        ling_imm__transitioning_num.col(ling_imm__area_idx).col(ling_imm__age_idx) = growthresult.col(0);
+                                        ling_imm__transitioning_wgt.col(ling_imm__area_idx).col(ling_imm__age_idx) = growthresult.col(1);
+                                    }
+                                }
+                                // Grow non-maturing ling_imm;
+                                {
+                                    auto growthresult = g3a_grow_apply(ling_imm__growth_l, ling_imm__growth_w, ling_imm__num.col(ling_imm__area_idx).col(ling_imm__age_idx)*((double)(1) - maturity_ratio), ling_imm__wgt.col(ling_imm__area_idx).col(ling_imm__age_idx));
+
+                                    {
+                                        ling_imm__num.col(ling_imm__area_idx).col(ling_imm__age_idx) = growthresult.col(0);
+                                        ling_imm__wgt.col(ling_imm__area_idx).col(ling_imm__age_idx) = growthresult.col(1);
+                                    }
+                                }
+                            }
                         } else {
-                            assert_msg(CppAD::abs(ling_imm__prevtotal - (ling_imm__num.col(ling_imm__age_idx).col(ling_imm__area_idx)).sum()) < (double)(1e-04), "g3a_growmature: ling_imm__num totals are not the same before and after growth");
+                            // Update ling_imm using delta matrices;
+                            {
+                                auto growthresult = g3a_grow_apply(ling_imm__growth_l, ling_imm__growth_w, ling_imm__num.col(ling_imm__area_idx).col(ling_imm__age_idx), ling_imm__wgt.col(ling_imm__area_idx).col(ling_imm__age_idx));
+
+                                {
+                                    ling_imm__num.col(ling_imm__area_idx).col(ling_imm__age_idx) = growthresult.col(0);
+                                    ling_imm__wgt.col(ling_imm__area_idx).col(ling_imm__age_idx) = growthresult.col(1);
+                                }
+                            }
+                        }
+                        if ( true ) {
+                            if (cur_step_final) {
+                                assert_msg(CppAD::abs(ling_imm__prevtotal - (ling_imm__num.col(ling_imm__area_idx).col(ling_imm__age_idx)).sum() - (ling_imm__transitioning_num.col(ling_imm__area_idx).col(ling_imm__age_idx)).sum()) < (double)(1e-04), "g3a_growmature: ling_imm__num totals are not the same before and after growth (excluding maturation)");
+                            } else {
+                                assert_msg(CppAD::abs(ling_imm__prevtotal - (ling_imm__num.col(ling_imm__area_idx).col(ling_imm__age_idx)).sum()) < (double)(1e-04), "g3a_growmature: ling_imm__num totals are not the same before and after growth");
+                            }
                         }
                     }
                 }
@@ -622,60 +628,64 @@ Type objective_function<Type>::operator() () {
         }
         {
             // g3a_grow for ling_mat;
-            for (auto age = ling_mat__minage; age <= ling_mat__maxage; age++) {
-                auto ling_mat__age_idx = age - ling_mat__minage + 1 - 1;
-
+            {
                 auto area = ling_mat__area;
 
                 auto ling_mat__area_idx = 0;
 
-                {
-                    if ( ling_mat__growth_lastcalc != std::floor(cur_step_size*12) ) {
-                        // Calculate length/weight delta matrices for current lengthgroups;
-                        ling_mat__growth_l = growth_bbinom(avoid_zero_vec(avoid_zero_vec((ling__Linf - ling_mat__midlen)*((double)(1) - exp(-((ling__K*(double)(0.001)))*cur_step_size))) / ling_mat__plusdl), 15, avoid_zero((ling__bbin*(double)(10))));
-                        ling_mat__growth_w = (g3a_grow_weightsimple_vec_rotate(pow((vector<Type>)(ling_mat__midlen), lingmat__wbeta), 15 + (double)(1)) - g3a_grow_weightsimple_vec_extrude(pow((vector<Type>)(ling_mat__midlen), lingmat__wbeta), 15 + (double)(1)))*lingmat__walpha;
-                        // Don't recalculate until cur_step_size changes;
-                        ling_mat__growth_lastcalc = std::floor(cur_step_size*12);
-                    }
-                    if ( true ) {
-                        ling_mat__prevtotal = (ling_mat__num.col(ling_mat__age_idx).col(ling_mat__area_idx)).sum();
-                    }
-                    // Update ling_mat using delta matrices;
-                    {
-                        auto growthresult = g3a_grow_apply(ling_mat__growth_l, ling_mat__growth_w, ling_mat__num.col(ling_mat__age_idx).col(ling_mat__area_idx), ling_mat__wgt.col(ling_mat__age_idx).col(ling_mat__area_idx));
+                for (auto age = ling_mat__minage; age <= ling_mat__maxage; age++) {
+                    auto ling_mat__age_idx = age - ling_mat__minage + 1 - 1;
 
-                        {
-                            ling_mat__num.col(ling_mat__age_idx).col(ling_mat__area_idx) = growthresult.col(0);
-                            ling_mat__wgt.col(ling_mat__age_idx).col(ling_mat__area_idx) = growthresult.col(1);
+                    {
+                        if ( ling_mat__growth_lastcalc != std::floor(cur_step_size*12) ) {
+                            // Calculate length/weight delta matrices for current lengthgroups;
+                            ling_mat__growth_l = growth_bbinom(avoid_zero_vec(avoid_zero_vec((ling__Linf - ling_mat__midlen)*((double)(1) - exp(-((ling__K*(double)(0.001)))*cur_step_size))) / ling_mat__plusdl), 15, avoid_zero((ling__bbin*(double)(10))));
+                            ling_mat__growth_w = (g3a_grow_weightsimple_vec_rotate(pow((vector<Type>)(ling_mat__midlen), lingmat__wbeta), 15 + (double)(1)) - g3a_grow_weightsimple_vec_extrude(pow((vector<Type>)(ling_mat__midlen), lingmat__wbeta), 15 + (double)(1)))*lingmat__walpha;
+                            // Don't recalculate until cur_step_size changes;
+                            ling_mat__growth_lastcalc = std::floor(cur_step_size*12);
                         }
-                    }
-                    if ( true ) {
-                        assert_msg(CppAD::abs(ling_mat__prevtotal - (ling_mat__num.col(ling_mat__age_idx).col(ling_mat__area_idx)).sum()) < (double)(1e-04), "g3a_growmature: ling_mat__num totals are not the same before and after growth");
+                        if ( true ) {
+                            ling_mat__prevtotal = (ling_mat__num.col(ling_mat__area_idx).col(ling_mat__age_idx)).sum();
+                        }
+                        // Update ling_mat using delta matrices;
+                        {
+                            auto growthresult = g3a_grow_apply(ling_mat__growth_l, ling_mat__growth_w, ling_mat__num.col(ling_mat__area_idx).col(ling_mat__age_idx), ling_mat__wgt.col(ling_mat__area_idx).col(ling_mat__age_idx));
+
+                            {
+                                ling_mat__num.col(ling_mat__area_idx).col(ling_mat__age_idx) = growthresult.col(0);
+                                ling_mat__wgt.col(ling_mat__area_idx).col(ling_mat__age_idx) = growthresult.col(1);
+                            }
+                        }
+                        if ( true ) {
+                            assert_msg(CppAD::abs(ling_mat__prevtotal - (ling_mat__num.col(ling_mat__area_idx).col(ling_mat__age_idx)).sum()) < (double)(1e-04), "g3a_growmature: ling_mat__num totals are not the same before and after growth");
+                        }
                     }
                 }
             }
         }
         {
             // Move ling_imm to ling_mat;
-            for (auto age = ling_mat__minage; age <= ling_mat__maxage; age++) if ( age >= ling_imm__minage && age <= ling_imm__maxage ) {
-                auto ling_mat__age_idx = age - ling_mat__minage + 1 - 1;
-
+            {
                 auto area = ling_mat__area;
 
                 auto ling_mat__area_idx = 0;
 
-                if ( area == ling_imm__area ) {
-                    if ( cur_step_final ) {
-                        auto ling_imm__age_idx = age - ling_imm__minage + 1 - 1;
+                for (auto age = ling_mat__minage; age <= ling_mat__maxage; age++) if ( area == ling_imm__area ) {
+                    if ( age >= ling_imm__minage && age <= ling_imm__maxage ) {
+                        if ( cur_step_final ) {
+                            auto ling_mat__age_idx = age - ling_mat__minage + 1 - 1;
 
-                        {
                             auto ling_imm__area_idx = 0;
 
                             {
-                                ling_mat__wgt.col(ling_mat__age_idx).col(ling_mat__area_idx) = (ling_mat__wgt.col(ling_mat__age_idx).col(ling_mat__area_idx)*ling_mat__num.col(ling_mat__age_idx).col(ling_mat__area_idx)) + ling_imm__transitioning_wgt.col(ling_imm__age_idx).col(ling_imm__area_idx)*ling_imm__transitioning_num.col(ling_imm__age_idx).col(ling_imm__area_idx);
-                                ling_mat__num.col(ling_mat__age_idx).col(ling_mat__area_idx) += ling_imm__transitioning_num.col(ling_imm__age_idx).col(ling_imm__area_idx);
-                                ling_imm__transitioning_num.col(ling_imm__age_idx).col(ling_imm__area_idx) -= ling_imm__transitioning_num.col(ling_imm__age_idx).col(ling_imm__area_idx);
-                                ling_mat__wgt.col(ling_mat__age_idx).col(ling_mat__area_idx) /= avoid_zero_vec(ling_mat__num.col(ling_mat__age_idx).col(ling_mat__area_idx));
+                                auto ling_imm__age_idx = age - ling_imm__minage + 1 - 1;
+
+                                {
+                                    ling_mat__wgt.col(ling_mat__area_idx).col(ling_mat__age_idx) = (ling_mat__wgt.col(ling_mat__area_idx).col(ling_mat__age_idx)*ling_mat__num.col(ling_mat__area_idx).col(ling_mat__age_idx)) + ling_imm__transitioning_wgt.col(ling_imm__area_idx).col(ling_imm__age_idx)*ling_imm__transitioning_num.col(ling_imm__area_idx).col(ling_imm__age_idx);
+                                    ling_mat__num.col(ling_mat__area_idx).col(ling_mat__age_idx) += ling_imm__transitioning_num.col(ling_imm__area_idx).col(ling_imm__age_idx);
+                                    ling_imm__transitioning_num.col(ling_imm__area_idx).col(ling_imm__age_idx) -= ling_imm__transitioning_num.col(ling_imm__area_idx).col(ling_imm__age_idx);
+                                    ling_mat__wgt.col(ling_mat__area_idx).col(ling_mat__age_idx) /= avoid_zero_vec(ling_mat__num.col(ling_mat__area_idx).col(ling_mat__age_idx));
+                                }
                             }
                         }
                     }
@@ -691,21 +701,23 @@ Type objective_function<Type>::operator() () {
 
             {
                 // g3a_renewal for ling_imm;
-                for (auto age = ling_imm__minage; age <= ling_imm__maxage; age++) if ( cur_step == 1 && age == 3 ) {
-                    auto ling_imm__age_idx = age - ling_imm__minage + 1 - 1;
-
+                {
                     auto area = ling_imm__area;
 
                     auto ling_imm__area_idx = 0;
 
-                    auto dnorm = ((ling_imm__midlen - (ling__Linf*((double)(1) - exp(-(double)(1)*ling__K*(age - (recage + log((double)(1) - ling__recl / ling__Linf) / ling__K)))))) / ling_imm_stddev ( as_integer(age) - 3 + 1 - 1 ));
+                    for (auto age = ling_imm__minage; age <= ling_imm__maxage; age++) if ( cur_step == 1 && age == 3 ) {
+                        auto ling_imm__age_idx = age - ling_imm__minage + 1 - 1;
 
-                    {
-                        ling_imm__renewalnum.col(ling_imm__age_idx).col(ling_imm__area_idx) = normalize_vec(exp(-(pow(dnorm, (Type)(double)(2)))*(double)(0.5)))*(double)(10000)*factor;
-                        ling_imm__renewalwgt.col(ling_imm__age_idx).col(ling_imm__area_idx) = lingimm__walpha*pow(ling_imm__midlen, (Type)lingimm__wbeta);
-                        // Add result to ling_imm;
-                        ling_imm__wgt.col(ling_imm__age_idx).col(ling_imm__area_idx) = ratio_add_vec(ling_imm__wgt.col(ling_imm__age_idx).col(ling_imm__area_idx), ling_imm__num.col(ling_imm__age_idx).col(ling_imm__area_idx), ling_imm__renewalwgt.col(ling_imm__age_idx).col(ling_imm__area_idx), ling_imm__renewalnum.col(ling_imm__age_idx).col(ling_imm__area_idx));
-                        ling_imm__num.col(ling_imm__age_idx).col(ling_imm__area_idx) += ling_imm__renewalnum.col(ling_imm__age_idx).col(ling_imm__area_idx);
+                        auto dnorm = ((ling_imm__midlen - (ling__Linf*((double)(1) - exp(-(double)(1)*ling__K*(age - (recage + log((double)(1) - ling__recl / ling__Linf) / ling__K)))))) / ling_imm_stddev ( as_integer(age) - 3 + 1 - 1 ));
+
+                        {
+                            ling_imm__renewalnum.col(ling_imm__area_idx).col(ling_imm__age_idx) = normalize_vec(exp(-(pow(dnorm, (Type)(double)(2)))*(double)(0.5)))*(double)(10000)*factor;
+                            ling_imm__renewalwgt.col(ling_imm__area_idx).col(ling_imm__age_idx) = lingimm__walpha*pow(ling_imm__midlen, (Type)lingimm__wbeta);
+                            // Add result to ling_imm;
+                            ling_imm__wgt.col(ling_imm__area_idx).col(ling_imm__age_idx) = ratio_add_vec(ling_imm__wgt.col(ling_imm__area_idx).col(ling_imm__age_idx), ling_imm__num.col(ling_imm__area_idx).col(ling_imm__age_idx), ling_imm__renewalwgt.col(ling_imm__area_idx).col(ling_imm__age_idx), ling_imm__renewalnum.col(ling_imm__area_idx).col(ling_imm__age_idx));
+                            ling_imm__num.col(ling_imm__area_idx).col(ling_imm__age_idx) += ling_imm__renewalnum.col(ling_imm__area_idx).col(ling_imm__age_idx);
+                        }
                     }
                 }
             }
@@ -715,59 +727,61 @@ Type objective_function<Type>::operator() () {
 
             {
                 // g3a_renewal for ling_imm;
-                for (auto age = ling_imm__minage; age <= ling_imm__maxage; age++) if ( cur_step == 1 && age == 5 ) {
-                    auto ling_imm__age_idx = age - ling_imm__minage + 1 - 1;
-
+                {
                     auto area = ling_imm__area;
 
                     auto ling_imm__area_idx = 0;
 
-                    auto dnorm = ((ling_imm__midlen - (ling__Linf*((double)(1) - exp(-(double)(1)*ling__K*(age - (recage + log((double)(1) - ling__recl / ling__Linf) / ling__K)))))) / ling_imm_stddev ( as_integer(age) - 3 + 1 - 1 ));
+                    for (auto age = ling_imm__minage; age <= ling_imm__maxage; age++) if ( cur_step == 1 && age == 5 ) {
+                        auto ling_imm__age_idx = age - ling_imm__minage + 1 - 1;
 
-                    {
-                        ling_imm__renewalnum.col(ling_imm__age_idx).col(ling_imm__area_idx) = normalize_vec(exp(-(pow(dnorm, (Type)(double)(2)))*(double)(0.5)))*(double)(10000)*factor;
-                        ling_imm__renewalwgt.col(ling_imm__age_idx).col(ling_imm__area_idx) = lingimm__walpha*pow(ling_imm__midlen, (Type)lingimm__wbeta);
-                        // Add result to ling_imm;
-                        ling_imm__wgt.col(ling_imm__age_idx).col(ling_imm__area_idx) = ratio_add_vec(ling_imm__wgt.col(ling_imm__age_idx).col(ling_imm__area_idx), ling_imm__num.col(ling_imm__age_idx).col(ling_imm__area_idx), ling_imm__renewalwgt.col(ling_imm__age_idx).col(ling_imm__area_idx), ling_imm__renewalnum.col(ling_imm__age_idx).col(ling_imm__area_idx));
-                        ling_imm__num.col(ling_imm__age_idx).col(ling_imm__area_idx) += ling_imm__renewalnum.col(ling_imm__age_idx).col(ling_imm__area_idx);
+                        auto dnorm = ((ling_imm__midlen - (ling__Linf*((double)(1) - exp(-(double)(1)*ling__K*(age - (recage + log((double)(1) - ling__recl / ling__Linf) / ling__K)))))) / ling_imm_stddev ( as_integer(age) - 3 + 1 - 1 ));
+
+                        {
+                            ling_imm__renewalnum.col(ling_imm__area_idx).col(ling_imm__age_idx) = normalize_vec(exp(-(pow(dnorm, (Type)(double)(2)))*(double)(0.5)))*(double)(10000)*factor;
+                            ling_imm__renewalwgt.col(ling_imm__area_idx).col(ling_imm__age_idx) = lingimm__walpha*pow(ling_imm__midlen, (Type)lingimm__wbeta);
+                            // Add result to ling_imm;
+                            ling_imm__wgt.col(ling_imm__area_idx).col(ling_imm__age_idx) = ratio_add_vec(ling_imm__wgt.col(ling_imm__area_idx).col(ling_imm__age_idx), ling_imm__num.col(ling_imm__area_idx).col(ling_imm__age_idx), ling_imm__renewalwgt.col(ling_imm__area_idx).col(ling_imm__age_idx), ling_imm__renewalnum.col(ling_imm__area_idx).col(ling_imm__age_idx));
+                            ling_imm__num.col(ling_imm__area_idx).col(ling_imm__age_idx) += ling_imm__renewalnum.col(ling_imm__area_idx).col(ling_imm__age_idx);
+                        }
                     }
                 }
             }
         }
         {
             // g3l_catchdistribution_sumofsquares: Collect catch from igfs/ling_imm for cdist_sumofsquares_ldist_lln;
-            for (auto age = ling_imm__minage; age <= ling_imm__maxage; age++) {
-                auto ling_imm__age_idx = age - ling_imm__minage + 1 - 1;
-
+            {
                 auto area = ling_imm__area;
 
                 auto ling_imm__area_idx = 0;
 
-                if ( area == cdist_sumofsquares_ldist_lln_model__area ) {
+                for (auto age = ling_imm__minage; age <= ling_imm__maxage; age++) if ( area == cdist_sumofsquares_ldist_lln_model__area ) {
+                    auto ling_imm__age_idx = age - ling_imm__minage + 1 - 1;
+
                     auto cdist_sumofsquares_ldist_lln_model__area_idx = 0;
 
                     {
                         // Take prey_stock__predby_predstock weight, convert to individuals, add to our count;
-                        cdist_sumofsquares_ldist_lln_model__num.col(cdist_sumofsquares_ldist_lln_model__area_idx) += ling_imm__predby_igfs.col(ling_imm__age_idx).col(ling_imm__area_idx) / avoid_zero_vec(ling_imm__wgt.col(ling_imm__age_idx).col(ling_imm__area_idx));
+                        cdist_sumofsquares_ldist_lln_model__num.col(cdist_sumofsquares_ldist_lln_model__area_idx) += ling_imm__predby_igfs.col(ling_imm__area_idx).col(ling_imm__age_idx) / avoid_zero_vec(ling_imm__wgt.col(ling_imm__area_idx).col(ling_imm__age_idx));
                     }
                 }
             }
         }
         {
             // g3l_catchdistribution_sumofsquares: Collect catch from igfs/ling_mat for cdist_sumofsquares_ldist_lln;
-            for (auto age = ling_mat__minage; age <= ling_mat__maxage; age++) {
-                auto ling_mat__age_idx = age - ling_mat__minage + 1 - 1;
-
+            {
                 auto area = ling_mat__area;
 
                 auto ling_mat__area_idx = 0;
 
-                if ( area == cdist_sumofsquares_ldist_lln_model__area ) {
+                for (auto age = ling_mat__minage; age <= ling_mat__maxage; age++) if ( area == cdist_sumofsquares_ldist_lln_model__area ) {
+                    auto ling_mat__age_idx = age - ling_mat__minage + 1 - 1;
+
                     auto cdist_sumofsquares_ldist_lln_model__area_idx = 0;
 
                     {
                         // Take prey_stock__predby_predstock weight, convert to individuals, add to our count;
-                        cdist_sumofsquares_ldist_lln_model__num.col(cdist_sumofsquares_ldist_lln_model__area_idx) += ling_mat__predby_igfs.col(ling_mat__age_idx).col(ling_mat__area_idx) / avoid_zero_vec(ling_mat__wgt.col(ling_mat__age_idx).col(ling_mat__area_idx));
+                        cdist_sumofsquares_ldist_lln_model__num.col(cdist_sumofsquares_ldist_lln_model__area_idx) += ling_mat__predby_igfs.col(ling_mat__area_idx).col(ling_mat__age_idx) / avoid_zero_vec(ling_mat__wgt.col(ling_mat__area_idx).col(ling_mat__age_idx));
                     }
                 }
             }
@@ -824,50 +838,62 @@ Type objective_function<Type>::operator() () {
             nll_understocking__weight(cur_time + 1 - 1) = (double)(1e+08);
         }
         if ( cur_step_final ) {
-            // g3a_age for ling_imm;
-            for (auto age = ling_imm__maxage; age >= ling_imm__minage; age--) {
-                auto ling_imm__age_idx = age - ling_imm__minage + 1 - 1;
+            auto ling_imm__area_idx = 0;
+
+            {
+                auto ling_imm_movement__area_idx = 0;
 
                 {
-                    // Check stock has remained finite for this step;
-                    if (age == ling_imm__maxage) {
-                        // Move oldest ling_imm into ling_imm_movement;
-                        ling_imm_movement__transitioning_num.col(0) = ling_imm__num.col(ling_imm__age_idx);
-                        ling_imm_movement__transitioning_wgt.col(0) = ling_imm__wgt.col(ling_imm__age_idx);
-                        ling_imm__num.col(ling_imm__age_idx) = ling_imm__num.col(ling_imm__age_idx - 1);
-                        ling_imm__wgt.col(ling_imm__age_idx) = ling_imm__wgt.col(ling_imm__age_idx - 1);
-                    } else {
-                        if (age == ling_imm__minage) {
-                            // Empty youngest ling_imm age-group;
-                            ling_imm__num.col(ling_imm__age_idx).setZero();
-                        } else {
-                            // Move ling_imm age-group to next one up;
-                            ling_imm__num.col(ling_imm__age_idx) = ling_imm__num.col(ling_imm__age_idx - 1);
-                            ling_imm__wgt.col(ling_imm__age_idx) = ling_imm__wgt.col(ling_imm__age_idx - 1);
+                    // g3a_age for ling_imm;
+                    for (auto age = ling_imm__maxage; age >= ling_imm__minage; age--) {
+                        auto ling_imm__age_idx = age - ling_imm__minage + 1 - 1;
+
+                        {
+                            // Check stock has remained finite for this step;
+                            if (age == ling_imm__maxage) {
+                                // Move oldest ling_imm into ling_imm_movement;
+                                ling_imm_movement__transitioning_num.col(ling_imm_movement__area_idx).col(0) = ling_imm__num.col(ling_imm__area_idx).col(ling_imm__age_idx);
+                                ling_imm_movement__transitioning_wgt.col(ling_imm_movement__area_idx).col(0) = ling_imm__wgt.col(ling_imm__area_idx).col(ling_imm__age_idx);
+                                ling_imm__num.col(ling_imm__area_idx).col(ling_imm__age_idx) = ling_imm__num.col(ling_imm__area_idx).col(ling_imm__age_idx - 1);
+                                ling_imm__wgt.col(ling_imm__area_idx).col(ling_imm__age_idx) = ling_imm__wgt.col(ling_imm__area_idx).col(ling_imm__age_idx - 1);
+                            } else {
+                                if (age == ling_imm__minage) {
+                                    // Empty youngest ling_imm age-group;
+                                    ling_imm__num.col(ling_imm__area_idx).col(ling_imm__age_idx).setZero();
+                                } else {
+                                    // Move ling_imm age-group to next one up;
+                                    ling_imm__num.col(ling_imm__area_idx).col(ling_imm__age_idx) = ling_imm__num.col(ling_imm__area_idx).col(ling_imm__age_idx - 1);
+                                    ling_imm__wgt.col(ling_imm__area_idx).col(ling_imm__age_idx) = ling_imm__wgt.col(ling_imm__area_idx).col(ling_imm__age_idx - 1);
+                                }
+                            }
                         }
                     }
                 }
             }
         }
         if ( cur_step_final ) {
-            // g3a_age for ling_mat;
-            for (auto age = ling_mat__maxage; age >= ling_mat__minage; age--) {
-                auto ling_mat__age_idx = age - ling_mat__minage + 1 - 1;
+            auto ling_mat__area_idx = 0;
 
-                {
-                    // Check stock has remained finite for this step;
-                    if (age == ling_mat__maxage) {
-                        // Oldest ling_mat is a plus-group, combine with younger individuals;
-                        ling_mat__wgt.col(ling_mat__age_idx) = ratio_add_vec(ling_mat__wgt.col(ling_mat__age_idx), ling_mat__num.col(ling_mat__age_idx), ling_mat__wgt.col(ling_mat__age_idx - 1), ling_mat__num.col(ling_mat__age_idx - 1));
-                        ling_mat__num.col(ling_mat__age_idx) += ling_mat__num.col(ling_mat__age_idx - 1);
-                    } else {
-                        if (age == ling_mat__minage) {
-                            // Empty youngest ling_mat age-group;
-                            ling_mat__num.col(ling_mat__age_idx).setZero();
+            {
+                // g3a_age for ling_mat;
+                for (auto age = ling_mat__maxage; age >= ling_mat__minage; age--) {
+                    auto ling_mat__age_idx = age - ling_mat__minage + 1 - 1;
+
+                    {
+                        // Check stock has remained finite for this step;
+                        if (age == ling_mat__maxage) {
+                            // Oldest ling_mat is a plus-group, combine with younger individuals;
+                            ling_mat__wgt.col(ling_mat__area_idx).col(ling_mat__age_idx) = ratio_add_vec(ling_mat__wgt.col(ling_mat__area_idx).col(ling_mat__age_idx), ling_mat__num.col(ling_mat__area_idx).col(ling_mat__age_idx), ling_mat__wgt.col(ling_mat__area_idx).col(ling_mat__age_idx - 1), ling_mat__num.col(ling_mat__area_idx).col(ling_mat__age_idx - 1));
+                            ling_mat__num.col(ling_mat__area_idx).col(ling_mat__age_idx) += ling_mat__num.col(ling_mat__area_idx).col(ling_mat__age_idx - 1);
                         } else {
-                            // Move ling_mat age-group to next one up;
-                            ling_mat__num.col(ling_mat__age_idx) = ling_mat__num.col(ling_mat__age_idx - 1);
-                            ling_mat__wgt.col(ling_mat__age_idx) = ling_mat__wgt.col(ling_mat__age_idx - 1);
+                            if (age == ling_mat__minage) {
+                                // Empty youngest ling_mat age-group;
+                                ling_mat__num.col(ling_mat__area_idx).col(ling_mat__age_idx).setZero();
+                            } else {
+                                // Move ling_mat age-group to next one up;
+                                ling_mat__num.col(ling_mat__area_idx).col(ling_mat__age_idx) = ling_mat__num.col(ling_mat__area_idx).col(ling_mat__age_idx - 1);
+                                ling_mat__wgt.col(ling_mat__area_idx).col(ling_mat__age_idx) = ling_mat__wgt.col(ling_mat__area_idx).col(ling_mat__age_idx - 1);
+                            }
                         }
                     }
                 }
@@ -875,24 +901,26 @@ Type objective_function<Type>::operator() () {
         }
         {
             // Move ling_imm_movement to ling_mat;
-            for (auto age = ling_mat__minage; age <= ling_mat__maxage; age++) if ( age >= ling_imm_movement__minage && age <= ling_imm_movement__maxage ) {
-                auto ling_mat__age_idx = age - ling_mat__minage + 1 - 1;
-
+            {
                 auto area = ling_mat__area;
 
                 auto ling_mat__area_idx = 0;
 
-                if ( area == ling_imm_movement__area ) {
-                    if ( cur_step_final ) {
-                        auto ling_imm_movement__age_idx = age - ling_imm_movement__minage + 1 - 1;
+                for (auto age = ling_mat__minage; age <= ling_mat__maxage; age++) if ( area == ling_imm_movement__area ) {
+                    if ( age >= ling_imm_movement__minage && age <= ling_imm_movement__maxage ) {
+                        if ( cur_step_final ) {
+                            auto ling_mat__age_idx = age - ling_mat__minage + 1 - 1;
 
-                        {
                             auto ling_imm_movement__area_idx = 0;
 
                             {
-                                ling_mat__wgt.col(ling_mat__age_idx).col(ling_mat__area_idx) = (ling_mat__wgt.col(ling_mat__age_idx).col(ling_mat__area_idx)*ling_mat__num.col(ling_mat__age_idx).col(ling_mat__area_idx)) + ling_imm_movement__transitioning_wgt.col(ling_imm_movement__age_idx).col(ling_imm_movement__area_idx)*ling_imm_movement__transitioning_num.col(ling_imm_movement__age_idx).col(ling_imm_movement__area_idx);
-                                ling_mat__num.col(ling_mat__age_idx).col(ling_mat__area_idx) += ling_imm_movement__transitioning_num.col(ling_imm_movement__age_idx).col(ling_imm_movement__area_idx);
-                                ling_mat__wgt.col(ling_mat__age_idx).col(ling_mat__area_idx) /= avoid_zero_vec(ling_mat__num.col(ling_mat__age_idx).col(ling_mat__area_idx));
+                                auto ling_imm_movement__age_idx = age - ling_imm_movement__minage + 1 - 1;
+
+                                {
+                                    ling_mat__wgt.col(ling_mat__area_idx).col(ling_mat__age_idx) = (ling_mat__wgt.col(ling_mat__area_idx).col(ling_mat__age_idx)*ling_mat__num.col(ling_mat__area_idx).col(ling_mat__age_idx)) + ling_imm_movement__transitioning_wgt.col(ling_imm_movement__area_idx).col(ling_imm_movement__age_idx)*ling_imm_movement__transitioning_num.col(ling_imm_movement__area_idx).col(ling_imm_movement__age_idx);
+                                    ling_mat__num.col(ling_mat__area_idx).col(ling_mat__age_idx) += ling_imm_movement__transitioning_num.col(ling_imm_movement__area_idx).col(ling_imm_movement__age_idx);
+                                    ling_mat__wgt.col(ling_mat__area_idx).col(ling_mat__age_idx) /= avoid_zero_vec(ling_mat__num.col(ling_mat__area_idx).col(ling_mat__age_idx));
+                                }
                             }
                         }
                     }

--- a/inttest/codegeneration/run.R
+++ b/inttest/codegeneration/run.R
@@ -14,13 +14,13 @@ end <- function (x) x
 areas <- list(area1=1)
 
 ling_imm <- g3_stock(c(species = 'ling', 'imm'), seq(20, 156, 4)) %>%
-    g3s_livesonareas(areas[c('area1')]) %>%
     g3s_age(3, 10) %>%
+    g3s_livesonareas(areas[c('area1')]) %>%
     end()
 
 ling_mat <- g3_stock(c(species = 'ling', 'mat'), seq(20, 156, 4)) %>%
-    g3s_livesonareas(areas[c('area1')]) %>%
     g3s_age(5, 15) %>%
+    g3s_livesonareas(areas[c('area1')]) %>%
     end()
 
 lln <- g3_fleet('lln') %>% g3s_livesonareas(areas[c('area1')])

--- a/man/step.Rd
+++ b/man/step.Rd
@@ -74,15 +74,19 @@ g3_step(step_f, recursing = FALSE, orig_env = environment(step_f))
 }
 
 \section{stock_ss}{
-  \code{stock_ss(stock_var, [ dimname = override, dimname = override, ... ])}
+  \code{stock_ss(stock_var, [ dimname = override, dimname = override, ... ][, vec = (dimname|full|single) ])}
 
-  Subsets \var{stock_var} to get a length vector for the current iteration
-  of \link{stock_iterate}(). If \var{dimname}s are supplied, then these
-  dimensions overwritten with the suppled override, which could be a missing
-  value, to preserve a dimension. See final example.
+  Subsets \var{stock_var} for the current iteration of \link{stock_iterate}().
 
-  Length is a missing value by default, i.e. we return length groups. To avoid
-  this happening, set \code{length = default} to iterate over length too.
+  The \var{vec} parameter decides the start value for all dimensions
+  If \code{full}, no other dimensions are set.
+  If set to a dimname, all dimensions after that dimension are set (i.e. a dimname-vector will be returned)
+  If \code{single}, all dimensions are set (i.e. a single value wil be returned).
+  The default is \code{length} if a length dimension is present (i.e. a length vector will be returned), otherwise \code{single}.
+
+  If \var{dimname}s are supplied, then the code supplied will override the above.
+  This code can include \code{default}, which will be substituted for the default subset,
+  or \code{missing} to represent an empty position in the subset.
 }
 
 \section{stock_ssinv}{
@@ -92,7 +96,7 @@ g3_step(step_f, recursing = FALSE, orig_env = environment(step_f))
 }
 
 \section{stock_switch}{
-  \code{stock_ss(stock, stock_name1 = expr, stock_name2 = expr, ... [ default ])}
+  \code{stock_switch(stock, stock_name1 = expr, stock_name2 = expr, ... [ default ])}
 
   Switch based on name of \var{stock}, returning the relevant \var{expr} or
   \var{default}. If no default supplied, then an unknown stock is an error.
@@ -185,7 +189,10 @@ stock <- g3_stock('halibut', 1:10) \%>\% g3s_age(1,10) \%>\% g3s_livesonareas(1)
 stock__num <- g3_stock_instance(stock)
 g3_step(~stock_iterate(stock, { x <- x + stock_ss(stock__num) }))
 g3_step(~stock_ss(stock__num, area = 5))
-g3_step(~stock_ss(stock__num, age = i + 1))
+# Lengthgroups for age_idx + 1
+g3_step(~stock_ss(stock__num, age = default + 1))
+# Vector for the entirety of the "next" area
+g3_step(~stock_ss(stock__num, area = default + 1, vec = area))
 g3_step(~stock_ss(stock__num, area = , age = j))
 
 ### stock_ssinv

--- a/tests/test-action_age.R
+++ b/tests/test-action_age.R
@@ -3,6 +3,12 @@ library(unittest)
 
 library(gadget3)
 
+ok_group("g3a_age:no_age")
+ok(ut_cmp_error({
+    g3a_age(g3_stock('prey_a', seq(20, 40, 4)))
+}, "age.*prey_a"), "Cannot use g3a_age() without an age dimension")
+#### g3a_age:no_age
+
 ok_group("g3a_age:single_age", {
     # prey_a, with single age, outputs into b & c
     prey_a <- g3_stock('prey_a', seq(20, 40, 4)) %>% g3s_age(11, 11)

--- a/tests/test-step.R
+++ b/tests/test-step.R
@@ -146,7 +146,7 @@ ok_group("g3_step:stock_reshape", {
 })
 
 ok_group("g3_step:stock_ss", {
-     stock <- g3_stock('halibut', 1:10) %>% g3s_age(1,10) %>% g3s_livesonareas(1)
+     stock <- g3_stock('halibut', 1:10) |> g3s_age(1,10) |> g3s_livesonareas(1)
      stock__num <- g3_stock_instance(stock)
      ok(cmp_code(
          gadget3:::g3_step(~stock_ss(stock__num, area = 5)),
@@ -164,6 +164,34 @@ ok_group("g3_step:stock_ss", {
      ok(cmp_code(
          gadget3:::g3_step(~stock_ss(stock__num, length = default)),
          ~stock__num[stock__length_idx, stock__age_idx, stock__area_idx]), "Length can be turned back on again")
+
+     ok(cmp_code(
+         gadget3:::g3_step(~stock_ss(stock__num, area = default + 1)),
+         ~stock__num[, stock__age_idx, stock__area_idx + 1] ), "We substitute 'default' so can be used in expressions")
+
+     ok(cmp_code(
+         gadget3:::g3_step(~stock_ss(stock__num, vec = full)),
+         ~stock__num[, , ] ), "vec = full returns entire vector")
+     ok(cmp_code(
+         gadget3:::g3_step(~stock_ss(stock__num, area = default, vec = full)),
+         ~stock__num[, , stock__area_idx] ), "vec = full still allows overrides")
+
+     ok(cmp_code(
+         gadget3:::g3_step(~stock_ss(stock__num, vec = single)),
+         ~stock__num[stock__length_idx, stock__age_idx, stock__area_idx] ), "vec = single returns single value")
+     ok(cmp_code(
+         gadget3:::g3_step(~stock_ss(stock__num, length = 4, vec = single)),
+         ~stock__num[4, stock__age_idx, stock__area_idx] ), "vec = single allows overrides")
+
+     ok(cmp_code(
+         gadget3:::g3_step(~stock_ss(stock__num, vec = area)),
+         ~stock__num[, , ] ), "vec = area clears everything up until area")
+     ok(cmp_code(
+         gadget3:::g3_step(~stock_ss(stock__num, vec = age)),
+         ~stock__num[, , stock__area_idx] ), "vec = age clears everything up until age")
+     ok(cmp_code(
+         gadget3:::g3_step(~stock_ss(stock__num, vec = length)),
+         ~stock__num[, stock__age_idx, stock__area_idx] ), "vec = length clears everything up until length (the default)")
 })
 
 ok_group("g3_step:stock_switch", {


### PR DESCRIPTION
Add extra options to ``stock_ss()`` so we can ditch ``action_age``()s custom logic, allowing the age/area dimension to be reordered.