### PR TITLE
Likelihood name parts / "predator" naming

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # gadget3 0.12-1-999:
 
+## New features
+* The `stock` column in likelihood data can now contain name parts as well as full stock names
+
 # gadget3 0.12-0:
 
 ## Bug fixes

--- a/R/likelihood_data.R
+++ b/R/likelihood_data.R
@@ -52,6 +52,7 @@ g3l_likelihood_data <- function (nll_name, data, missing_val = 0, area_group = N
 
     modelstock <- g3_storage(paste(nll_name, "model", sep = "_"))
     obsstock <- g3_storage(paste(nll_name, "obs", sep = "_"))
+    maps <- list()
 
     # Turn incoming data into stocks with correct dimensions
     d <- ld_dim_length(data)
@@ -94,69 +95,14 @@ g3l_likelihood_data <- function (nll_name, data, missing_val = 0, area_group = N
         handled_columns$tag <- NULL
     }
 
-    if ('stock' %in% names(data)) {
-        if ('stock_re' %in% names(data)) stop("Don't support both stock and stock_re")
-        # Unique stock string groupings, in order
-        stock_groups <- as.character(data$stock[!duplicated(data$stock)])
-
-        # stock_map: list of stock$name --> index of stock_groups it should be added to
-        # Start off with everything mapping to NULL
-        stock_map <- structure(
-            rep(list(NULL), length(all_stocks)),
-            names = vapply(all_stocks, function (s) s$name, character(1)))
-
-        # For 1..(max name parts) and all stocks...
-        for (n in seq_len(max(vapply(all_stocks, function (s) length(s$name_parts), integer(1))))) {
-            for (i in seq_along(all_stocks)) {
-                s <- all_stocks[[i]]
-
-                # Get all (n)-long combinations of (s)' name parts. fish_imm_f --> c("fish_f", "imm_f", ...)
-                if (n > length(s$name_parts)) next
-                name_combn <- apply(utils::combn(s$name_parts, n), 2, function (x) paste(x, collapse = "_"))
-
-                # If any one of these matches a stock_group, assign this stock to that string
-                # NB: We do shortest first, so longer matches will override shorter ones
-                matches <- which(stock_groups %in% name_combn)
-                if (length(matches) > 0) stock_map[[i]] <- head(matches, 1)
-            }
-        }
-
-        unused_groups <- setdiff(
-            seq_along(stock_groups),
-            unique(unlist(stock_map)) )
-        if (length(unused_groups) > 0) {
-            stop("stock groups matched no stocks in likelihood data: ", paste(stock_groups[unused_groups], collapse = ", "))
-        }
-
-        # NB: We have to replace stockidx_f later whenever we intersect over these
-        modelstock <- g3s_manual(modelstock, 'stock', stock_groups, ~stockidx_f)
-        obsstock <- g3s_manual(obsstock, 'stock', stock_groups, ~stockidx_f)
-        handled_columns$stock <- NULL
-    } else if ('stock_re' %in% names(data)) {
-        # Start off with everything mapping to NULL
-        stock_map <- structure(
-            rep(list(NULL), length(all_stocks)),
-            names = vapply(all_stocks, function (s) s$name, character(1)))
-
-        # For each regex, find all matches and map to that index
-        stock_regexes <- as.character(data$stock_re[!duplicated(data$stock_re)])
-        for (i in rev(seq_along(stock_regexes))) {  # NB: Reverse so first ones have precedence
-            stock_map[grep(stock_regexes[[i]], names(stock_map))] <- i
-        }
-
-        unused_regexes <- setdiff(
-            seq_along(stock_regexes),
-            unique(unlist(stock_map)) )
-        if (length(unused_regexes) > 0) {
-            stop("stock_re regexes matched no stocks in likelihood data: ", paste(stock_regexes[unused_regexes], collapse = ", "))
-        }
-
-        # NB: We have to replace stockidx_f later whenever we intersect over these
-        modelstock <- g3s_manual(modelstock, 'stock_re', stock_regexes, ~stockidx_f)
-        obsstock <- g3s_manual(obsstock, 'stock_re', stock_regexes, ~stockidx_f)
-        handled_columns$stock_re <- NULL
-    } else {
-        stock_map <- NULL
+    d <- ld_dim_g3stock(data, "stock", all_stocks)
+    if (!is.null(d[[1]])) {
+        modelstock <- copydim(modelstock, d[[1]])
+        # NB: We intersect obbstock onto modelstock, so we should copy that rather than the current stock
+        obsstock <- g3s_manual(obsstock, names(d[[1]]$dim), d$groups, as.symbol( paste0(modelstock$name, "__stock_idx") ))
+        # NB: g3stock doesn't modify data, so don't bother with d[[2]]
+        handled_columns[[names(d[[1]]$dim)]] <- NULL
+        maps[["stock"]] <- d$map
     }
 
     d <- ld_dim_length(data, col_name = 'predator_length')
@@ -183,62 +129,14 @@ g3l_likelihood_data <- function (nll_name, data, missing_val = 0, area_group = N
         handled_columns$predator_tag <- NULL
     }
 
-    if ('fleet' %in% names(data)) {
-        if ('fleet_re' %in% names(data)) stop("Don't support both fleet and fleet_re")
-        # Unique fleet string groupings, in order
-        fleet_groups <- as.character(data$fleet[!duplicated(data$fleet)])
-
-        # fleet_map: list of fleet$name --> index of fleet_groups it should be added to
-        # Start off with everything mapping to NULL
-        fleet_map <- structure(
-            rep(list(NULL), length(all_fleets)),
-            names = vapply(all_fleets, function (s) s$name, character(1)))
-
-        # For 1..(max name parts) and all fleets...
-        for (n in seq_len(max(vapply(all_fleets, function (s) length(s$name_parts), integer(1))))) {
-            for (i in seq_along(all_fleets)) {
-                s <- all_fleets[[i]]
-
-                # Get all (n)-long combinations of (s)' name parts. fish_imm_f --> c("fish_f", "imm_f", ...)
-                if (n > length(s$name_parts)) next
-                name_combn <- apply(utils::combn(s$name_parts, n), 2, function (x) paste(x, collapse = "_"))
-
-                # If any one of these matches a fleet_group, assign this fleet to that string
-                # NB: We do shortest first, so longer matches will override shorter ones
-                matches <- which(fleet_groups %in% name_combn)
-                if (length(matches) > 0) fleet_map[[i]] <- head(matches, 1)
-            }
-        }
-
-        unused_groups <- setdiff(
-            seq_along(fleet_groups),
-            unique(unlist(fleet_map)) )
-        if (length(unused_groups) > 0) {
-            stop("fleet groups matched no fleets in likelihood data: ", paste(fleet_groups[unused_groups], collapse = ", "))
-        }
-
-        # NB: We have to replace fleetidx_f later whenever we intersect over these
-        modelstock <- g3s_manual(modelstock, 'fleet', fleet_groups, ~fleetidx_f)
-        obsstock <- g3s_manual(obsstock, 'fleet', fleet_groups, ~fleetidx_f)
-        handled_columns$fleet <- NULL
-    } else if ('fleet_re' %in% names(data)) {
-        # Start off with everything mapping to NULL
-        fleet_map <- structure(
-            rep(list(NULL), length(all_fleets)),
-            names = vapply(all_fleets, function (s) s$name, character(1)))
-
-        # For each regex, find all matches and map to that index
-        fleet_regexes <- as.character(data$fleet_re[!duplicated(data$fleet_re)])
-        for (i in rev(seq_along(fleet_regexes))) {  # NB: Reverse so first ones have precedence
-            fleet_map[grep(fleet_regexes[[i]], names(fleet_map))] <- i
-        }
-
-        # NB: We have to replace fleetidx_f later whenever we intersect over these
-        modelstock <- g3s_manual(modelstock, 'fleet_re', fleet_regexes, ~fleetidx_f)
-        obsstock <- g3s_manual(obsstock, 'fleet_re', fleet_regexes, ~fleetidx_f)
-        handled_columns$fleet_re <- NULL
-    } else {
-        fleet_map <- NULL
+    d <- ld_dim_g3stock(data, "fleet", all_fleets)
+    if (!is.null(d[[1]])) {
+        modelstock <- copydim(modelstock, d[[1]])
+        # NB: We intersect obbstock onto modelstock, so we should copy that rather than the current stock
+        obsstock <- g3s_manual(obsstock, names(d[[1]]$dim), d$groups, as.symbol( paste0(modelstock$name, "__fleet_idx") ))
+        # NB: g3stock doesn't modify data, so don't bother with d[[2]]
+        handled_columns[[names(d[[1]]$dim)]] <- NULL
+        maps[["fleet"]] <- d$map
     }
 
     # Add time dimension if it's supposed to be last
@@ -327,8 +225,8 @@ g3l_likelihood_data <- function (nll_name, data, missing_val = 0, area_group = N
         modelstock = modelstock,
         obsstock = obsstock,
         done_aggregating_f = if ('step' %in% names(data)) ~TRUE else ~cur_step_final,
-        stock_map = stock_map,
-        fleet_map = fleet_map,
+        stock_map = maps[["stock"]],
+        fleet_map = maps[["fleet"]],
         number = number_array,
         weight = weight_array,
         nll_name = nll_name))
@@ -475,6 +373,84 @@ ld_dim_tag <- function(data, col_name = 'tag') {
         stock <- g3s_tag(g3_storage("x"), tag_ids, force_untagged = FALSE)
     }
     return(list( stock, data_col ))
+}
+
+ld_dim_g3stock <- function(data, col_name = "stock", all_stocks) {
+    col_name_re <- paste0(col_name, "_re")
+    if (col_name %in% names(data) && col_name_re %in% names(data)) {
+        stop("Don't support both ", col_name, " and ", col_name_re)
+    }
+
+    if (col_name %in% names(data)) {
+        actual_col <- col_name
+        # Unique stock string groupings, in order
+        stock_groups <- as.character(data[[col_name]][!duplicated(data[[col_name]])])
+
+        # stock_map: list of stock$name --> index of stock_groups it should be added to
+        # Start off with everything mapping to NULL
+        stock_map <- structure(
+            rep(list(NULL), length(all_stocks)),
+            names = vapply(all_stocks, function (s) s$name, character(1)))
+
+        # For 1..(max name parts) and all stocks...
+        for (n in seq_len(max(vapply(all_stocks, function (s) length(s$name_parts), integer(1))))) {
+            for (i in seq_along(all_stocks)) {
+                s <- all_stocks[[i]]
+
+                # Get all (n)-long combinations of (s)' name parts. fish_imm_f --> c("fish_f", "imm_f", ...)
+                if (n > length(s$name_parts)) next
+                name_combn <- apply(utils::combn(s$name_parts, n), 2, function (x) paste(x, collapse = "_"))
+
+                # If any one of these matches a stock_group, assign this stock to that string
+                # NB: We do shortest first, so longer matches will override shorter ones
+                matches <- which(stock_groups %in% name_combn)
+                if (length(matches) > 0) stock_map[[i]] <- head(matches, 1)
+            }
+        }
+
+        unused_groups <- setdiff(
+            seq_along(stock_groups),
+            unique(unlist(stock_map)) )
+        if (length(unused_groups) > 0) {
+            stop(col_name, " groups matched no ", col_name, " in likelihood data: ", paste(stock_groups[unused_groups], collapse = ", "))
+        }
+    } else if (col_name_re %in% names(data)) {
+        actual_col <- col_name_re
+        # Start off with everything mapping to NULL
+        stock_map <- structure(
+            rep(list(NULL), length(all_stocks)),
+            names = vapply(all_stocks, function (s) s$name, character(1)))
+
+        # For each regex, find all matches and map to that index
+        stock_groups <- as.character(data[[col_name_re]][!duplicated(data[[col_name_re]])])
+        for (i in rev(seq_along(stock_groups))) {  # NB: Reverse so first ones have precedence
+            stock_map[grep(stock_groups[[i]], names(stock_map))] <- i
+        }
+
+        unused_regexes <- setdiff(
+            seq_along(stock_groups),
+            unique(unlist(stock_map)) )
+        if (length(unused_regexes) > 0) {
+            stop("stock_re regexes matched no stocks in likelihood data: ", paste(stock_groups[unused_regexes], collapse = ", "))
+        }
+    } else {
+        # No relevant column --> nothing to do
+        return(list(NULL))
+    }
+
+    # Turn stock_map mapping into formula
+    intersect_idx_f <- list_to_stock_switch(
+        # Wrap each value of stock_map with g3_idx(i)
+        # NB: -1 will cause g3s_manual() to ignore this intersect
+        sapply(stock_map, function (i) substitute(g3_idx(i), list(i = if (is.null(i)) -1L else i)) ),
+        # Variable in g3l_distribution() this should be looking for
+       if (col_name == "stock") "stock" else "predstock" )
+
+    return(list(
+        g3s_manual(g3_storage("x"), actual_col, stock_groups, intersect_idx_f),
+        NULL,  # This is data_col in other methods
+        groups = stock_groups,
+        map = stock_map ))
 }
 
 # Copy a single dimension from (new_stock) atop (old_stock), renaming dimension by adding (prefix)

--- a/R/likelihood_data.R
+++ b/R/likelihood_data.R
@@ -32,7 +32,7 @@ parse_levels <- function (lvls, var_name) {
     stop("Unknown form of ", var_name, " levels, see ?cut for formatting: ", paste(lvls, collapse = ", "))
 }
 
-g3l_likelihood_data <- function (nll_name, data, missing_val = 0, area_group = NULL, model_history = "", all_stocks = list(), all_fleets = list()) {
+g3l_likelihood_data <- function (nll_name, data, missing_val = 0, area_group = NULL, model_history = "", all_stocks = list(), all_fleets = list(), all_predators = list()) {
     # vector of col names, will cross them off as we go
     handled_columns <- structure(as.list(seq_along(names(data))), names = names(data))
 
@@ -127,6 +127,16 @@ g3l_likelihood_data <- function (nll_name, data, missing_val = 0, area_group = N
         obsstock <- copydim(obsstock, d[[1]], prefix = 'predator_')
         data$predator_tag <- d[[2]]
         handled_columns$predator_tag <- NULL
+    }
+
+    d <- ld_dim_g3stock(data, "predator", all_predators)
+    if (!is.null(d[[1]])) {
+        modelstock <- copydim(modelstock, d[[1]])
+        # NB: We intersect obbstock onto modelstock, so we should copy that rather than the current stock
+        obsstock <- g3s_manual(obsstock, names(d[[1]]$dim), d$groups, as.symbol( paste0(modelstock$name, "__predator_idx") ))
+        # NB: g3stock doesn't modify data, so don't bother with d[[2]]
+        handled_columns[[names(d[[1]]$dim)]] <- NULL
+        maps[["predator"]] <- d$map
     }
 
     d <- ld_dim_g3stock(data, "fleet", all_fleets)

--- a/R/likelihood_data.R
+++ b/R/likelihood_data.R
@@ -225,8 +225,7 @@ g3l_likelihood_data <- function (nll_name, data, missing_val = 0, area_group = N
         modelstock = modelstock,
         obsstock = obsstock,
         done_aggregating_f = if ('step' %in% names(data)) ~TRUE else ~cur_step_final,
-        stock_map = maps[["stock"]],
-        fleet_map = maps[["fleet"]],
+        maps = maps,
         number = number_array,
         weight = weight_array,
         nll_name = nll_name))
@@ -446,11 +445,17 @@ ld_dim_g3stock <- function(data, col_name = "stock", all_stocks) {
         # Variable in g3l_distribution() this should be looking for
        if (col_name == "stock") "stock" else "predstock" )
 
+    # Make diagnostic fleet map with names for g3_distribution_preview()
+    map <- vapply(
+        stock_map,
+        function (i) if (is.null(i)) as.character(NA) else stock_groups[[i]],
+        character(1) )
+
     return(list(
         g3s_manual(g3_storage("x"), actual_col, stock_groups, intersect_idx_f),
         NULL,  # This is data_col in other methods
         groups = stock_groups,
-        map = stock_map ))
+        map = map ))
 }
 
 # Copy a single dimension from (new_stock) atop (old_stock), renaming dimension by adding (prefix)

--- a/R/likelihood_distribution.R
+++ b/R/likelihood_distribution.R
@@ -146,9 +146,34 @@ g3_distribution_preview <- function (
         all_fleets = fleets,
         area_group = area_group,
         model_history = "" )
-    if (!is.null(ld$number)) return(ld$number)
-    if (!is.null(ld$weight)) return(ld$weight)
-    stop('obs_data should contain either a number column or weight column')
+
+    if (!is.null(ld$number)) {
+        out <- ld$number
+    } else if (!is.null(ld$weight)) {
+        out <- ld$weight
+    } else {
+        stop('obs_data should contain either a number column or weight column')
+    }
+
+    # If the output has a stock_map, show the user
+    if (!is.null(ld$stock_map) && 'stock' %in% names(obs_data)) {
+        stock_groups <- as.character(obs_data$stock[!duplicated(obs_data$stock)])
+        attr(out, "stock_map") <- vapply(
+            ld$stock_map,
+            function (i) if (is.null(i)) as.character(NA) else stock_groups[[i]],
+            character(1) )
+    }
+
+    # If the output has a fleet_map, show the user
+    if (!is.null(ld$fleet_map) && 'fleet' %in% names(obs_data)) {
+        fleet_groups <- as.character(obs_data$fleet[!duplicated(obs_data$fleet)])
+        attr(out, "fleet_map") <- vapply(
+            ld$fleet_map,
+            function (i) if (is.null(i)) as.character(NA) else fleet_groups[[i]],
+            character(1) )
+    }
+
+    return(out)
 }
 
 # Compare model state to observation data

--- a/R/likelihood_distribution.R
+++ b/R/likelihood_distribution.R
@@ -155,22 +155,9 @@ g3_distribution_preview <- function (
         stop('obs_data should contain either a number column or weight column')
     }
 
-    # If the output has a stock_map, show the user
-    if (!is.null(ld$stock_map) && 'stock' %in% names(obs_data)) {
-        stock_groups <- as.character(obs_data$stock[!duplicated(obs_data$stock)])
-        attr(out, "stock_map") <- vapply(
-            ld$stock_map,
-            function (i) if (is.null(i)) as.character(NA) else stock_groups[[i]],
-            character(1) )
-    }
-
-    # If the output has a fleet_map, show the user
-    if (!is.null(ld$fleet_map) && 'fleet' %in% names(obs_data)) {
-        fleet_groups <- as.character(obs_data$fleet[!duplicated(obs_data$fleet)])
-        attr(out, "fleet_map") <- vapply(
-            ld$fleet_map,
-            function (i) if (is.null(i)) as.character(NA) else fleet_groups[[i]],
-            character(1) )
+    # Attach any maps present in output
+    for (i in seq_along(ld$maps)) {
+        attr(out, paste0(names(ld$maps)[[i]], "_map")) <- ld$maps[[i]]
     }
 
     return(out)

--- a/R/likelihood_distribution.R
+++ b/R/likelihood_distribution.R
@@ -26,7 +26,7 @@ dist_prop <- function (var_name, over) {
 }
 
 g3l_distribution_sumofsquares <- function (
-        over = c('area', 'predator_tag', 'predator_age', 'predator_length')) {
+        over = c('area', 'predator', 'predator_tag', 'predator_age', 'predator_length')) {
     out <- f_substitute( quote((modelstock_prop - obsstock_prop) ** 2), list(
         modelstock_prop = dist_prop("modelstock__x", c('time', over)),
         obsstock_prop = dist_prop("obsstock__x", c('time', over))))
@@ -135,6 +135,7 @@ g3l_distribution_sumofsquaredlogratios <- function (epsilon = 10) {
 
 g3_distribution_preview <- function (
         obs_data,
+        predators = list(),
         fleets = list(),
         stocks = list(),
         area_group = NULL) {
@@ -142,6 +143,7 @@ g3_distribution_preview <- function (
         'preview',
         obs_data,
         missing_val = NA,
+        all_predators = predators,
         all_stocks = stocks,
         all_fleets = fleets,
         area_group = area_group,
@@ -182,6 +184,7 @@ g3l_distribution <- function (
         fleets = list(),
         stocks,
         function_f,
+        predators = list(),
         transform_fs = list(),
         missing_val = 0,
         area_group = NULL,
@@ -194,9 +197,12 @@ g3l_distribution <- function (
     stopifnot(is.character(nll_name) && length(nll_name) == 1)
     stopifnot(is.data.frame(obs_data))
     stopifnot(is.list(fleets) && all(sapply(fleets, g3_is_stock)))
+    stopifnot(is.list(predators) && all(sapply(predators, g3_is_stock)))
     stopifnot(is.list(stocks) && all(sapply(stocks, g3_is_stock)))
     stopifnot(rlang::is_formula(function_f))
     stopifnot(is.list(transform_fs))
+
+    fleetpreds <- c(fleets, predators)
 
     if ("modelstock__time_idx" %in% all.vars(function_f)) {
         # g3l_distribution_surveyindices needs to generate time vectors, so needs time early in dimension list
@@ -242,10 +248,10 @@ g3l_distribution <- function (
 
     out <- new.env(parent = emptyenv())
 
-    # Find name of function user called, error if it was catchdistribution but with missing fleets
+    # Find name of function user called, error if it was catchdistribution but with missing predators
     this_name <- as.character(sys.call()[[1]])
-    if (this_name == "g3l_catchdistribution" && length(fleets) == 0) stop("Fleets must be supplied for g3l_catchdistribution")
-    if (this_name == "g3l_abundancedistribution" && length(fleets) > 0) stop("Fleets must not be supplied for g3l_abundancedistribution")
+    if (this_name == "g3l_catchdistribution" && length(fleetpreds) == 0) stop("fleets/predators must be supplied for g3l_catchdistribution")
+    if (this_name == "g3l_abundancedistribution" && length(fleetpreds) > 0) stop("fleets/predators must not be supplied for g3l_abundancedistribution")
 
     # Find name of function user called, and g3l_substitution function used
     function_f_name <- if (is.call(substitute(function_f))) as.character(substitute(function_f)[[1]]) else "custom"
@@ -254,13 +260,13 @@ g3l_distribution <- function (
     # Add our called name / function name to labels & nll_name
     prefix <- paste0(this_name, "_", function_f_name, ": ")
     nll_name <- paste(
-        if (length(fleets) > 0) 'cdist' else 'adist',
+        if (length(fleetpreds) > 0) 'cdist' else 'adist',
         function_f_name,
         nll_name,
         sep = "_")
 
     # Convert data to stocks
-    ld <- g3l_likelihood_data(nll_name, obs_data, missing_val = missing_val, area_group = area_group, model_history = model_history, all_stocks = stocks, all_fleets = fleets)
+    ld <- g3l_likelihood_data(nll_name, obs_data, missing_val = missing_val, area_group = area_group, model_history = model_history, all_stocks = stocks, all_fleets = fleets, all_predators = predators)
     modelstock <- ld$modelstock
     obsstock <- ld$obsstock
     if (!is.null(ld$number)) {
@@ -272,8 +278,8 @@ g3l_distribution <- function (
         obsstock__wgt <- g3_stock_instance(obsstock, ld$weight)
     }
 
-    # If no fleets, set predstock = NULL, otherwise iterate over fleets
-    for (predstock in (if (length(fleets) > 0) fleets else list(NULL))) for (prey_stock in stocks) {
+    # If no fleets/predators, set predstock = NULL, otherwise iterate over fleets
+    for (predstock in (if (length(fleetpreds) > 0) fleetpreds else list(NULL))) for (prey_stock in stocks) {
         stock <- prey_stock  # Alias stock == prey_stock
 
         # NB: In lockstep with action_predate()

--- a/R/stock_manual.R
+++ b/R/stock_manual.R
@@ -7,6 +7,15 @@ g3s_manual <- function(inner_stock, var_base_name, dimnames, intersect_idx_f) {
     idx_var_name <- paste0("stock__", var_base_name, "_idx")
     with_names <- function (n, i) structure(i, names = n)
 
+    # Separate code / env of intersect_idx_f
+    if (rlang::is_formula(intersect_idx_f)) {
+        intersect_idx_c <- rlang::f_rhs(intersect_idx_f)
+        env <- as.environment(c(as.list(inner_stock$env), as.list(environment(intersect_idx_f))))
+    } else {
+        intersect_idx_c <- intersect_idx_f
+        env <- inner_stock$env
+    }
+
     structure(list(
         dim = c(inner_stock$dim,
             with_names(var_base_name, length(dimnames))),
@@ -19,17 +28,17 @@ g3s_manual <- function(inner_stock, var_base_name, dimnames, intersect_idx_f) {
             dim_size = length(dimnames)))))),
         iter_ss = c(inner_stock$iter_ss, with_names(var_base_name, list(as.symbol(idx_var_name)))),
         intersect = c(inner_stock$intersect, with_names(var_base_name, list(substitute(
-            g3_with(idx_var_name := intersect_idx_code, extension_point),
+            g3_with(idx_var_name := intersect_idx_code, if (idx_var_name >= g3_idx(1L)) extension_point),
             list(
                 idx_var_name = as.symbol(idx_var_name),
-                intersect_idx_code = rlang::f_rhs(intersect_idx_f)))))),
+                intersect_idx_code = intersect_idx_c ))))),
         interact = c(inner_stock$interact, with_names(var_base_name, list(substitute(
             for (idx_var_name in seq(g3_idx(1L), g3_idx(dim_size), by = 1L)) extension_point
         , list(
             idx_var_name = as.symbol(idx_var_name),
             dim_size = length(dimnames)))))),
         with = c(inner_stock$with, with_names(var_base_name, list(quote(extension_point)))),
-        env = as.environment(c(as.list(inner_stock$env), as.list(environment(intersect_idx_f)))),
+        env = env,
         name_parts = inner_stock$name_parts,
         name = inner_stock$name), class = c("g3_stock", "list"))
 }

--- a/man/likelihood_distribution.Rd
+++ b/man/likelihood_distribution.Rd
@@ -17,7 +17,7 @@
 
 \usage{
 g3l_distribution_sumofsquares(
-        over = c('area', 'predator_tag', 'predator_age', 'predator_length'))
+        over = c('area', 'predator', 'predator_tag', 'predator_age', 'predator_length'))
 
 g3l_distribution_multinomial(epsilon = 10)
 
@@ -35,6 +35,7 @@ g3l_abundancedistribution(
         fleets = list(),
         stocks,
         function_f,
+        predators = list(),
         transform_fs = list(),
         missing_val = 0,
         area_group = NULL,
@@ -51,6 +52,7 @@ g3l_catchdistribution(
         fleets = list(),
         stocks,
         function_f,
+        predators = list(),
         transform_fs = list(),
         missing_val = 0,
         area_group = NULL,
@@ -63,6 +65,7 @@ g3l_catchdistribution(
 
 g3_distribution_preview(
         obs_data,
+        predators = list(),
         fleets = list(),
         stocks = list(),
         area_group = NULL)
@@ -104,7 +107,7 @@ g3_distribution_preview(
     Should at least have a year column, and a length or weight column.
     For more information, see "obs_data and data aggregation" below.
   }
-  \item{fleets}{
+  \item{fleets, predators}{
     A list of \code{\link{g3_stock}} objects to collect catch data for.
     If empty, will collect abundance data for \var{stocks} instead.
   }
@@ -550,10 +553,10 @@ actions <- list(
     g3l_catchdistribution(
         'pred_a_sizepref',
         pred_a_sizepref_obs,
-        fleets = list(pred_a),
+        predators = list(pred_a),
         # NB: Only referencing stocks included in observation data
         stocks = list(prey_a),
-        g3l_distribution_sumofsquares(),
+        function_f = g3l_distribution_sumofsquares(),
         # Use transform_fs to apply digestioncoefficients
         transform_fs = list(length = list(prey_a = g3_formula(
             quote( diag(d0 + d1 * prey_a__midlen^d2) ),

--- a/man/likelihood_distribution.Rd
+++ b/man/likelihood_distribution.Rd
@@ -222,12 +222,18 @@ g3_distribution_preview(
       }
       \item{stock}{
         Optional.
-        If this and stock_re are missing all stocks in \var{stocks} will be
-        summed to compare to the data.
+        If tmissing all stocks in \var{stocks} will be summed to compare to the data.
 
         The values in the stocks column should match the names of the stocks
         given in the \var{stocks} parameter. This column can be factor or
         character.
+
+        The values can also some of the stock name parts, e.g. \code{"st_f"} or \code{"f"}
+        which would then aggregate \code{"st_imm_f"}, \code{"st_mat_f"} together.
+
+        However, note that a stock can only be included in one grouping,
+        so given columns \code{"f"} & \code{"imm"}, \code{"st_imm_f"} would only be included in the former group.
+        If you want to do something along these lines, 2 separate likelihood actions would be more appropriate.
 
         Any missing stocks (when there is otherwise data for that
         year/step) will be compared to zero.

--- a/tests/test-action_predate-predator.R
+++ b/tests/test-action_predate-predator.R
@@ -11,6 +11,7 @@ pred_a_catch_obs <- expand.grid(
     year = 2000:2005,
     length = c(0,5,10),
     stock = c('prey_a', 'prey_b', 'otherfood'),
+    predator = c('pred_a'),  # NB: Not essential if there's only one predator, only for testing
     predator_length = c(50,70),
     predator_age = c("[0,5)", "[6,10)"), # ((
     number = 0 )
@@ -48,27 +49,27 @@ actions <- list(
     g3l_catchdistribution(
         'pred_a_catch',
         pred_a_catch_obs,
-        fleets = list(pred_a),
+        predators = list(pred_a),
         stocks = list(prey_a, prey_b, otherfood),
-        g3l_distribution_sumofsquares(),
+        function_f = g3l_distribution_sumofsquares(),
         nll_breakdown = TRUE,
         report = TRUE ),
 
     g3l_catchdistribution(
         'pred_a_preypref',
         pred_a_preypref_obs,
-        fleets = list(pred_a),
+        predators = list(pred_a),
         stocks = list(prey_a, prey_b, otherfood),
-        g3l_distribution_sumofsquares(),
+        function_f = g3l_distribution_sumofsquares(),
         nll_breakdown = TRUE,
         report = TRUE ),
 
     g3l_catchdistribution(
         'pred_a_sizepref',
         pred_a_sizepref_obs,
-        fleets = list(pred_a),
+        predators = list(pred_a),
         stocks = list(prey_a, prey_b),  # NB: otherfood missing
-        g3l_distribution_sumofsquares(),
+        function_f = g3l_distribution_sumofsquares(),
         nll_breakdown = TRUE,
         report = TRUE ),
 
@@ -134,7 +135,11 @@ ok(ut_cmp_equal(
     r$detail_prey_a_pred_a__cons[1,1,3,1,1] / 75^2 * 85^2,
     tolerance = 1e-8 ), "r$detail_prey_a_pred_a__cons: Jump in consumption 75 -> 85")
 
-ok(gadget3:::ut_cmp_array(r$cdist_sumofsquares_pred_a_catch_model__num, '
+ok(ut_cmp_identical(
+    dimnames(r$cdist_sumofsquares_pred_a_catch_model__num)$predator,
+    c("pred_a") ), "cdist_sumofsquares_pred_a_catch_model__num: Single predator dimension for our one predator")
+
+ok(gadget3:::ut_cmp_array(drop(r$cdist_sumofsquares_pred_a_catch_model__num), '
     length     stock predator_length predator_age time        Freq
 1      0:5    prey_a           50:70          0:4 2000  84464.2913
 2     5:10    prey_a           50:70          0:4 2000 105580.3641

--- a/tests/test-likelihood_data.R
+++ b/tests/test-likelihood_data.R
@@ -717,7 +717,7 @@ ok_group('g3l_likelihood_data:stock', {
           4 2001      2001.4
           6 2001      2001.6
         ")
-    ok(is.null(ld$stock_map), "No stock column, so no stock map")
+    ok(is.null(ld$maps$stock), "No stock column, so no stock map")
 
     ok(ut_cmp_error(generate_ld("
         age year stock stock_re number
@@ -735,7 +735,7 @@ ok_group('g3l_likelihood_data:stock', {
           6 2001    b  2001.6
         ", all_stocks = c('a', 'b'))
     ok(ut_cmp_identical(dimnames(ld$number)[['stock']], c("a", "b")), "Array has stocks a & b")
-    ok(ut_cmp_identical(ld$stock_map, list(a = 1L, b = 2L)), "stock_map is 1:1 mapping")
+    ok(ut_cmp_identical(ld$maps$stock, c(a = 'a', b = 'b')), "stock_map is 1:1 mapping")
 
     ok(ut_cmp_error(generate_ld("
         age year stock number
@@ -765,12 +765,12 @@ ok_group('g3l_likelihood_data:stock', {
         dimnames(ld$number)[['stock_re']],
         c("_f$", "^stock_mat", "^stock_imm")), "Array names are regexes")
     ok(ut_cmp_identical(
-        ld$stock_map,
-        list(
-            stock_imm_f = 1L,
-            stock_imm_m = 3L,
-            stock_mat_f = 1L,
-            stock_mat_m = 2L)), "Stock map used first regexes first")
+        ld$maps$stock,
+        c(
+            stock_imm_f = '_f$',
+            stock_imm_m = '^stock_imm',
+            stock_mat_f = '_f$',
+            stock_mat_m = '^stock_mat')), "Stock map used first regexes first")
 
     ok(ut_cmp_error(generate_ld("
         age year stock_re number
@@ -799,12 +799,12 @@ ok_group('g3l_likelihood_data:stock', {
         dimnames(ld$number)[['stock_re']],
         c("_mat_f$", "_imm_f$")), "Array names are regexes")
     ok(ut_cmp_identical(
-        ld$stock_map,
-        list(
-            stock_imm_f = 2L,
-            stock_imm_m = NULL,
-            stock_mat_f = 1L,
-            stock_mat_m = NULL)), "Stock map ignored unused stocks")
+        ld$maps$stock,
+        c(
+            stock_imm_f = '_imm_f$',
+            stock_imm_m = NA,
+            stock_mat_f = '_mat_f$',
+            stock_mat_m = NA )), "Stock map ignored unused stocks")
 })
 
 ok_group('g3l_likelihood_data:stock:name_parts', {
@@ -812,53 +812,53 @@ ok_group('g3l_likelihood_data:stock:name_parts', {
         tbl <- expand.grid(number = 0, stock = stock_cols, age = 3:6, year = 1999:2001)
         tbl$number <- seq_len(nrow(tbl))
         ld <- generate_ld(tbl, all_stocks = stock_names)
-        return(ld$stock_map)
+        return(ld$maps$stock)
     }
     out <- stock_groupings(
         list(c('fish', 'imm'), c('fish', 'mat'), c('fish', 'sen')),
         c('fish'))
-    ok(ut_cmp_equal(out, list(
-        fish_imm = 1,
-        fish_mat = 1,
-        fish_sen = 1 )), '"fish": Groups both maturity groups together')
+    ok(ut_cmp_equal(out, c(
+        fish_imm = 'fish',
+        fish_mat = 'fish',
+        fish_sen = 'fish' )), '"fish": Groups both maturity groups together')
 
     out <- stock_groupings(
         list(c('fish', 'imm'), c('fish', 'mat'), c('fish', 'sen')),
         c('fish_mat', 'fish'))
-    ok(ut_cmp_equal(out, list(
-        fish_imm = 2,
-        fish_mat = 1,
-        fish_sen = 2 )), '"fish_mat": Overrides "fish" group due to longer length')
+    ok(ut_cmp_equal(out, c(
+        fish_imm = 'fish',
+        fish_mat = 'fish_mat',
+        fish_sen = 'fish' )), '"fish_mat": Overrides "fish" group due to longer length')
 
     out <- stock_groupings(
         list(c('a', 'imm'), c('a', 'mat'), c('b', 'imm'), c('b', 'mat'), c('c', 'mat')),
         c('a', 'b', 'mat'))
-    ok(ut_cmp_equal(out, list(
-        a_imm = 1,
-        a_mat = 1,
-        b_imm = 2,
-        b_mat = 2,
-        c_mat = 3 )), "'b' wins over 'mat' because it comes first")
+    ok(ut_cmp_equal(out, c(
+        a_imm = 'a',
+        a_mat = 'a',
+        b_imm = 'b',
+        b_mat = 'b',
+        c_mat = 'mat' )), "'b' wins over 'mat' because it comes first")
 
     out <- stock_groupings(
         list(c('a', 'imm'), c('a', 'mat'), c('b', 'imm'), c('b', 'mat'), c('c', 'mat')),
         c('a', 'mat', 'b'))
-    ok(ut_cmp_equal(out, list(
-        a_imm = 1,
-        a_mat = 1,
-        b_imm = 3,
-        b_mat = 2,
-        c_mat = 2 )), "'mat' wins over 'b' because it comes first")
+    ok(ut_cmp_equal(out, c(
+        a_imm = 'a',
+        a_mat = 'a',
+        b_imm = 'b',
+        b_mat = 'mat',
+        c_mat = 'mat' )), "'mat' wins over 'b' because it comes first")
 
     out <- stock_groupings(
         list(c('a', 'imm', 'f'), c('a', 'mat', 'f'), c('a', 'imm', 'm'), c('a', 'mat', 'm'), c('c', 'mat')),
         c('a_f', 'a_m', 'c'))
-    ok(ut_cmp_equal(out, list(
-        a_imm_f = 1,
-        a_mat_f = 1,
-        a_imm_m = 2,
-        a_mat_m = 2,
-        c_mat = 3 )), "Name part groupings don't have to be sequential")
+    ok(ut_cmp_equal(out, c(
+        a_imm_f = 'a_f',
+        a_mat_f = 'a_f',
+        a_imm_m = 'a_m',
+        a_mat_m = 'a_m',
+        c_mat = 'c' )), "Name part groupings don't have to be sequential")
 })
 
 
@@ -873,7 +873,7 @@ ok_group('g3l_likelihood_data:fleet', {
           4 2001      2001.4
           6 2001      2001.6
         ")
-    ok(is.null(ld$fleet_map), "No fleet column, so no fleet map")
+    ok(is.null(ld$maps$fleet), "No fleet column, so no fleet map")
 
     ok(ut_cmp_error(generate_ld("
         age year fleet fleet_re number
@@ -891,7 +891,7 @@ ok_group('g3l_likelihood_data:fleet', {
           6 2001    b  2001.6
         ", all_fleets = list(g3_fleet('a'), g3_fleet('b')))
     ok(ut_cmp_identical(dimnames(ld$number)[['fleet']], c("a", "b")), "Array has fleets a & b")
-    ok(ut_cmp_identical(ld$fleet_map, list(a = 1L, b = 2L)), "fleet_map is 1:1 mapping")
+    ok(ut_cmp_identical(ld$maps$fleet, c(a = 'a', b = 'b')), "fleet_map is 1:1 mapping")
 
     # Generate a list of fleets "fleet_(trawl|gil)_(f|m)"
     fleets <- lapply(paste(
@@ -913,12 +913,12 @@ ok_group('g3l_likelihood_data:fleet', {
         dimnames(ld$number)[['fleet_re']],
         c("_is$", "^fleet_trawl", "^fleet_gil")), "Array names are regexes")
     ok(ut_cmp_identical(
-        ld$fleet_map,
-        list(
-            fleet_trawl_is = 1L,
-            fleet_trawl_no = 2L,
-            fleet_gil_is = 1L,
-            fleet_gil_no = 3L)), "fleet map used first regexes first")
+        ld$maps$fleet,
+        c(
+            fleet_trawl_is = '_is$',
+            fleet_trawl_no = '^fleet_trawl',
+            fleet_gil_is = '_is$',
+            fleet_gil_no = '^fleet_gil' )), "fleet map used first regexes first")
 
     # Generate a list of fleets "fleet_(trawl|gil)_(f|m)"
     fleets <- lapply(paste(
@@ -940,12 +940,12 @@ ok_group('g3l_likelihood_data:fleet', {
         dimnames(ld$number)[['fleet_re']],
         c("_gil_is$", "_trawl_is$")), "Array names are regexes")
     ok(ut_cmp_identical(
-        ld$fleet_map,
-        list(
-            fleet_trawl_is = 2L,
-            fleet_trawl_no = NULL,
-            fleet_gil_is = 1L,
-            fleet_gil_no = NULL)), "fleet map ignored unused fleets")
+        ld$maps$fleet,
+        c(
+            fleet_trawl_is = '_trawl_is$',
+            fleet_trawl_no = NA,
+            fleet_gil_is = '_gil_is$',
+            fleet_gil_no = NA )), "fleet map ignored unused fleets")
 })
 
 ok_group('g3l_likelihood_data:predator') ##########

--- a/tests/test-likelihood_distribution.R
+++ b/tests/test-likelihood_distribution.R
@@ -277,14 +277,14 @@ ok(ut_cmp_error(g3l_catchdistribution(
     fleets = list(),
     stocks = list(prey_a, prey_b, prey_c),
     area_group = areas,
-    g3l_distribution_sumofsquares()), "Fleets must be supplied"), "g3l_catchdistribution: Invalid without fleets")
+    g3l_distribution_sumofsquares()), "fleets/predators must be supplied"), "g3l_catchdistribution: Invalid without fleets")
 ok(ut_cmp_error(g3l_abundancedistribution(
     'utcd',
     cd_data,
     fleets = list(fleet_abc),
     stocks = list(prey_a, prey_b, prey_c),
     area_group = areas,
-    g3l_distribution_sumofsquares()), "Fleets must not be supplied"), "g3l_abundancedistribution: Invalid with fleets")
+    g3l_distribution_sumofsquares()), "fleets/predators must not be supplied"), "g3l_abundancedistribution: Invalid with fleets")
 
 # Generate a step that reports the value of (var_name) into separate variable (steps) times
 # (initial_val) provides a definition to use to set variable type

--- a/tests/test-likelihood_distribution.R
+++ b/tests/test-likelihood_distribution.R
@@ -58,6 +58,26 @@ ok_group("g3_distribution_preview", {
             time = c("1990-02", "1991-02", "1992-02", "1993-02", "1994-02"),
             area = "IXa") )), "Number array wins if both present")
 
+    stocks <- list(
+       g3_stock(c(species = 'fish', 'imm', 'f'), 1:10),
+       g3_stock(c(species = 'fish', 'imm', 'm'), 1:10),
+       g3_stock(c(species = 'fish', 'mat', 'f'), 1:10),
+       g3_stock(c(species = 'fish', 'mat', 'm'), 1:10) )
+    dat <- expand.grid(year = 1990:1994, stock = c("imm", "mat"), number = 0)
+    out <- drop(g3_distribution_preview(dat, stocks = stocks, area_group = c(IXa = 1)))
+    ok(ut_cmp_identical(out, structure(
+        array(0, dim = c(stock = 2L, time = 5L), dimnames = list(stock = c("imm", "mat"), time = c("1990", "1991", "1992", "1993", "1994"))),
+        stock_map = c(fish_imm_f = "imm", fish_imm_m = "imm", fish_mat_f = "mat", fish_mat_m = "mat") )), "Included stock map for stock column")
+
+    fleets <- list(
+       g3_fleet(c('comm', 'se')),
+       g3_fleet(c('comm', 'no')),
+       g3_fleet(c('surv')) )
+    dat <- expand.grid(year = 1990:1994, fleet = c("comm", "surv"), number = 0)
+    out <- drop(g3_distribution_preview(dat, fleets = fleets, area_group = c(IXa = 1)))
+    ok(ut_cmp_identical(out, structure(
+        array(0, dim = c(fleet = 2L, time = 5L), dimnames = list(fleet = c("comm", "surv"), time = c("1990", "1991", "1992", "1993", "1994"))),
+        fleet_map = c(comm_se = "comm", comm_no = "comm", surv = "surv") )), "Included fleet map for fleet column")
 })
 
 ok_group("g3l_distribution_sumofsquares", {

--- a/vignettes/incorporating-observation-data.Rmd
+++ b/vignettes/incorporating-observation-data.Rmd
@@ -311,24 +311,74 @@ year    stock    number
 
 The stock names have to match what gadget3 uses, or an error will be generated.
 
+You can also use partial stock names, for example:
+
+```{r}
+stocks <- list(
+   g3_stock(c(species = 'fish', 'imm', 'f'), 1:10),
+   g3_stock(c(species = 'fish', 'imm', 'm'), 1:10),
+   g3_stock(c(species = 'fish', 'mat', 'f'), 1:10),
+   g3_stock(c(species = 'fish', 'mat', 'm'), 1:10) )
+
+drop(g3_distribution_preview(read.table(header = TRUE, text="
+year    stock    number
+1999   imm   1000
+1999   mat   4305
+2000   imm   7034
+2000   mat   2381
+"), stocks = stocks))
+```
+
+The `imm` columns will compare to the sum of `fish_imm_f` & `fish_mat_f`.
+
+The parts do not have to be in order, the following is also valid:
+
+```{r}
+drop(g3_distribution_preview(read.table(header = TRUE, text="
+year    stock    number
+1999   fish_f   1000
+1999   fish_m   4305
+2000   fish_f   7034
+2000   fish_m   2381
+"), stocks = stocks))
+```
+
+*NB:* A stock can only appear in one grouping:
+
+```{r}
+# NB: Wrong!
+drop(g3_distribution_preview(read.table(header = TRUE, text="
+year    stock    number
+1999   f         1000
+1999   imm       4305
+2000   f         7034
+2000   imm       2381
+"), stocks = stocks))
+```
+
+`fish_imm_f` will only appear in the `f` rows, not `imm` rows.
+In this case, multiple likelhood components would be a better approach.
+
 As before, gaps in data are preserved, and ``missing_val`` is used to decide what to do with them.
 
 ### *fleet* column
 
 ```{r}
-f_comm <- g3_fleet('comm')
-f_surv <- g3_fleet('surv')
+fleets <- list(
+    g3_fleet(c('comm', country = 'se')),
+    g3_fleet(c('comm', country = 'fi')),
+    g3_fleet(c('surv', country = 'se')) )
 
 g3_distribution_preview(read.table(header = TRUE, text="
 year    fleet    number
-1999   f_comm   1000
-1999   f_surv   4305
-2000   f_comm   7034
-2000   f_surv   2381
-2001   f_surv   3913
-"), fleets = list(f_comm, f_surv))[length = '0:Inf',,]
+1999   comm      1000
+1999   surv_se   4305
+2000   comm      7034
+2000   surv_se   2381
+2001   surv_se   3913
+"), fleets = fleets)[length = '0:Inf',,]
 ```
 
-The stock names have to match what gadget3 uses, or an error will be generated.
+The name matching works in the same way as stocks above, and should be either the name gadget3 uses or parts of it.
 
 As before, gaps in data are preserved, and ``missing_val`` is used to decide what to do with them.

--- a/vignettes/incorporating-observation-data.Rmd
+++ b/vignettes/incorporating-observation-data.Rmd
@@ -32,7 +32,7 @@ Each run of a model will generate a likelihood score, by summing the result of a
 To fit a model to observation data, we need to add a *likelihood action* that will compare observation data to the model.
 
 To do this you either need `g3l_catchdistribution()` or `g3l_abundancedistribution()`.
-As the names suggest, `g3l_catchdistribution()` will compare catch data of stocks from the provided fleets,
+As the names suggest, `g3l_catchdistribution()` will compare catch data of stocks from the provided fleets/predators,
 `g3l_abundancedistribution()` will compare total abundance of stocks.
 Otherwise they are identical.
 
@@ -377,6 +377,28 @@ year    fleet    number
 2000   surv_se   2381
 2001   surv_se   3913
 "), fleets = fleets)[length = '0:Inf',,]
+```
+
+The name matching works in the same way as stocks above, and should be either the name gadget3 uses or parts of it.
+
+As before, gaps in data are preserved, and ``missing_val`` is used to decide what to do with them.
+
+### *predator* column
+
+```{r}
+predators <- list(
+    g3_stock(c('seal', 'imm', 'f'), 10:20),
+    g3_stock(c('seal', 'mat', 'f'), 10:20),
+    g3_stock(c('seal', 'imm', 'm'), 10:20),
+    g3_stock(c('seal', 'mat', 'm'), 10:20) )
+
+drop(g3_distribution_preview(read.table(header = TRUE, text="
+year    predator    number
+1999   seal_f   1000
+1999   seal_m   4305
+2000   seal_f   7034
+2000   seal_m   2381
+"), predators = predators))
 ```
 
 The name matching works in the same way as stocks above, and should be either the name gadget3 uses or parts of it.


### PR DESCRIPTION
Broadly, this does 2 things:

* name parts are now valid values in "stock" / "fleet" columns in likelihood components. So for stocks ``ghl_imm_m``, etc. you could use ``m``, ``ghl_f`` & ``imm`` to match males, females and immatures. These aren't regexes, so ``m`` won't match every stock with an m in it's name.
* Aliases so you can call predators a predator, not fleet. Due to argument ordering, you have to label all your arguments to ``g3l_catchdistribution()``, specifically ``function_f``, which wasn't labelled in examples before.

