### PR TITLE
Param help & other fixes

### DIFF
--- a/R/action_report.R
+++ b/R/action_report.R
@@ -157,7 +157,8 @@ g3a_report_history <- function (
 
 g3a_report_detail <- function (actions,
     # NB: We could in theory remove report_detail, but g3_fit looks for it in params
-    run_f = quote( g3_param('report_detail', optimise = FALSE, value = 1L) == 1 ),
+    run_f = quote( g3_param('report_detail', optimise = FALSE, value = 1L,
+        source = "g3a_report_detail") == 1 ),
     abundance_run_at = g3_action_order$report_early,
     run_at = g3_action_order$report) {
     c(

--- a/R/action_spawn.R
+++ b/R/action_spawn.R
@@ -1,7 +1,12 @@
-g3a_spawn_recruitment_fecundity <- function (p0, p1, p2, p3, p4) {
+g3a_spawn_recruitment_fecundity <- function (
+        p0 = g3_parameterized('spawn.p0', value = 1, by_stock = by_stock),
+        p1 = g3_parameterized('spawn.p1', value = 1, by_stock = by_stock),
+        p2 = g3_parameterized('spawn.p2', value = 1, by_stock = by_stock),
+        p3 = g3_parameterized('spawn.p3', value = 1, by_stock = by_stock),
+        p4 = g3_parameterized('spawn.p4', value = 1, by_stock = by_stock),
+        by_stock = TRUE ) {
     subs <- list(p0 = p0, p1 = p1, p2 = p2, p3 = p3, p4 = p4)
 
-    # NB: ricker is calculated over an entire area, so divide up so each age/length spawn equally.
     list(
         s = f_substitute(~sum(
                 stock__midlen ^ p1 *
@@ -11,7 +16,9 @@ g3a_spawn_recruitment_fecundity <- function (p0, p1, p2, p3, p4) {
         r = f_substitute(~p0 * s, subs))
 }
 
-g3a_spawn_recruitment_simplessb <- function (mu) {
+g3a_spawn_recruitment_simplessb <- function (
+        mu = g3_parameterized('spawn.mu', by_stock = by_stock),
+        by_stock = TRUE ) {
     # NB: simplessb is calculated over an entire area, so divide up so each age/length spawn equally.
     list(
         s = ~sum(stock_ss(stock__wgt) * stock_ss(stock__spawningnum)),
@@ -21,7 +28,10 @@ g3a_spawn_recruitment_simplessb <- function (mu) {
 
 # https://github.com/gadget-framework/gadget-course/blob/master/stock_interactions.Rmd#L81
 # SpawnData::calcRecruitNumber() line 466
-g3a_spawn_recruitment_ricker <- function (mu, lambda) {
+g3a_spawn_recruitment_ricker <- function (
+        mu = g3_parameterized('spawn.mu', by_stock = by_stock),
+        lambda = g3_parameterized('spawn.lambda', by_stock = by_stock),
+        by_stock = TRUE ) {
     # NB: ricker is calculated over an entire area, so divide up so each age/length spawn equally.
     list(
         s = ~sum(stock_ss(stock__wgt) * stock_ss(stock__spawningnum)),
@@ -30,7 +40,10 @@ g3a_spawn_recruitment_ricker <- function (mu, lambda) {
             lambda = lambda)))
 }
 
-g3a_spawn_recruitment_bevertonholt <- function (mu, lambda) {
+g3a_spawn_recruitment_bevertonholt <- function (
+        mu = g3_parameterized('spawn.mu', by_stock = by_stock),
+        lambda = g3_parameterized('spawn.lambda', by_stock = by_stock),
+        by_stock = TRUE ) {
     # NB: bevertonholt is calculated over an entire area, so divide up so each age/length spawn equally.
     list(
         s = ~sum(stock_ss(stock__wgt) * stock_ss(stock__spawningnum)),
@@ -42,22 +55,25 @@ g3a_spawn_recruitment_bevertonholt <- function (mu, lambda) {
 # https://nmfs-ost.github.io/ss3-doc/SS330_User_Manual_release.html#beverton-holt
 g3a_spawn_recruitment_bevertonholt_ss3 <- function (
         # Steepness parameter
-        h = g3_parameterized('srr_h', lower = 0.1, upper = 1, value = 0.5,
+        h = g3_parameterized('spawn.h', lower = 0.1, upper = 1, value = 0.5,
             by_stock = by_stock ),
         # Recruitment deviates
-        R = g3_parameterized('R', by_year = TRUE, exponentiate = TRUE,
+        R = g3_parameterized('spawn.R', by_year = TRUE, exponentiate = TRUE,
             # Unfished equilibrium recruitment
-            scale = "R0",
+            scale = "spawn.R0",
             by_stock = by_stock),
         # Unfished equilibrium spawning biomass (corresponding to R0)
-        B0 = g3_parameterized('B0', by_stock = by_stock),
+        B0 = g3_parameterized('spawn.B0', by_stock = by_stock),
         by_stock = TRUE ) {
     list(
         s = ~sum(stock_ss(stock__wgt) * stock_ss(stock__spawningnum)),
         r = ~ 4 * h * s * R / (B0 * (1 - h) + s * (5 * h - 1)) )
 }
 
-g3a_spawn_recruitment_hockeystick <- function (r0, blim) {
+g3a_spawn_recruitment_hockeystick <- function (
+        r0 = g3_parameterized('spawn.r0', by_stock = by_stock),
+        blim = g3_parameterized('spawn.blim', value = 1, by_stock = by_stock),
+        by_stock = TRUE ) {
     # NB: hockeystick is calculated over an entire area, so divide up so each age/length spawn equally.
     list(
         s = ~sum(stock_ss(stock__wgt) * stock_ss(stock__spawningnum)),

--- a/R/likelihood_distribution.R
+++ b/R/likelihood_distribution.R
@@ -184,9 +184,8 @@ g3l_distribution <- function (
         area_group = NULL,
         report = FALSE,
         nll_breakdown = FALSE,
-        weight = substitute(
-            g3_param(n, optimise = FALSE, value = 1),
-            list(n = paste0(nll_name, "_weight"))),
+        weight = g3_parameterized(paste0(nll_name, "_weight"),
+            optimise = FALSE, value = 1),
         run_at = g3_action_order$likelihood) {
     stopifnot(is.character(nll_name) && length(nll_name) == 1)
     stopifnot(is.data.frame(obs_data))

--- a/R/likelihood_random.R
+++ b/R/likelihood_random.R
@@ -19,9 +19,8 @@ g3l_random_dnorm <- function (
         log_f = TRUE,
         period = 'auto',
         nll_breakdown = FALSE,
-        weight = substitute(
-            g3_param(n, optimise = FALSE, value = 1),
-            list(n = paste0(nll_name, "_weight"))),
+        weight = g3_parameterized(paste0(nll_name, "_weight"),
+            optimise = FALSE, value = 1),
         run_at = g3_action_order$likelihood) {
     stopifnot(period %in% c('year', 'step', 'single', 'auto'))
     stopifnot(is.logical(log_f))
@@ -67,9 +66,8 @@ g3l_random_walk <- function (
         log_f = TRUE,
         period = 'auto',
         nll_breakdown = FALSE,
-        weight = substitute(
-            g3_param(n, optimise = FALSE, value = 1),
-            list(n = paste0(nll_name, "_weight"))),
+        weight = g3_parameterized(paste0(nll_name, "_weight"),
+            optimise = FALSE, value = 1),
         run_at = g3_action_order$likelihood) {
     stopifnot(period %in% c('year', 'step', 'single', 'auto'))
     stopifnot(is.logical(log_f))

--- a/R/likelihood_tagging_ckmr.R
+++ b/R/likelihood_tagging_ckmr.R
@@ -4,7 +4,8 @@ g3l_tagging_ckmr <- function (
         fleets,
         parent_stocks,
         offspring_stocks,
-        weight = substitute(g3_param(n, optimise = FALSE, value = 1), list(n = paste0(nll_name, "_weight"))),
+        weight = g3_parameterized(paste0(nll_name, "_weight"),
+            optimise = FALSE, value = 1),
         run_at = g3_action_order$likelihood) {
     stopifnot(is.character(nll_name))
     stopifnot(is.list(fleets) && all(sapply(fleets, g3_is_stock)))

--- a/R/run_r.R
+++ b/R/run_r.R
@@ -200,7 +200,7 @@ g3_to_r <- function(
     }
 
     # Wrap all steps in a function call
-    out <- call("function", pairlist(param = alist(y=)$y), as.call(c(
+    out <- call("function", pairlist(param = quote( attr(get(sys.call()[[1]]), "parameter_template") )), as.call(c(
         list(as.symbol(open_curly_bracket)),
         scope,
         all_actions_code )))

--- a/R/run_tmb.R
+++ b/R/run_tmb.R
@@ -698,6 +698,7 @@ g3_to_tmb <- function(actions, trace = FALSE, strict = FALSE) {
                 lower <- as.numeric(find_arg('lower', NA))
                 upper <- as.numeric(find_arg('upper', NA))
                 parscale <- as.numeric(find_arg('parscale', NA))
+                source <- as.character(find_arg('source', as.character(NA)))
 
                 data.frame(
                     switch = name,  # NB: This should be pre-C++ mangling
@@ -711,6 +712,7 @@ g3_to_tmb <- function(actions, trace = FALSE, strict = FALSE) {
                     lower = if (dims[[1]] > 0) lower else numeric(0),
                     upper = if (dims[[1]] > 0) upper else numeric(0),
                     parscale = if (dims[[1]] > 0) parscale else numeric(0),
+                    source = if (dims[[1]] > 0) source else as.character(NA),
                     row.names = name,
                     stringsAsFactors = FALSE)
             }

--- a/R/run_tmb.R
+++ b/R/run_tmb.R
@@ -904,6 +904,7 @@ g3_to_tmb <- function(actions, trace = FALSE, strict = FALSE) {
                         c('vector<Type>' = 'DATA_VECTOR', 'vector<int>' = 'DATA_IVECTOR',
                           'array<Type>' = 'DATA_ARRAY', 'array<int>' = 'DATA_IARRAY')[[cpp_type]],
                         '(', cpp_escape_varname(var_name) , ')')
+                    attr(var_val, "desc") <- NULL  # The desc break's TMB's type detection
                     assign(cpp_escape_varname(var_name), hide_force_vector(var_val), envir = model_data)
                 } else if (is.numeric(var_val[[1]]) && var_val[[1]] == 0) {  # NB: FALSE == 0
                     defn <- paste0(defn, " ", cpp_escape_varname(var_name), ".setZero();")

--- a/R/run_tmb.R
+++ b/R/run_tmb.R
@@ -349,9 +349,14 @@ cpp_code <- function(in_call, in_envir, indent = "\n    ", statement = FALSE, ex
             "(", paste(inds, collapse=","), ")"))
     }
 
-    if (call_name %in% c('break', 'next')) {
+    if (call_name %in% c('break')) {
         # Flow-control
         return(call_name)
+    }
+
+    if (call_name %in% c('next')) {
+        # Flow-control
+        return("continue")
     }
 
     if (call_name %in% c('return')) {

--- a/R/stock.R
+++ b/R/stock.R
@@ -15,21 +15,24 @@ stock_definition <- function(...) {
 g3_stock_instance <- function (stock, init_value = NA, desc = "") {
     if (length(stock$dim) == 0) {
         # No dimensions mean a 1-entry array
-        return(array(init_value, dim = (1)))
-    }
-    # TODO: Don't make it yet, defer until g3 needs it
-    if (all(is.numeric(stock$dim))) {
-        return(array(init_value, dim = stock$dim, dimnames = stock$dimnames))
-    }
-
-    # Filter any dynamic dimensions, and set them to 1 initially
-    use_dynamic_dim <- FALSE
-    init_dim <- vapply(stock$dim, function (x) if (is.call(x) || is.symbol(x)) {use_dynamic_dim <<- TRUE; 1L} else as.integer(x), integer(1))
-    init_dimnames <- lapply(stock$dimnames, function (x) if (is.call(x) || is.symbol(x)) {use_dynamic_dim <<- TRUE; NULL} else x)
-    x <- array(init_value, dim = init_dim, dimnames = init_dimnames)
-    if (use_dynamic_dim) {
-        attr(x, 'dynamic_dim') <- stock$dim
-        attr(x, 'dynamic_dimnames') <- stock$dimnames
+        x <- array(init_value, dim = (1))
+    } else if (all(is.numeric(stock$dim))) {
+        # TODO: Don't make it yet, defer until g3 needs it
+        x <- array(init_value, dim = stock$dim, dimnames = stock$dimnames)
+    } else {
+        # Filter any dynamic dimensions, and set them to 1 initially
+        use_dynamic_dim <- FALSE
+        init_dim <- vapply(stock$dim, function (x) {
+            if (is.call(x) || is.symbol(x)) { use_dynamic_dim <<- TRUE; 1L } else as.integer(x)
+        }, integer(1))
+        init_dimnames <- lapply(stock$dimnames, function (x) {
+            if (is.call(x) || is.symbol(x)) { use_dynamic_dim <<- TRUE; NULL } else x
+        })
+        x <- array(init_value, dim = init_dim, dimnames = init_dimnames)
+        if (use_dynamic_dim) {
+            attr(x, 'dynamic_dim') <- stock$dim
+            attr(x, 'dynamic_dimnames') <- stock$dimnames
+        }
     }
     if (nzchar(desc)) {
         attr(x, 'desc') <- desc

--- a/R/stock.R
+++ b/R/stock.R
@@ -123,10 +123,14 @@ g3s_length <- function(inner_stock, lengthgroups, open_ended = TRUE, plus_dl = N
         iter_ss = c(inner_stock$iter_ss, length = as.symbol("stock__length_idx")),
         intersect = c(inner_stock$intersect, length = quote(
                 for (stock__length_idx in seq_along(stock__minlen)) {
-                    if (stock__minlen[[stock__length_idx]] <= length &&
-                            length < stock__maxlen[[stock__length_idx]]) {
-                        extension_point
-                        break
+                    if (stock_isdefined(length)) {
+                        if (stock__minlen[[stock__length_idx]] <= length &&
+                                length < stock__maxlen[[stock__length_idx]]) {
+                            extension_point
+                            break
+                        }
+                    } else {
+                        g3_with(length := stock__midlen[[stock__length_idx]], extension_point)
                     }
                 }
             )),

--- a/R/stock_age.R
+++ b/R/stock_age.R
@@ -26,9 +26,13 @@ g3s_age <- function(inner_stock, minage, maxage) {
             )),
         iter_ss = c(inner_stock$iter_ss, age = as.symbol("stock__age_idx")),
         intersect = c(inner_stock$intersect, age = quote(
-            if (age >= stock__minage && age <= stock__maxage) g3_with(
-                stock__age_idx := g3_idx(age - stock__minage + 1L), extension_point)
-            )),
+            if (stock_isdefined(age)) {
+                if (age >= stock__minage && age <= stock__maxage) g3_with(
+                    stock__age_idx := g3_idx(age - stock__minage + 1L), extension_point)
+            } else {
+                for (age in seq(stock__minage, stock__maxage, by = 1)) g3_with(
+                    stock__age_idx := g3_idx(age - stock__minage + 1L), extension_point)
+            } )),
         interact = c(inner_stock$interact, age = quote(
                 for (interactvar_age in seq(stock__minage, stock__maxage, by = 1)) g3_with(
                     stock__age_idx := g3_idx(interactvar_age - stock__minage + 1L), extension_point)
@@ -73,10 +77,14 @@ g3s_agegroup <- function(inner_stock, agegroups) {
         )),
         iter_ss = c(inner_stock$iter_ss, age = as.symbol("stock__agegroup_idx")),
         intersect = c(inner_stock$intersect, age = substitute(
-            g3_with(
-                stock__agegroup_idx := g3_idx(lookup_code),
-                if (stock__agegroup_idx > g3_idx(-1L)) extension_point),
-            list(lookup_code = rlang::f_rhs(lookup_f)))),
+            if (stock_isdefined(age)) {
+                g3_with(
+                    stock__agegroup_idx := g3_idx(lookup_code),
+                    if (stock__agegroup_idx > g3_idx(-1L)) extension_point)
+            } else {
+                for (stock__agegroup_idx in seq_along(stock__minages)) g3_with(
+                    interactvar_age := stock__minages[[stock__agegroup_idx]], extension_point)
+            }, list(lookup_code = rlang::f_rhs(lookup_f)) )),
         interact = c(inner_stock$interact, age = quote(
             for (stock__agegroup_idx in seq_along(stock__minages)) g3_with(
                 interactvar_age := stock__minages[[stock__agegroup_idx]], extension_point)

--- a/R/stock_areas.R
+++ b/R/stock_areas.R
@@ -37,9 +37,16 @@ g3s_livesonareas <- function(inner_stock, areas) {
                     extension_point)
             )),
             intersect = c(inner_stock$intersect, area = quote(
-                 if (area == stock__area) g3_with(
-                     stock__area_idx := g3_idx(1L),
-                     extension_point)
+                if (stock_isdefined(area)) {
+                     if (area == stock__area) g3_with(
+                         stock__area_idx := g3_idx(1L),
+                         extension_point)
+                } else {
+                    g3_with(
+                        area := stock__area,
+                        stock__area_idx := g3_idx(1L),
+                        extension_point)
+                }
             )),
             interact = c(inner_stock$interact, area = quote(
                 if (area == stock__area) g3_with(
@@ -68,11 +75,17 @@ g3s_livesonareas <- function(inner_stock, areas) {
                     extension_point)
             )),
             intersect = c(inner_stock$intersect, area = quote(
-                for (stock__area_idx in seq_along(stock__areas)) {
-                    if (stock__areas[[stock__area_idx]] == area) {
-                        extension_point
-                        break
+                if (stock_isdefined(area)) {
+                    for (stock__area_idx in seq_along(stock__areas)) {
+                        if (stock__areas[[stock__area_idx]] == area) {
+                            extension_point
+                            break
+                        }
                     }
+                } else {
+                    for (stock__area_idx in seq_along(stock__areas)) g3_with(
+                        area := stock__areas[[stock__area_idx]],
+                        extension_point)
                 }
             )),
             interact = c(inner_stock$interact, area = quote(
@@ -123,9 +136,14 @@ g3s_areagroup <- function(inner_stock, areagroups) {
         )),
         iter_ss = c(inner_stock$iter_ss, area = as.symbol("stock__areagroup_idx")),
         intersect = c(inner_stock$intersect, area = substitute(
-            g3_with(
-                stock__areagroup_idx := g3_idx(lookup_code),
-                if (stock__areagroup_idx > g3_idx(-1L)) extension_point),
+            if (stock_isdefined(area)) {
+                g3_with(
+                    stock__areagroup_idx := g3_idx(lookup_code),
+                    if (stock__areagroup_idx > g3_idx(-1L)) extension_point)
+            } else {
+                for (stock__areagroup_idx in seq_along(stock__minareas)) g3_with(
+                    area := stock__minareas[[stock__areagroup_idx]], extension_point)
+            },
             list(lookup_code = rlang::f_rhs(lookup_f)))),
         interact = c(inner_stock$interact, area = substitute(
             g3_with(

--- a/R/stock_tag.R
+++ b/R/stock_tag.R
@@ -31,11 +31,16 @@ g3s_tag <- function(inner_stock, tag_ids, force_untagged = TRUE) {
         iter_ss = c(inner_stock$iter_ss,
             tag = as.symbol("stock__tag_idx")),
         intersect = c(inner_stock$intersect, tag = quote(
-            for (stock__tag_idx in seq_along(stock__tag_ids)) {
-                if (stock__tag_ids[[stock__tag_idx]] == tag) {
-                    extension_point
-                    break
+            if (stock_isdefined(tag)) {
+                for (stock__tag_idx in seq_along(stock__tag_ids)) {
+                    if (stock__tag_ids[[stock__tag_idx]] == tag) {
+                        extension_point
+                        break
+                    }
                 }
+            } else {
+                for (stock__tag_idx in seq_along(stock__tag_ids)) g3_with(
+                    tag := stock__tag_ids[[stock__tag_idx]], extension_point)
             }
         )),
         interact = c(inner_stock$interact, tag = quote(

--- a/baseline/multiple-substocks.cpp
+++ b/baseline/multiple-substocks.cpp
@@ -1050,16 +1050,18 @@ Type objective_function<Type>::operator() () {
 
                 auto fish_mat__area_idx = 0;
 
-                if ( area == fish_imm__area ) {
+                {
                     auto fish_imm__age_idx = age - fish_imm__minage + 1 - 1;
 
-                    auto fish_imm__area_idx = 0;
+                    if ( area == fish_imm__area ) {
+                        auto fish_imm__area_idx = 0;
 
-                    {
-                        fish_mat__wgt.col(fish_mat__age_idx).col(fish_mat__area_idx) = (fish_mat__wgt.col(fish_mat__age_idx).col(fish_mat__area_idx)*fish_mat__num.col(fish_mat__age_idx).col(fish_mat__area_idx)) + fish_imm__transitioning_wgt.col(fish_imm__age_idx).col(fish_imm__area_idx)*fish_imm__transitioning_num.col(fish_imm__age_idx).col(fish_imm__area_idx);
-                        fish_mat__num.col(fish_mat__age_idx).col(fish_mat__area_idx) += fish_imm__transitioning_num.col(fish_imm__age_idx).col(fish_imm__area_idx);
-                        fish_imm__transitioning_num.col(fish_imm__age_idx).col(fish_imm__area_idx) -= fish_imm__transitioning_num.col(fish_imm__age_idx).col(fish_imm__area_idx);
-                        fish_mat__wgt.col(fish_mat__age_idx).col(fish_mat__area_idx) /= avoid_zero_vec(fish_mat__num.col(fish_mat__age_idx).col(fish_mat__area_idx));
+                        {
+                            fish_mat__wgt.col(fish_mat__age_idx).col(fish_mat__area_idx) = (fish_mat__wgt.col(fish_mat__age_idx).col(fish_mat__area_idx)*fish_mat__num.col(fish_mat__age_idx).col(fish_mat__area_idx)) + fish_imm__transitioning_wgt.col(fish_imm__age_idx).col(fish_imm__area_idx)*fish_imm__transitioning_num.col(fish_imm__age_idx).col(fish_imm__area_idx);
+                            fish_mat__num.col(fish_mat__age_idx).col(fish_mat__area_idx) += fish_imm__transitioning_num.col(fish_imm__age_idx).col(fish_imm__area_idx);
+                            fish_imm__transitioning_num.col(fish_imm__age_idx).col(fish_imm__area_idx) -= fish_imm__transitioning_num.col(fish_imm__age_idx).col(fish_imm__area_idx);
+                            fish_mat__wgt.col(fish_mat__age_idx).col(fish_mat__area_idx) /= avoid_zero_vec(fish_mat__num.col(fish_mat__age_idx).col(fish_mat__area_idx));
+                        }
                     }
                 }
             }
@@ -1996,11 +1998,11 @@ Type objective_function<Type>::operator() () {
 
                 auto fish_mat__area_idx = 0;
 
-                if ( area == fish_imm_movement__area ) {
-                    if ( cur_step_final ) {
-                        auto fish_imm_movement__age_idx = age - fish_imm_movement__minage + 1 - 1;
+                {
+                    auto fish_imm_movement__age_idx = age - fish_imm_movement__minage + 1 - 1;
 
-                        {
+                    if ( area == fish_imm_movement__area ) {
+                        if ( cur_step_final ) {
                             auto fish_imm_movement__area_idx = 0;
 
                             {

--- a/inttest/codegeneration-defaults/model.R
+++ b/inttest/codegeneration-defaults/model.R
@@ -1,4 +1,4 @@
-structure(function (param) 
+structure(function (param = attr(get(sys.call()[[1]]), "parameter_template")) 
 {
     stopifnot("retro_years" %in% names(param))
     stopifnot("fish.Linf" %in% names(param))

--- a/inttest/codegeneration-defaults/model.R
+++ b/inttest/codegeneration-defaults/model.R
@@ -529,15 +529,17 @@ structure(function (param)
                 if (cdist_sumofsquares_comm_ldist_model__time_idx >= (1L)) 
                   if (area == cdist_sumofsquares_comm_ldist_obs__area) {
                     cdist_sumofsquares_comm_ldist_model__sstotal <- avoid_zero(sum(cdist_sumofsquares_comm_ldist_model__wgt[, cdist_sumofsquares_comm_ldist_model__time_idx, cdist_sumofsquares_comm_ldist_model__area_idx]))
-                    cdist_sumofsquares_comm_ldist_obs__area_idx <- (1L)
-                    cdist_sumofsquares_comm_ldist_obs__time_idx <- intlookup_getdefault(cdist_sumofsquares_comm_ldist_obs__times, (cur_year * 100L + cur_step * 0L), -1L)
-                    if (cdist_sumofsquares_comm_ldist_obs__time_idx >= (1L)) {
-                      cdist_sumofsquares_comm_ldist_obs__sstotal <- avoid_zero(sum(cdist_sumofsquares_comm_ldist_obs__wgt[, cdist_sumofsquares_comm_ldist_obs__time_idx, cdist_sumofsquares_comm_ldist_obs__area_idx]))
-                      cur_cdist_nll <- sum((((cdist_sumofsquares_comm_ldist_model__wgt[, cdist_sumofsquares_comm_ldist_model__time_idx, cdist_sumofsquares_comm_ldist_model__area_idx]/cdist_sumofsquares_comm_ldist_model__sstotal) - (cdist_sumofsquares_comm_ldist_obs__wgt[, cdist_sumofsquares_comm_ldist_obs__time_idx, cdist_sumofsquares_comm_ldist_obs__area_idx]/cdist_sumofsquares_comm_ldist_obs__sstotal))^2))
-                      {
-                        nll <- nll + param[["cdist_sumofsquares_comm_ldist_weight"]] * cur_cdist_nll
-                        nll_cdist_sumofsquares_comm_ldist__wgt[cur_time + 1L] <- nll_cdist_sumofsquares_comm_ldist__wgt[cur_time + 1L] + cur_cdist_nll
-                        nll_cdist_sumofsquares_comm_ldist__weight[cur_time + 1L] <- param[["cdist_sumofsquares_comm_ldist_weight"]]
+                    {
+                      cdist_sumofsquares_comm_ldist_obs__area_idx <- (1L)
+                      cdist_sumofsquares_comm_ldist_obs__time_idx <- intlookup_getdefault(cdist_sumofsquares_comm_ldist_obs__times, (cur_year * 100L + cur_step * 0L), -1L)
+                      if (cdist_sumofsquares_comm_ldist_obs__time_idx >= (1L)) {
+                        cdist_sumofsquares_comm_ldist_obs__sstotal <- avoid_zero(sum(cdist_sumofsquares_comm_ldist_obs__wgt[, cdist_sumofsquares_comm_ldist_obs__time_idx, cdist_sumofsquares_comm_ldist_obs__area_idx]))
+                        cur_cdist_nll <- sum((((cdist_sumofsquares_comm_ldist_model__wgt[, cdist_sumofsquares_comm_ldist_model__time_idx, cdist_sumofsquares_comm_ldist_model__area_idx]/cdist_sumofsquares_comm_ldist_model__sstotal) - (cdist_sumofsquares_comm_ldist_obs__wgt[, cdist_sumofsquares_comm_ldist_obs__time_idx, cdist_sumofsquares_comm_ldist_obs__area_idx]/cdist_sumofsquares_comm_ldist_obs__sstotal))^2))
+                        {
+                          nll <- nll + param[["cdist_sumofsquares_comm_ldist_weight"]] * cur_cdist_nll
+                          nll_cdist_sumofsquares_comm_ldist__wgt[cur_time + 1L] <- nll_cdist_sumofsquares_comm_ldist__wgt[cur_time + 1L] + cur_cdist_nll
+                          nll_cdist_sumofsquares_comm_ldist__weight[cur_time + 1L] <- param[["cdist_sumofsquares_comm_ldist_weight"]]
+                        }
                       }
                     }
                   }

--- a/inttest/codegeneration-defaults/model.cpp
+++ b/inttest/codegeneration-defaults/model.cpp
@@ -659,19 +659,21 @@ Type objective_function<Type>::operator() () {
                     if ( area == cdist_sumofsquares_comm_ldist_obs__area ) {
                         auto cdist_sumofsquares_comm_ldist_model__sstotal = avoid_zero((cdist_sumofsquares_comm_ldist_model__wgt.col(cdist_sumofsquares_comm_ldist_model__area_idx).col(cdist_sumofsquares_comm_ldist_model__time_idx)).sum());
 
-                        auto cdist_sumofsquares_comm_ldist_obs__area_idx = 0;
+                        {
+                            auto cdist_sumofsquares_comm_ldist_obs__area_idx = 0;
 
-                        auto cdist_sumofsquares_comm_ldist_obs__time_idx = intlookup_getdefault(cdist_sumofsquares_comm_ldist_obs__times, (cur_year*100 + cur_step*0), -1) - 1;
+                            auto cdist_sumofsquares_comm_ldist_obs__time_idx = intlookup_getdefault(cdist_sumofsquares_comm_ldist_obs__times, (cur_year*100 + cur_step*0), -1) - 1;
 
-                        if ( cdist_sumofsquares_comm_ldist_obs__time_idx >= 0 ) {
-                            auto cdist_sumofsquares_comm_ldist_obs__sstotal = avoid_zero((cdist_sumofsquares_comm_ldist_obs__wgt.col(cdist_sumofsquares_comm_ldist_obs__area_idx).col(cdist_sumofsquares_comm_ldist_obs__time_idx)).sum());
+                            if ( cdist_sumofsquares_comm_ldist_obs__time_idx >= 0 ) {
+                                auto cdist_sumofsquares_comm_ldist_obs__sstotal = avoid_zero((cdist_sumofsquares_comm_ldist_obs__wgt.col(cdist_sumofsquares_comm_ldist_obs__area_idx).col(cdist_sumofsquares_comm_ldist_obs__time_idx)).sum());
 
-                            auto cur_cdist_nll = ((pow(((cdist_sumofsquares_comm_ldist_model__wgt.col(cdist_sumofsquares_comm_ldist_model__area_idx).col(cdist_sumofsquares_comm_ldist_model__time_idx) / cdist_sumofsquares_comm_ldist_model__sstotal) - (cdist_sumofsquares_comm_ldist_obs__wgt.col(cdist_sumofsquares_comm_ldist_obs__area_idx).col(cdist_sumofsquares_comm_ldist_obs__time_idx) / cdist_sumofsquares_comm_ldist_obs__sstotal)), (Type)(double)(2)))).sum();
+                                auto cur_cdist_nll = ((pow(((cdist_sumofsquares_comm_ldist_model__wgt.col(cdist_sumofsquares_comm_ldist_model__area_idx).col(cdist_sumofsquares_comm_ldist_model__time_idx) / cdist_sumofsquares_comm_ldist_model__sstotal) - (cdist_sumofsquares_comm_ldist_obs__wgt.col(cdist_sumofsquares_comm_ldist_obs__area_idx).col(cdist_sumofsquares_comm_ldist_obs__time_idx) / cdist_sumofsquares_comm_ldist_obs__sstotal)), (Type)(double)(2)))).sum();
 
-                            {
-                                nll += cdist_sumofsquares_comm_ldist_weight*cur_cdist_nll;
-                                nll_cdist_sumofsquares_comm_ldist__wgt(cur_time + 1 - 1) += cur_cdist_nll;
-                                nll_cdist_sumofsquares_comm_ldist__weight(cur_time + 1 - 1) = cdist_sumofsquares_comm_ldist_weight;
+                                {
+                                    nll += cdist_sumofsquares_comm_ldist_weight*cur_cdist_nll;
+                                    nll_cdist_sumofsquares_comm_ldist__wgt(cur_time + 1 - 1) += cur_cdist_nll;
+                                    nll_cdist_sumofsquares_comm_ldist__weight(cur_time + 1 - 1) = cdist_sumofsquares_comm_ldist_weight;
+                                }
                             }
                         }
                     }

--- a/inttest/codegeneration-defaults/model.tmbparam
+++ b/inttest/codegeneration-defaults/model.tmbparam
@@ -1,50 +1,50 @@
-                                                                                   switch type value optimise random lower upper parscale
-retro_years                                                                   retro_years          0    FALSE  FALSE    NA    NA       NA
-fish.Linf                                                                       fish.Linf          1     TRUE  FALSE    NA    NA       NA
-fish.K                                                                             fish.K          1     TRUE  FALSE    NA    NA       NA
-fish.t0                                                                           fish.t0          0     TRUE  FALSE    NA    NA       NA
-fish.lencv                                                                     fish.lencv        0.1    FALSE  FALSE    NA    NA       NA
-fish.init.scalar                                                         fish.init.scalar          1     TRUE  FALSE    NA    NA       NA
-fish.init.1                                                                   fish.init.1          1     TRUE  FALSE    NA    NA       NA
-fish.init.2                                                                   fish.init.2          1     TRUE  FALSE    NA    NA       NA
-fish.init.3                                                                   fish.init.3          1     TRUE  FALSE    NA    NA       NA
-fish.init.4                                                                   fish.init.4          1     TRUE  FALSE    NA    NA       NA
-fish.init.5                                                                   fish.init.5          1     TRUE  FALSE    NA    NA       NA
-fish.init.6                                                                   fish.init.6          1     TRUE  FALSE    NA    NA       NA
-fish.init.7                                                                   fish.init.7          1     TRUE  FALSE    NA    NA       NA
-fish.init.8                                                                   fish.init.8          1     TRUE  FALSE    NA    NA       NA
-fish.init.9                                                                   fish.init.9          1     TRUE  FALSE    NA    NA       NA
-fish.init.10                                                                 fish.init.10          1     TRUE  FALSE    NA    NA       NA
-fish.M.1                                                                         fish.M.1          0     TRUE  FALSE    NA    NA       NA
-fish.M.2                                                                         fish.M.2          0     TRUE  FALSE    NA    NA       NA
-fish.M.3                                                                         fish.M.3          0     TRUE  FALSE    NA    NA       NA
-fish.M.4                                                                         fish.M.4          0     TRUE  FALSE    NA    NA       NA
-fish.M.5                                                                         fish.M.5          0     TRUE  FALSE    NA    NA       NA
-fish.M.6                                                                         fish.M.6          0     TRUE  FALSE    NA    NA       NA
-fish.M.7                                                                         fish.M.7          0     TRUE  FALSE    NA    NA       NA
-fish.M.8                                                                         fish.M.8          0     TRUE  FALSE    NA    NA       NA
-fish.M.9                                                                         fish.M.9          0     TRUE  FALSE    NA    NA       NA
-fish.M.10                                                                       fish.M.10          0     TRUE  FALSE    NA    NA       NA
-init.F                                                                             init.F          0     TRUE  FALSE    NA    NA       NA
-recage                                                                             recage          0    FALSE  FALSE    NA    NA       NA
-fish.walpha                                                                   fish.walpha          0     TRUE  FALSE    NA    NA       NA
-fish.wbeta                                                                     fish.wbeta          0     TRUE  FALSE    NA    NA       NA
-report_detail                                                               report_detail          0    FALSE  FALSE    NA    NA       NA
-fish.comm.alpha                                                           fish.comm.alpha          0     TRUE  FALSE    NA    NA       NA
-fish.comm.l50                                                               fish.comm.l50          0     TRUE  FALSE    NA    NA       NA
-fish.bbin                                                                       fish.bbin          0     TRUE  FALSE    NA    NA       NA
-fish.rec.1990                                                               fish.rec.1990          0     TRUE  FALSE    NA    NA       NA
-fish.rec.1991                                                               fish.rec.1991          0     TRUE  FALSE    NA    NA       NA
-fish.rec.1992                                                               fish.rec.1992          0     TRUE  FALSE    NA    NA       NA
-fish.rec.1993                                                               fish.rec.1993          0     TRUE  FALSE    NA    NA       NA
-fish.rec.1994                                                               fish.rec.1994          0     TRUE  FALSE    NA    NA       NA
-fish.rec.1995                                                               fish.rec.1995          0     TRUE  FALSE    NA    NA       NA
-fish.rec.1996                                                               fish.rec.1996          0     TRUE  FALSE    NA    NA       NA
-fish.rec.1997                                                               fish.rec.1997          0     TRUE  FALSE    NA    NA       NA
-fish.rec.1998                                                               fish.rec.1998          0     TRUE  FALSE    NA    NA       NA
-fish.rec.1999                                                               fish.rec.1999          0     TRUE  FALSE    NA    NA       NA
-fish.rec.2000                                                               fish.rec.2000          0     TRUE  FALSE    NA    NA       NA
-fish.rec.scalar                                                           fish.rec.scalar          0     TRUE  FALSE    NA    NA       NA
-adist_surveyindices_log_acoustic_dist_weight adist_surveyindices_log_acoustic_dist_weight          1    FALSE  FALSE    NA    NA       NA
-cdist_sumofsquares_comm_ldist_weight                 cdist_sumofsquares_comm_ldist_weight          1    FALSE  FALSE    NA    NA       NA
-project_years                                                               project_years          0    FALSE  FALSE    NA    NA       NA
+                                                                                   switch type value optimise random lower upper parscale                    source
+retro_years                                                                   retro_years          0    FALSE  FALSE    NA    NA       NA                  g3a_time
+fish.Linf                                                                       fish.Linf          1     TRUE  FALSE    NA    NA       NA       g3a_renewal_vonb_t0
+fish.K                                                                             fish.K          1     TRUE  FALSE    NA    NA       NA       g3a_renewal_vonb_t0
+fish.t0                                                                           fish.t0          0     TRUE  FALSE    NA    NA       NA       g3a_renewal_vonb_t0
+fish.lencv                                                                     fish.lencv        0.1    FALSE  FALSE    NA    NA       NA     g3a_renewal_len_dnorm
+fish.init.scalar                                                         fish.init.scalar          1     TRUE  FALSE    NA    NA       NA     g3a_renewal_initabund
+fish.init.1                                                                   fish.init.1          1     TRUE  FALSE    NA    NA       NA     g3a_renewal_initabund
+fish.init.2                                                                   fish.init.2          1     TRUE  FALSE    NA    NA       NA     g3a_renewal_initabund
+fish.init.3                                                                   fish.init.3          1     TRUE  FALSE    NA    NA       NA     g3a_renewal_initabund
+fish.init.4                                                                   fish.init.4          1     TRUE  FALSE    NA    NA       NA     g3a_renewal_initabund
+fish.init.5                                                                   fish.init.5          1     TRUE  FALSE    NA    NA       NA     g3a_renewal_initabund
+fish.init.6                                                                   fish.init.6          1     TRUE  FALSE    NA    NA       NA     g3a_renewal_initabund
+fish.init.7                                                                   fish.init.7          1     TRUE  FALSE    NA    NA       NA     g3a_renewal_initabund
+fish.init.8                                                                   fish.init.8          1     TRUE  FALSE    NA    NA       NA     g3a_renewal_initabund
+fish.init.9                                                                   fish.init.9          1     TRUE  FALSE    NA    NA       NA     g3a_renewal_initabund
+fish.init.10                                                                 fish.init.10          1     TRUE  FALSE    NA    NA       NA     g3a_renewal_initabund
+fish.M.1                                                                         fish.M.1          0     TRUE  FALSE    NA    NA       NA  g3a_naturalmortality_exp
+fish.M.2                                                                         fish.M.2          0     TRUE  FALSE    NA    NA       NA  g3a_naturalmortality_exp
+fish.M.3                                                                         fish.M.3          0     TRUE  FALSE    NA    NA       NA  g3a_naturalmortality_exp
+fish.M.4                                                                         fish.M.4          0     TRUE  FALSE    NA    NA       NA  g3a_naturalmortality_exp
+fish.M.5                                                                         fish.M.5          0     TRUE  FALSE    NA    NA       NA  g3a_naturalmortality_exp
+fish.M.6                                                                         fish.M.6          0     TRUE  FALSE    NA    NA       NA  g3a_naturalmortality_exp
+fish.M.7                                                                         fish.M.7          0     TRUE  FALSE    NA    NA       NA  g3a_naturalmortality_exp
+fish.M.8                                                                         fish.M.8          0     TRUE  FALSE    NA    NA       NA  g3a_naturalmortality_exp
+fish.M.9                                                                         fish.M.9          0     TRUE  FALSE    NA    NA       NA  g3a_naturalmortality_exp
+fish.M.10                                                                       fish.M.10          0     TRUE  FALSE    NA    NA       NA  g3a_naturalmortality_exp
+init.F                                                                             init.F          0     TRUE  FALSE    NA    NA       NA     g3a_renewal_initabund
+recage                                                                             recage          0    FALSE  FALSE    NA    NA       NA     g3a_renewal_initabund
+fish.walpha                                                                   fish.walpha          0     TRUE  FALSE    NA    NA       NA        g3a_renewal_wgt_wl
+fish.wbeta                                                                     fish.wbeta          0     TRUE  FALSE    NA    NA       NA        g3a_renewal_wgt_wl
+report_detail                                                               report_detail          0    FALSE  FALSE    NA    NA       NA         g3a_report_detail
+fish.comm.alpha                                                           fish.comm.alpha          0     TRUE  FALSE    NA    NA       NA               g3a_predate
+fish.comm.l50                                                               fish.comm.l50          0     TRUE  FALSE    NA    NA       NA               g3a_predate
+fish.bbin                                                                       fish.bbin          0     TRUE  FALSE    NA    NA       NA      g3a_grow_impl_bbinom
+fish.rec.1990                                                               fish.rec.1990          0     TRUE  FALSE    NA    NA       NA     g3a_renewal_len_dnorm
+fish.rec.1991                                                               fish.rec.1991          0     TRUE  FALSE    NA    NA       NA     g3a_renewal_len_dnorm
+fish.rec.1992                                                               fish.rec.1992          0     TRUE  FALSE    NA    NA       NA     g3a_renewal_len_dnorm
+fish.rec.1993                                                               fish.rec.1993          0     TRUE  FALSE    NA    NA       NA     g3a_renewal_len_dnorm
+fish.rec.1994                                                               fish.rec.1994          0     TRUE  FALSE    NA    NA       NA     g3a_renewal_len_dnorm
+fish.rec.1995                                                               fish.rec.1995          0     TRUE  FALSE    NA    NA       NA     g3a_renewal_len_dnorm
+fish.rec.1996                                                               fish.rec.1996          0     TRUE  FALSE    NA    NA       NA     g3a_renewal_len_dnorm
+fish.rec.1997                                                               fish.rec.1997          0     TRUE  FALSE    NA    NA       NA     g3a_renewal_len_dnorm
+fish.rec.1998                                                               fish.rec.1998          0     TRUE  FALSE    NA    NA       NA     g3a_renewal_len_dnorm
+fish.rec.1999                                                               fish.rec.1999          0     TRUE  FALSE    NA    NA       NA     g3a_renewal_len_dnorm
+fish.rec.2000                                                               fish.rec.2000          0     TRUE  FALSE    NA    NA       NA     g3a_renewal_len_dnorm
+fish.rec.scalar                                                           fish.rec.scalar          0     TRUE  FALSE    NA    NA       NA     g3a_renewal_len_dnorm
+adist_surveyindices_log_acoustic_dist_weight adist_surveyindices_log_acoustic_dist_weight          1    FALSE  FALSE    NA    NA       NA g3l_abundancedistribution
+cdist_sumofsquares_comm_ldist_weight                 cdist_sumofsquares_comm_ldist_weight          1    FALSE  FALSE    NA    NA       NA     g3l_catchdistribution
+project_years                                                               project_years          0    FALSE  FALSE    NA    NA       NA                  g3a_time

--- a/inttest/codegeneration-defaults/run.R
+++ b/inttest/codegeneration-defaults/run.R
@@ -118,7 +118,7 @@ params <- attr(model_cpp, 'parameter_template')
 params <- g3_init_val(params, 'report_detail', 0)
 oldWidth <- getOption("width")
 options(width=1000)
-capture.output(print(params), file = 'inttest/codegeneration-defaults/model.tmbparam')
+capture.output(print(params, width = 500), file = 'inttest/codegeneration-defaults/model.tmbparam')
 options(width=oldWidth)
 
 r <- attributes(model_fn(params$value))

--- a/inttest/codegeneration/ling.R
+++ b/inttest/codegeneration/ling.R
@@ -1,4 +1,4 @@
-structure(function (param) 
+structure(function (param = attr(get(sys.call()[[1]]), "parameter_template")) 
 {
     stopifnot("retro_years" %in% names(param))
     stopifnot("ling.Linf" %in% names(param))

--- a/inttest/codegeneration/ling.R
+++ b/inttest/codegeneration/ling.R
@@ -566,12 +566,12 @@ structure(function (param)
             {
                 area <- ling_mat__area
                 ling_mat__area_idx <- (1L)
-                for (age in seq(ling_mat__minage, ling_mat__maxage, by = 1)) if (area == ling_imm__area) 
-                  if (age >= ling_imm__minage && age <= ling_imm__maxage) 
-                    if (cur_step_final) {
-                      ling_mat__age_idx <- age - ling_mat__minage + 1L
-                      ling_imm__area_idx <- (1L)
-                      {
+                for (age in seq(ling_mat__minage, ling_mat__maxage, by = 1)) if (area == ling_imm__area) {
+                  ling_mat__age_idx <- age - ling_mat__minage + 1L
+                  {
+                    ling_imm__area_idx <- (1L)
+                    if (age >= ling_imm__minage && age <= ling_imm__maxage) 
+                      if (cur_step_final) {
                         ling_imm__age_idx <- age - ling_imm__minage + 1L
                         {
                           ling_mat__wgt[, ling_mat__age_idx, ling_mat__area_idx] <- (ling_mat__wgt[, ling_mat__age_idx, ling_mat__area_idx] * ling_mat__num[, ling_mat__age_idx, ling_mat__area_idx]) + ling_imm__transitioning_wgt[, ling_imm__age_idx, ling_imm__area_idx] * ling_imm__transitioning_num[, ling_imm__age_idx, ling_imm__area_idx]
@@ -580,7 +580,8 @@ structure(function (param)
                           ling_mat__wgt[, ling_mat__age_idx, ling_mat__area_idx] <- ling_mat__wgt[, ling_mat__age_idx, ling_mat__area_idx]/avoid_zero_vec(ling_mat__num[, ling_mat__age_idx, ling_mat__area_idx])
                         }
                       }
-                    }
+                  }
+                }
             }
             comment("Move any unclaimed stock back to ling_imm")
             if (cur_step_final) 
@@ -641,10 +642,12 @@ structure(function (param)
                 ling_imm__area_idx <- (1L)
                 for (age in seq(ling_imm__minage, ling_imm__maxage, by = 1)) if (area == cdist_sumofsquares_ldist_lln_model__area) {
                   ling_imm__age_idx <- age - ling_imm__minage + 1L
-                  cdist_sumofsquares_ldist_lln_model__area_idx <- (1L)
                   {
-                    comment("Convert ling_imm_igfs to num")
-                    cdist_sumofsquares_ldist_lln_model__num[, cdist_sumofsquares_ldist_lln_model__area_idx] <- cdist_sumofsquares_ldist_lln_model__num[, cdist_sumofsquares_ldist_lln_model__area_idx] + (ling_imm_igfs__cons[, ling_imm__age_idx, ling_imm__area_idx]/avoid_zero_vec(ling_imm__wgt[, ling_imm__age_idx, ling_imm__area_idx]))
+                    cdist_sumofsquares_ldist_lln_model__area_idx <- (1L)
+                    {
+                      comment("Convert ling_imm_igfs to num")
+                      cdist_sumofsquares_ldist_lln_model__num[, cdist_sumofsquares_ldist_lln_model__area_idx] <- cdist_sumofsquares_ldist_lln_model__num[, cdist_sumofsquares_ldist_lln_model__area_idx] + (ling_imm_igfs__cons[, ling_imm__age_idx, ling_imm__area_idx]/avoid_zero_vec(ling_imm__wgt[, ling_imm__age_idx, ling_imm__area_idx]))
+                    }
                   }
                 }
             }
@@ -656,10 +659,12 @@ structure(function (param)
                 ling_mat__area_idx <- (1L)
                 for (age in seq(ling_mat__minage, ling_mat__maxage, by = 1)) if (area == cdist_sumofsquares_ldist_lln_model__area) {
                   ling_mat__age_idx <- age - ling_mat__minage + 1L
-                  cdist_sumofsquares_ldist_lln_model__area_idx <- (1L)
                   {
-                    comment("Convert ling_mat_igfs to num")
-                    cdist_sumofsquares_ldist_lln_model__num[, cdist_sumofsquares_ldist_lln_model__area_idx] <- cdist_sumofsquares_ldist_lln_model__num[, cdist_sumofsquares_ldist_lln_model__area_idx] + (ling_mat_igfs__cons[, ling_mat__age_idx, ling_mat__area_idx]/avoid_zero_vec(ling_mat__wgt[, ling_mat__age_idx, ling_mat__area_idx]))
+                    cdist_sumofsquares_ldist_lln_model__area_idx <- (1L)
+                    {
+                      comment("Convert ling_mat_igfs to num")
+                      cdist_sumofsquares_ldist_lln_model__num[, cdist_sumofsquares_ldist_lln_model__area_idx] <- cdist_sumofsquares_ldist_lln_model__num[, cdist_sumofsquares_ldist_lln_model__area_idx] + (ling_mat_igfs__cons[, ling_mat__age_idx, ling_mat__area_idx]/avoid_zero_vec(ling_mat__wgt[, ling_mat__age_idx, ling_mat__area_idx]))
+                    }
                   }
                 }
             }
@@ -670,8 +675,8 @@ structure(function (param)
                 {
                   area <- cdist_sumofsquares_ldist_lln_model__area
                   cdist_sumofsquares_ldist_lln_model__area_idx <- (1L)
+                  cdist_sumofsquares_ldist_lln_model__sstotal <- avoid_zero(sum(cdist_sumofsquares_ldist_lln_model__num[, cdist_sumofsquares_ldist_lln_model__area_idx]))
                   if (area == cdist_sumofsquares_ldist_lln_obs__area) {
-                    cdist_sumofsquares_ldist_lln_model__sstotal <- avoid_zero(sum(cdist_sumofsquares_ldist_lln_model__num[, cdist_sumofsquares_ldist_lln_model__area_idx]))
                     cdist_sumofsquares_ldist_lln_obs__area_idx <- (1L)
                     cdist_sumofsquares_ldist_lln_obs__time_idx <- intlookup_getdefault(cdist_sumofsquares_ldist_lln_obs__times, (cur_year * 100L + cur_step), -1L)
                     if (cdist_sumofsquares_ldist_lln_obs__time_idx >= (1L)) {
@@ -770,12 +775,12 @@ structure(function (param)
             {
                 area <- ling_mat__area
                 ling_mat__area_idx <- (1L)
-                for (age in seq(ling_mat__minage, ling_mat__maxage, by = 1)) if (area == ling_imm_movement__area) 
-                  if (age >= ling_imm_movement__minage && age <= ling_imm_movement__maxage) 
-                    if (cur_step_final) {
-                      ling_mat__age_idx <- age - ling_mat__minage + 1L
-                      ling_imm_movement__area_idx <- (1L)
-                      {
+                for (age in seq(ling_mat__minage, ling_mat__maxage, by = 1)) if (area == ling_imm_movement__area) {
+                  ling_mat__age_idx <- age - ling_mat__minage + 1L
+                  {
+                    ling_imm_movement__area_idx <- (1L)
+                    if (age >= ling_imm_movement__minage && age <= ling_imm_movement__maxage) 
+                      if (cur_step_final) {
                         ling_imm_movement__age_idx <- age - ling_imm_movement__minage + 1L
                         {
                           ling_mat__wgt[, ling_mat__age_idx, ling_mat__area_idx] <- (ling_mat__wgt[, ling_mat__age_idx, ling_mat__area_idx] * ling_mat__num[, ling_mat__age_idx, ling_mat__area_idx]) + ling_imm_movement__transitioning_wgt[, ling_imm_movement__age_idx, ling_imm_movement__area_idx] * ling_imm_movement__transitioning_num[, ling_imm_movement__age_idx, ling_imm_movement__area_idx]
@@ -783,7 +788,8 @@ structure(function (param)
                           ling_mat__wgt[, ling_mat__age_idx, ling_mat__area_idx] <- ling_mat__wgt[, ling_mat__age_idx, ling_mat__area_idx]/avoid_zero_vec(ling_mat__num[, ling_mat__age_idx, ling_mat__area_idx])
                         }
                       }
-                    }
+                  }
+                }
             }
         }
     }

--- a/inttest/codegeneration/ling.cpp
+++ b/inttest/codegeneration/ling.cpp
@@ -664,13 +664,13 @@ Type objective_function<Type>::operator() () {
                 auto ling_mat__area_idx = 0;
 
                 for (auto age = ling_mat__minage; age <= ling_mat__maxage; age++) if ( area == ling_imm__area ) {
-                    if ( age >= ling_imm__minage && age <= ling_imm__maxage ) {
-                        if ( cur_step_final ) {
-                            auto ling_mat__age_idx = age - ling_mat__minage + 1 - 1;
+                    auto ling_mat__age_idx = age - ling_mat__minage + 1 - 1;
 
-                            auto ling_imm__area_idx = 0;
+                    {
+                        auto ling_imm__area_idx = 0;
 
-                            {
+                        if ( age >= ling_imm__minage && age <= ling_imm__maxage ) {
+                            if ( cur_step_final ) {
                                 auto ling_imm__age_idx = age - ling_imm__minage + 1 - 1;
 
                                 {
@@ -751,11 +751,13 @@ Type objective_function<Type>::operator() () {
                 for (auto age = ling_imm__minage; age <= ling_imm__maxage; age++) if ( area == cdist_sumofsquares_ldist_lln_model__area ) {
                     auto ling_imm__age_idx = age - ling_imm__minage + 1 - 1;
 
-                    auto cdist_sumofsquares_ldist_lln_model__area_idx = 0;
-
                     {
-                        // Convert ling_imm_igfs to num;
-                        cdist_sumofsquares_ldist_lln_model__num.col(cdist_sumofsquares_ldist_lln_model__area_idx) += (ling_imm_igfs__cons.col(ling_imm__area_idx).col(ling_imm__age_idx) / avoid_zero_vec(ling_imm__wgt.col(ling_imm__area_idx).col(ling_imm__age_idx)));
+                        auto cdist_sumofsquares_ldist_lln_model__area_idx = 0;
+
+                        {
+                            // Convert ling_imm_igfs to num;
+                            cdist_sumofsquares_ldist_lln_model__num.col(cdist_sumofsquares_ldist_lln_model__area_idx) += (ling_imm_igfs__cons.col(ling_imm__area_idx).col(ling_imm__age_idx) / avoid_zero_vec(ling_imm__wgt.col(ling_imm__area_idx).col(ling_imm__age_idx)));
+                        }
                     }
                 }
             }
@@ -770,11 +772,13 @@ Type objective_function<Type>::operator() () {
                 for (auto age = ling_mat__minage; age <= ling_mat__maxage; age++) if ( area == cdist_sumofsquares_ldist_lln_model__area ) {
                     auto ling_mat__age_idx = age - ling_mat__minage + 1 - 1;
 
-                    auto cdist_sumofsquares_ldist_lln_model__area_idx = 0;
-
                     {
-                        // Convert ling_mat_igfs to num;
-                        cdist_sumofsquares_ldist_lln_model__num.col(cdist_sumofsquares_ldist_lln_model__area_idx) += (ling_mat_igfs__cons.col(ling_mat__area_idx).col(ling_mat__age_idx) / avoid_zero_vec(ling_mat__wgt.col(ling_mat__area_idx).col(ling_mat__age_idx)));
+                        auto cdist_sumofsquares_ldist_lln_model__area_idx = 0;
+
+                        {
+                            // Convert ling_mat_igfs to num;
+                            cdist_sumofsquares_ldist_lln_model__num.col(cdist_sumofsquares_ldist_lln_model__area_idx) += (ling_mat_igfs__cons.col(ling_mat__area_idx).col(ling_mat__age_idx) / avoid_zero_vec(ling_mat__wgt.col(ling_mat__area_idx).col(ling_mat__age_idx)));
+                        }
                     }
                 }
             }
@@ -787,9 +791,9 @@ Type objective_function<Type>::operator() () {
 
                     auto cdist_sumofsquares_ldist_lln_model__area_idx = 0;
 
-                    if ( area == cdist_sumofsquares_ldist_lln_obs__area ) {
-                        auto cdist_sumofsquares_ldist_lln_model__sstotal = avoid_zero((cdist_sumofsquares_ldist_lln_model__num.col(cdist_sumofsquares_ldist_lln_model__area_idx)).sum());
+                    auto cdist_sumofsquares_ldist_lln_model__sstotal = avoid_zero((cdist_sumofsquares_ldist_lln_model__num.col(cdist_sumofsquares_ldist_lln_model__area_idx)).sum());
 
+                    if ( area == cdist_sumofsquares_ldist_lln_obs__area ) {
                         auto cdist_sumofsquares_ldist_lln_obs__area_idx = 0;
 
                         auto cdist_sumofsquares_ldist_lln_obs__time_idx = intlookup_getdefault(cdist_sumofsquares_ldist_lln_obs__times, (cur_year*100 + cur_step), -1) - 1;
@@ -900,13 +904,13 @@ Type objective_function<Type>::operator() () {
                 auto ling_mat__area_idx = 0;
 
                 for (auto age = ling_mat__minage; age <= ling_mat__maxage; age++) if ( area == ling_imm_movement__area ) {
-                    if ( age >= ling_imm_movement__minage && age <= ling_imm_movement__maxage ) {
-                        if ( cur_step_final ) {
-                            auto ling_mat__age_idx = age - ling_mat__minage + 1 - 1;
+                    auto ling_mat__age_idx = age - ling_mat__minage + 1 - 1;
 
-                            auto ling_imm_movement__area_idx = 0;
+                    {
+                        auto ling_imm_movement__area_idx = 0;
 
-                            {
+                        if ( age >= ling_imm_movement__minage && age <= ling_imm_movement__maxage ) {
+                            if ( cur_step_final ) {
                                 auto ling_imm_movement__age_idx = age - ling_imm_movement__minage + 1 - 1;
 
                                 {

--- a/inttest/codegeneration/ling.tmbparam
+++ b/inttest/codegeneration/ling.tmbparam
@@ -1,49 +1,49 @@
-                                                                 switch   type value optimise random lower upper parscale
-retro_years                                                 retro_years            0    FALSE  FALSE    NA    NA       NA
-ling.Linf                                                     ling.Linf            1     TRUE  FALSE    NA    NA       NA
-ling.K                                                           ling.K            1     TRUE  FALSE    NA    NA       NA
-recage                                                           recage            0    FALSE  FALSE    NA    NA       NA
-ling.recl                                                     ling.recl            0     TRUE  FALSE    NA    NA       NA
-lingimm.init.scalar                                 lingimm.init.scalar            0     TRUE  FALSE    NA    NA       NA
-lingimm.M                                                     lingimm.M            0     TRUE  FALSE    NA    NA       NA
-ling.init.F                                                 ling.init.F            0     TRUE  FALSE    NA    NA       NA
-lingimm.init                                               lingimm.init VECTOR     0     TRUE  FALSE    NA    NA       NA
-lingimm.walpha                                           lingimm.walpha            0     TRUE  FALSE    NA    NA       NA
-lingimm.wbeta                                             lingimm.wbeta            0     TRUE  FALSE    NA    NA       NA
-lingmat.init.scalar                                 lingmat.init.scalar            0     TRUE  FALSE    NA    NA       NA
-lingmat.M                                                     lingmat.M            0     TRUE  FALSE    NA    NA       NA
-lingmat.init                                               lingmat.init VECTOR     0     TRUE  FALSE    NA    NA       NA
-lingmat.walpha                                           lingmat.walpha            0     TRUE  FALSE    NA    NA       NA
-lingmat.wbeta                                             lingmat.wbeta            0     TRUE  FALSE    NA    NA       NA
-ling.igfs.alpha                                         ling.igfs.alpha            0     TRUE  FALSE    NA    NA       NA
-ling.igfs.l50                                             ling.igfs.l50            0     TRUE  FALSE    NA    NA       NA
-ling.mat1                                                     ling.mat1            0     TRUE  FALSE    NA    NA       NA
-ling.mat2                                                     ling.mat2            0     TRUE  FALSE    NA    NA       NA
-ling.bbin                                                     ling.bbin            0     TRUE  FALSE    NA    NA       NA
-ling.rec.scalar                                         ling.rec.scalar            0     TRUE  FALSE    NA    NA       NA
-ling.rec.1994                                             ling.rec.1994            0     TRUE  FALSE    NA    NA       NA
-ling.rec.1995                                             ling.rec.1995            0     TRUE  FALSE    NA    NA       NA
-ling.rec.1996                                             ling.rec.1996            0     TRUE  FALSE    NA    NA       NA
-ling.rec.1997                                             ling.rec.1997            0     TRUE  FALSE    NA    NA       NA
-ling.rec.1998                                             ling.rec.1998            0     TRUE  FALSE    NA    NA       NA
-ling.rec.1999                                             ling.rec.1999            0     TRUE  FALSE    NA    NA       NA
-ling.rec.2000                                             ling.rec.2000            0     TRUE  FALSE    NA    NA       NA
-ling.rec.2001                                             ling.rec.2001            0     TRUE  FALSE    NA    NA       NA
-ling.rec.2002                                             ling.rec.2002            0     TRUE  FALSE    NA    NA       NA
-ling.rec.2003                                             ling.rec.2003            0     TRUE  FALSE    NA    NA       NA
-ling.rec.2004                                             ling.rec.2004            0     TRUE  FALSE    NA    NA       NA
-ling.rec.2005                                             ling.rec.2005            0     TRUE  FALSE    NA    NA       NA
-ling.rec.2006                                             ling.rec.2006            0     TRUE  FALSE    NA    NA       NA
-ling.rec.2007                                             ling.rec.2007            0     TRUE  FALSE    NA    NA       NA
-ling.rec.2008                                             ling.rec.2008            0     TRUE  FALSE    NA    NA       NA
-ling.rec.2009                                             ling.rec.2009            0     TRUE  FALSE    NA    NA       NA
-ling.rec.2010                                             ling.rec.2010            0     TRUE  FALSE    NA    NA       NA
-ling.rec.2011                                             ling.rec.2011            0     TRUE  FALSE    NA    NA       NA
-ling.rec.2012                                             ling.rec.2012            0     TRUE  FALSE    NA    NA       NA
-ling.rec.2013                                             ling.rec.2013            0     TRUE  FALSE    NA    NA       NA
-ling.rec.2014                                             ling.rec.2014            0     TRUE  FALSE    NA    NA       NA
-ling.rec.2015                                             ling.rec.2015            0     TRUE  FALSE    NA    NA       NA
-ling.rec.2016                                             ling.rec.2016            0     TRUE  FALSE    NA    NA       NA
-ling.rec.2017                                             ling.rec.2017            0     TRUE  FALSE    NA    NA       NA
-ling.rec.2018                                             ling.rec.2018            0     TRUE  FALSE    NA    NA       NA
-cdist_sumofsquares_ldist_lln_weight cdist_sumofsquares_ldist_lln_weight            1    FALSE  FALSE    NA    NA       NA
+                                                                 switch   type value optimise random lower upper parscale                source
+retro_years                                                 retro_years            0    FALSE  FALSE    NA    NA       NA              g3a_time
+ling.Linf                                                     ling.Linf            1     TRUE  FALSE    NA    NA       NA      g3a_renewal_vonb
+ling.K                                                           ling.K            1     TRUE  FALSE    NA    NA       NA      g3a_renewal_vonb
+recage                                                           recage            0    FALSE  FALSE    NA    NA       NA      g3a_renewal_vonb
+ling.recl                                                     ling.recl            0     TRUE  FALSE    NA    NA       NA      g3a_renewal_vonb
+lingimm.init.scalar                                 lingimm.init.scalar            0     TRUE  FALSE    NA    NA       NA                  <NA>
+lingimm.M                                                     lingimm.M            0     TRUE  FALSE    NA    NA       NA                  <NA>
+ling.init.F                                                 ling.init.F            0     TRUE  FALSE    NA    NA       NA                  <NA>
+lingimm.init                                               lingimm.init VECTOR     0     TRUE  FALSE    NA    NA       NA                  <NA>
+lingimm.walpha                                           lingimm.walpha            0     TRUE  FALSE    NA    NA       NA                  <NA>
+lingimm.wbeta                                             lingimm.wbeta            0     TRUE  FALSE    NA    NA       NA                  <NA>
+lingmat.init.scalar                                 lingmat.init.scalar            0     TRUE  FALSE    NA    NA       NA                  <NA>
+lingmat.M                                                     lingmat.M            0     TRUE  FALSE    NA    NA       NA                  <NA>
+lingmat.init                                               lingmat.init VECTOR     0     TRUE  FALSE    NA    NA       NA                  <NA>
+lingmat.walpha                                           lingmat.walpha            0     TRUE  FALSE    NA    NA       NA                  <NA>
+lingmat.wbeta                                             lingmat.wbeta            0     TRUE  FALSE    NA    NA       NA                  <NA>
+ling.igfs.alpha                                         ling.igfs.alpha            0     TRUE  FALSE    NA    NA       NA                  <NA>
+ling.igfs.l50                                             ling.igfs.l50            0     TRUE  FALSE    NA    NA       NA                  <NA>
+ling.mat1                                                     ling.mat1            0     TRUE  FALSE    NA    NA       NA                  <NA>
+ling.mat2                                                     ling.mat2            0     TRUE  FALSE    NA    NA       NA                  <NA>
+ling.bbin                                                     ling.bbin            0     TRUE  FALSE    NA    NA       NA                  <NA>
+ling.rec.scalar                                         ling.rec.scalar            0     TRUE  FALSE    NA    NA       NA                  <NA>
+ling.rec.1994                                             ling.rec.1994            0     TRUE  FALSE    NA    NA       NA                  <NA>
+ling.rec.1995                                             ling.rec.1995            0     TRUE  FALSE    NA    NA       NA                  <NA>
+ling.rec.1996                                             ling.rec.1996            0     TRUE  FALSE    NA    NA       NA                  <NA>
+ling.rec.1997                                             ling.rec.1997            0     TRUE  FALSE    NA    NA       NA                  <NA>
+ling.rec.1998                                             ling.rec.1998            0     TRUE  FALSE    NA    NA       NA                  <NA>
+ling.rec.1999                                             ling.rec.1999            0     TRUE  FALSE    NA    NA       NA                  <NA>
+ling.rec.2000                                             ling.rec.2000            0     TRUE  FALSE    NA    NA       NA                  <NA>
+ling.rec.2001                                             ling.rec.2001            0     TRUE  FALSE    NA    NA       NA                  <NA>
+ling.rec.2002                                             ling.rec.2002            0     TRUE  FALSE    NA    NA       NA                  <NA>
+ling.rec.2003                                             ling.rec.2003            0     TRUE  FALSE    NA    NA       NA                  <NA>
+ling.rec.2004                                             ling.rec.2004            0     TRUE  FALSE    NA    NA       NA                  <NA>
+ling.rec.2005                                             ling.rec.2005            0     TRUE  FALSE    NA    NA       NA                  <NA>
+ling.rec.2006                                             ling.rec.2006            0     TRUE  FALSE    NA    NA       NA                  <NA>
+ling.rec.2007                                             ling.rec.2007            0     TRUE  FALSE    NA    NA       NA                  <NA>
+ling.rec.2008                                             ling.rec.2008            0     TRUE  FALSE    NA    NA       NA                  <NA>
+ling.rec.2009                                             ling.rec.2009            0     TRUE  FALSE    NA    NA       NA                  <NA>
+ling.rec.2010                                             ling.rec.2010            0     TRUE  FALSE    NA    NA       NA                  <NA>
+ling.rec.2011                                             ling.rec.2011            0     TRUE  FALSE    NA    NA       NA                  <NA>
+ling.rec.2012                                             ling.rec.2012            0     TRUE  FALSE    NA    NA       NA                  <NA>
+ling.rec.2013                                             ling.rec.2013            0     TRUE  FALSE    NA    NA       NA                  <NA>
+ling.rec.2014                                             ling.rec.2014            0     TRUE  FALSE    NA    NA       NA                  <NA>
+ling.rec.2015                                             ling.rec.2015            0     TRUE  FALSE    NA    NA       NA                  <NA>
+ling.rec.2016                                             ling.rec.2016            0     TRUE  FALSE    NA    NA       NA                  <NA>
+ling.rec.2017                                             ling.rec.2017            0     TRUE  FALSE    NA    NA       NA                  <NA>
+ling.rec.2018                                             ling.rec.2018            0     TRUE  FALSE    NA    NA       NA                  <NA>
+cdist_sumofsquares_ldist_lln_weight cdist_sumofsquares_ldist_lln_weight            1    FALSE  FALSE    NA    NA       NA g3l_catchdistribution

--- a/inttest/codegeneration/run.R
+++ b/inttest/codegeneration/run.R
@@ -202,7 +202,7 @@ writeLines(model_cpp, con = 'inttest/codegeneration/ling.cpp')
 
 # model_cpp <- edit(model_cpp)
 tmb_param <- attr(model_cpp, 'parameter_template')
-capture.output(print(tmb_param), file = 'inttest/codegeneration/ling.tmbparam')
+capture.output(print(tmb_param, width = 500), file = 'inttest/codegeneration/ling.tmbparam')
 # Fill parameters - Map original list into data.frame format
 tmb_param$value <- I(params[tmb_param$switch])
 # Random parameters with: tmb_param["ling.Linf", "random"] <- TRUE

--- a/man/action_report.Rd
+++ b/man/action_report.Rd
@@ -23,7 +23,8 @@ g3a_report_history(
         run_at = g3_action_order$report)
 
 g3a_report_detail(actions,
-    run_f = quote( g3_param('report_detail', optimise = FALSE, value = 1L) == 1 ),
+    run_f = quote( g3_param('report_detail', optimise = FALSE, value = 1L,
+        source = "g3a_report_detail") == 1 ),
     abundance_run_at = g3_action_order$report_early,
     run_at = g3_action_order$report)
 }

--- a/man/action_spawn.Rd
+++ b/man/action_spawn.Rd
@@ -14,28 +14,45 @@
 }
 
 \usage{
-g3a_spawn_recruitment_fecundity(p0, p1, p2, p3, p4)
+g3a_spawn_recruitment_fecundity(
+        p0 = g3_parameterized('spawn.p0', value = 1, by_stock = by_stock),
+        p1 = g3_parameterized('spawn.p1', value = 1, by_stock = by_stock),
+        p2 = g3_parameterized('spawn.p2', value = 1, by_stock = by_stock),
+        p3 = g3_parameterized('spawn.p3', value = 1, by_stock = by_stock),
+        p4 = g3_parameterized('spawn.p4', value = 1, by_stock = by_stock),
+        by_stock = TRUE )
 
-g3a_spawn_recruitment_simplessb(mu)
+g3a_spawn_recruitment_simplessb(
+        mu = g3_parameterized('spawn.mu', by_stock = by_stock),
+        by_stock = TRUE )
 
-g3a_spawn_recruitment_ricker(mu, lambda)
+g3a_spawn_recruitment_ricker(
+        mu = g3_parameterized('spawn.mu', by_stock = by_stock),
+        lambda = g3_parameterized('spawn.lambda', by_stock = by_stock),
+        by_stock = TRUE )
 
-g3a_spawn_recruitment_bevertonholt(mu, lambda)
+g3a_spawn_recruitment_bevertonholt(
+        mu = g3_parameterized('spawn.mu', by_stock = by_stock),
+        lambda = g3_parameterized('spawn.lambda', by_stock = by_stock),
+        by_stock = TRUE )
 
 g3a_spawn_recruitment_bevertonholt_ss3(
         # Steepness parameter
-        h = g3_parameterized('srr_h', lower = 0.1, upper = 1, value = 0.5,
+        h = g3_parameterized('spawn.h', lower = 0.1, upper = 1, value = 0.5,
             by_stock = by_stock ),
         # Recruitment deviates
-        R = g3_parameterized('R', by_year = TRUE, exponentiate = TRUE,
+        R = g3_parameterized('spawn.R', by_year = TRUE, exponentiate = TRUE,
             # Unfished equilibrium recruitment
-            scale = "R0",
+            scale = "spawn.R0",
             by_stock = by_stock),
         # Unfished equilibrium spawning biomass (corresponding to R0)
-        B0 = g3_parameterized('B0', by_stock = by_stock),
+        B0 = g3_parameterized('spawn.B0', by_stock = by_stock),
         by_stock = TRUE )
 
-g3a_spawn_recruitment_hockeystick(r0, blim)
+g3a_spawn_recruitment_hockeystick(
+        r0 = g3_parameterized('spawn.r0', by_stock = by_stock),
+        blim = g3_parameterized('spawn.blim', value = 1, by_stock = by_stock),
+        by_stock = TRUE )
 
 g3a_spawn(
         stock,

--- a/man/likelihood_distribution.Rd
+++ b/man/likelihood_distribution.Rd
@@ -41,9 +41,8 @@ g3l_abundancedistribution(
         area_group = NULL,
         report = FALSE,
         nll_breakdown = FALSE,
-        weight = substitute(
-            g3_param(n, optimise = FALSE, value = 1),
-            list(n = paste0(nll_name, "_weight"))),
+        weight = g3_parameterized(paste0(nll_name, "_weight"),
+            optimise = FALSE, value = 1),
         run_at = g3_action_order$likelihood)
 
 g3l_catchdistribution(
@@ -58,9 +57,8 @@ g3l_catchdistribution(
         area_group = NULL,
         report = FALSE,
         nll_breakdown = FALSE,
-        weight = substitute(
-            g3_param(n, optimise = FALSE, value = 1),
-            list(n = paste0(nll_name, "_weight"))),
+        weight = g3_parameterized(paste0(nll_name, "_weight"),
+            optimise = FALSE, value = 1),
         run_at = g3_action_order$likelihood)
 
 g3_distribution_preview(

--- a/man/likelihood_random.Rd
+++ b/man/likelihood_random.Rd
@@ -17,9 +17,8 @@ g3l_random_dnorm(
         log_f = TRUE,
         period = 'auto',
         nll_breakdown = FALSE,
-        weight = substitute(
-            g3_param(n, optimise = FALSE, value = 1),
-            list(n = paste0(nll_name, "_weight"))),
+        weight = g3_parameterized(paste0(nll_name, "_weight"),
+            optimise = FALSE, value = 1),
         run_at = g3_action_order$likelihood)
 
 g3l_random_walk(
@@ -29,9 +28,8 @@ g3l_random_walk(
         log_f = TRUE,
         period = 'auto',
         nll_breakdown = FALSE,
-        weight = substitute(
-            g3_param(n, optimise = FALSE, value = 1),
-            list(n = paste0(nll_name, "_weight"))),
+        weight = g3_parameterized(paste0(nll_name, "_weight"),
+            optimise = FALSE, value = 1),
         run_at = g3_action_order$likelihood)
 }
 

--- a/man/likelihood_tagging_ckmr.Rd
+++ b/man/likelihood_tagging_ckmr.Rd
@@ -14,9 +14,8 @@ g3l_tagging_ckmr(
         fleets,
         parent_stocks,
         offspring_stocks,
-        weight = substitute(
-            g3_param(n, optimise = FALSE, value = 1),
-            list(n = paste0(nll_name, "_weight"))),
+        weight = g3_parameterized(paste0(nll_name, "_weight"),
+            optimise = FALSE, value = 1),
         run_at = g3_action_order$likelihood)
 }
 

--- a/man/run_tmb.Rd
+++ b/man/run_tmb.Rd
@@ -158,25 +158,19 @@ if (interactive()) {
 }
 
 # Set initial conditions for parameters
-tmb_param <- attr(cpp, 'parameter_template')
-tmb_param$value$project_years <- 0
-tmb_param$value$ling.init.F <- 0.4
-tmb_param$value$ling.Linf <- 160
-tmb_param$value$ling.K <- 90
-tmb_param$value$ling.t0 <- 0
-tmb_param[grepl('^ling.init.sd.', rownames(tmb_param)), 'value'] <- 50.527220
-tmb_param[grepl('^ling_imm.init.\\\\d+', rownames(tmb_param)), 'value'] <- 1
-tmb_param$value$ling_imm.init.scalar <- 200
-tmb_param$value$ling_imm.walpha <- 2.27567436711055e-06
-tmb_param$value$ling_imm.wbeta <- 3.20200445996187
-tmb_param[grepl('\\\\.M$', rownames(tmb_param)), 'value'] <- 0.15
-
-# We can set lower/upper bounds for multiple properties at once with grepl()
-tmb_param[grepl('.', rownames(tmb_param)), 'lower'] <- -1000
-tmb_param[grepl('.', rownames(tmb_param)), 'upper'] <- 1000
-
-# parscale gives optim() a relative scale of parameters
-tmb_param['parscale'] <- 1
+attr(cpp, 'parameter_template') |>
+    g3_init_val("project_years", 0) |>
+    g3_init_val("ling.init.F", 0.4) |>
+    g3_init_val("ling.Linf", 160) |>
+    g3_init_val("ling.K", 90) |>
+    g3_init_val("ling.t0", 0) |>
+    g3_init_val("ling.init.sd.#", 50.527220) |>
+    g3_init_val("ling_imm.init.#", 1, lower = 0, upper = 1000) |>
+    g3_init_val("ling_imm.init.scalar", 200) |>
+    g3_init_val("ling_imm.walpha", 2.275e-06) |>
+    g3_init_val("ling_imm.wbeta", 3.2020) |>
+    g3_init_val("ling_*.M.#", 0.15) |>
+    identity() -> tmb_param
 
 \donttest{\dontshow{comment("NB: Making / optimising a TMB function is slow")}
 

--- a/tests/test-action_renewal.R
+++ b/tests/test-action_renewal.R
@@ -7,8 +7,14 @@ cmp_formula <- function (a, b) {
         # NB: Can't order an empty list
         if (length(x) > 0) x[order(names(x))] else x
     }
+    # strip source option from g3_param(), so we don't have to add it to everything below
+    strip_source <- function (in_c) gadget3:::call_replace(in_c,
+        g3_param = function (x) {
+            x$source <- NULL
+            return(x)
+        })
 
-    out <- ut_cmp_identical(rlang::f_rhs(a), rlang::f_rhs(b))
+    out <- ut_cmp_identical(strip_source(rlang::f_rhs(a)), strip_source(rlang::f_rhs(b)))
     if (!identical(out, TRUE)) return(out)
     out <- ut_cmp_identical(ordered_list(environment(a)), ordered_list(environment(b)))
     return(out)

--- a/tests/test-action_spawn.R
+++ b/tests/test-action_spawn.R
@@ -101,11 +101,11 @@ ok_group('g3a_spawn', {
     params <- attr(model_fn, 'parameter_template')
 
     # g3a_spawn_recruitment_bevertonholt_ss3
-    params <- g3_init_val(params, 'mat_*.srr_h', runif(1, 1.4, 1.5))
-    params <- g3_init_val(params, 'mat_*.R0', runif(1, 1e4 - 10, 1e4 + 10))
+    params <- g3_init_val(params, 'mat_*.spawn.h', runif(1, 1.4, 1.5))
+    params <- g3_init_val(params, 'mat_*.spawn.R0', runif(1, 1e4 - 10, 1e4 + 10))
     bholt_ss3_R <- runif(length(year_range), 1e2 - 10, 1e2 + 10)
-    params <- g3_init_val(params, 'mat_*.R.#', bholt_ss3_R)
-    params <- g3_init_val(params, 'mat_*.B0', runif(1, 1e3 - 10, 1e3 + 10))
+    params <- g3_init_val(params, 'mat_*.spawn.R.#', bholt_ss3_R)
+    params <- g3_init_val(params, 'mat_*.spawn.B0', runif(1, 1e3 - 10, 1e3 + 10))
 
     r <- lapply(attributes(model_fn(params)), drop)  # NB: Drop all redundant dimensions,
     age <- 5
@@ -170,15 +170,15 @@ ok_group('g3a_spawn', {
         c(FALSE, rep(TRUE, 36 - 1)) ), "hist_mat_g3a_spawn_recruitment_bevertonholt_ss3__offspringnum: Some recruitment happened")
     ok(ut_cmp_equal(
         colSums(r$hist_mat_g3a_spawn_recruitment_bevertonholt_ss3__offspringnum),
-        4 * params$mat_g3a_spawn_recruitment_bevertonholt_ss3.srr_h *
-        params$mat_g3a_spawn_recruitment_bevertonholt_ss3.R0 *
+        4 * params$mat_g3a_spawn_recruitment_bevertonholt_ss3.spawn.h *
+        params$mat_g3a_spawn_recruitment_bevertonholt_ss3.spawn.R0 *
         hist_biomass *
         rep(bholt_ss3_R, each = 4) / (
-            params$mat_g3a_spawn_recruitment_bevertonholt_ss3.B0 *
-            (1 - params$mat_g3a_spawn_recruitment_bevertonholt_ss3.srr_h)
+            params$mat_g3a_spawn_recruitment_bevertonholt_ss3.spawn.B0 *
+            (1 - params$mat_g3a_spawn_recruitment_bevertonholt_ss3.spawn.h)
           +
             hist_biomass *
-            (5 * params$mat_g3a_spawn_recruitment_bevertonholt_ss3.srr_h - 1)),
+            (5 * params$mat_g3a_spawn_recruitment_bevertonholt_ss3.spawn.h - 1)),
         end = NULL ), "hist_mat_g3a_spawn_recruitment_bevertonholt_ss3__offspringnum: Matches formula")
 
     ok(ut_cmp_equal(

--- a/tests/test-likelihood_data.R
+++ b/tests/test-likelihood_data.R
@@ -534,15 +534,14 @@ ok(gadget3:::ut_cmp_code(generate_code(ld, 'stock_intersect', age = 1, cur_year 
     ut_obs__time_idx <- intlookup_getdefault(ut_obs__times, (cur_year *
         100L + cur_step * 0L), -1L)
     if (ut_obs__time_idx >= (1L)) {
-        ut_obs__agegroup_idx <- intlookup_getdefault(ut_obs__agegroup,
-            age, -1L)
-        if (ut_obs__agegroup_idx > -1L)
-            for (ut_obs__length_idx in seq_along(ut_obs__minlen)) if (ut_obs__minlen[[ut_obs__length_idx]] <=
-                length && length < ut_obs__maxlen[[ut_obs__length_idx]]) {
+        for (ut_obs__agegroup_idx in seq_along(ut_obs__minages)) {
+            `_age` <- ut_obs__minages[[ut_obs__agegroup_idx]]
+            for (ut_obs__length_idx in seq_along(ut_obs__minlen)) {
+                length <- ut_obs__midlen[[ut_obs__length_idx]]
                 ut_obs__num[ut_obs__length_idx, ut_obs__agegroup_idx,
                   ut_obs__time_idx]
-                break
             }
+        }
     }
 }), optimize = TRUE), "stock_intersect: Renamed all vars, including ut_obs__agegroup")
 
@@ -1065,21 +1064,20 @@ ok(gadget3:::ut_cmp_code(generate_code(ld, 'stock_iterate', cur_year = 1999, cur
 ok(gadget3:::ut_cmp_code(generate_code(ld, 'stock_intersect', cur_year = 1999, cur_step = 1, predator_tag = 1, predator_length = 1, predator_age = 1), quote({
     ut_obs__time_idx <- intlookup_getdefault(ut_obs__times, (cur_year * 100L + cur_step * 0L), -1L)
     if (ut_obs__time_idx >= 1L) {
-        for (ut_obs__predator_tag_idx in seq_along(ut_obs__predator_tag_ids)) if (ut_obs__predator_tag_ids[[ut_obs__predator_tag_idx]] == predator_tag) {
-            ut_obs__predator_agegroup_idx <- intlookup_getdefault(ut_obs__predator_agegroup, predator_age, -1L)
-            if (ut_obs__predator_agegroup_idx > -1L) {
-                for (ut_obs__predator_length_idx in seq_along(ut_obs__predator_minlen)) if (ut_obs__predator_minlen[[ut_obs__predator_length_idx]] <= 
-                  predator_length && predator_length < ut_obs__predator_maxlen[[ut_obs__predator_length_idx]]) {
-                  for (ut_obs__length_idx in seq_along(ut_obs__minlen)) if (ut_obs__minlen[[ut_obs__length_idx]] <= length && length < ut_obs__maxlen[[ut_obs__length_idx]]) {
+        for (ut_obs__predator_tag_idx in seq_along(ut_obs__predator_tag_ids)) {
+            predator_tag <- ut_obs__predator_tag_ids[[ut_obs__predator_tag_idx]]
+            for (ut_obs__predator_agegroup_idx in seq_along(ut_obs__predator_minages)) {
+                `_age` <- ut_obs__predator_minages[[ut_obs__predator_agegroup_idx]]
+                for (ut_obs__predator_length_idx in seq_along(ut_obs__predator_minlen)) {
+                  predator_length <- ut_obs__predator_midlen[[ut_obs__predator_length_idx]]
+                  for (ut_obs__length_idx in seq_along(ut_obs__minlen)) {
+                    length <- ut_obs__midlen[[ut_obs__length_idx]]
                     ut_obs__num[ut_obs__length_idx, ut_obs__predator_length_idx,
                       ut_obs__predator_agegroup_idx, ut_obs__predator_tag_idx,
                       ut_obs__time_idx]
-                    break
                   }
-                  break
                 }
             }
-            break
         }
     }
 }), optimize = TRUE), "stock_intersect: All predator dimensions included, with prefixed variables")

--- a/tests/test-run_r.R
+++ b/tests/test-run_r.R
@@ -9,6 +9,8 @@ ok_group('edit.g3_r - Round-trip through an editor results in working code', {
         return(nll)
     }))
     model_fn_n <- edit(model_fn, editor = '/bin/true')
+    attr(model_fn, 'srcref') <- NULL
+    attr(model_fn, 'srcfile') <- NULL
     attr(model_fn_n, 'srcref') <- NULL
     attr(model_fn_n, 'srcfile') <- NULL
     ok(ut_cmp_identical(
@@ -31,7 +33,7 @@ ok_group('print.g3_r', {
         y = c(4, 5),
         x = g3_parameterized('parp') )))
     ok(ut_cmp_identical(cap(print(model_fn)), c(
-        "function (param) ",
+        "function (param = attr(get(sys.call()[[1]]), \"parameter_template\")) ",
         "{",
         "    stopifnot(\"parp\" %in% names(param))",
         "    x <- param[[\"parp\"]]",
@@ -43,7 +45,7 @@ ok_group('print.g3_r', {
         "<environment: xxx>",
         NULL)), "Default print output has code, no attributes")
     ok(ut_cmp_identical(cap(print(model_fn, with_environment = TRUE, with_template = TRUE)), c(
-        "function (param) ",
+        "function (param = attr(get(sys.call()[[1]]), \"parameter_template\")) ",
         "{",
         "    stopifnot(\"parp\" %in% names(param))",
         "    x <- param[[\"parp\"]]",
@@ -128,4 +130,11 @@ ok_group('g3_param_table', {
     ok(ut_cmp_identical(grep('^par', names(params.in), value = TRUE), c(
         paste0('par.years.', 1990:2000, '_exp'),
         NULL)), "exponentiate prefix ends up at the end of parameters")
+})
+
+ok_group('parameter_template default', {
+    # By default we read arguments from the parameter_template
+    model_fn <- g3_to_r(~return(g3_param("archibald", value = 45)))
+    ok(ut_cmp_equal(model_fn(), 45), "Used default from parameter_template")
+    ok(ut_cmp_equal(model_fn(list(archibald = 99)), 99), "Override default")
 })

--- a/tests/test-run_tmb.R
+++ b/tests/test-run_tmb.R
@@ -650,6 +650,26 @@ actions <- c(actions, ~{
 expecteds$as_vector_result1 <- pnorm(as_vector_array[,1], as_vector_mean, as_vector_sigma)
 expecteds$as_vector_result2 <- pnorm(as_vector_array[,2], as_vector_mean, as_vector_sigma)
 
+# Flow control
+flow_control_vec <- runif(10)
+flow_control_break_sum <- 0.0
+flow_control_next_sum <- 0.0
+actions <- c(actions, ~{
+    comment('Flow control')
+    for (flow_control_idx in seq_along(flow_control_vec)) {
+        if (flow_control_idx == g3_idx(5)) break
+        flow_control_break_sum <- flow_control_break_sum + flow_control_vec[[flow_control_idx]]
+    }
+    REPORT(flow_control_break_sum)
+    for (flow_control_idx in seq_along(flow_control_vec)) {
+        if (flow_control_idx == g3_idx(5)) next
+        flow_control_next_sum <- flow_control_next_sum + flow_control_vec[[flow_control_idx]]
+    }
+    REPORT(flow_control_next_sum)
+})
+expecteds$flow_control_break_sum <- sum(flow_control_vec[1:4])
+expecteds$flow_control_next_sum <- sum(flow_control_vec[-5])
+
 # pow() / .pow()
 pow_scalar <- 99
 pow_scalar_result <- 0

--- a/tests/test-run_tmb.R
+++ b/tests/test-run_tmb.R
@@ -293,6 +293,7 @@ ok_group('g3_param', {
             lower = c(NA, 5),
             upper = c(NA, 10),
             parscale = as.numeric(c(NA, NA)),  # NB: Not derived yet, only when calling g3_tmb_parscale()
+            source = as.character(NA),
             stringsAsFactors = FALSE)), "Param table included custom values")
 })
 
@@ -330,6 +331,7 @@ ok_group('g3_param_table', {
             upper = c(NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, 10, 10),
             # NB: Not derived yet, only when calling g3_tmb_parscale()
             parscale = as.numeric(c(NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA)),
+            source = as.character(NA),
             stringsAsFactors = FALSE)), "Param table included custom values")
     ok(ut_cmp_identical(
         attr(g3_to_tmb(list(~{

--- a/tests/test-step.R
+++ b/tests/test-step.R
@@ -465,3 +465,24 @@ ok_group("g3_step:stock_iterate", {
                             stock[halibut__length_idx, halibut__age_idx, halibut__area_idx])))
     )), "Can turn length back on & iterate over all dimensions")
 })
+
+ok_group("g3_step:stock_isdefined", {
+    ok(gadget3:::ut_cmp_code(gadget3:::g3_step(~{
+        if (stock_isdefined(gerald)) print("woo")
+    }), quote({
+    }), optimize = FALSE), "stock_isdefined alone")
+
+    ok(gadget3:::ut_cmp_code(gadget3:::g3_step(~{
+        for(gerald in 1:10) if (stock_isdefined(gerald)) print("woo")
+    }), quote(
+        for(gerald in 1:10) print("woo")
+    ), optimize = FALSE), "stock_isdefined nested in for")
+
+    ok(gadget3:::ut_cmp_code(gadget3:::g3_step(~{
+        g3_with(gerald := 1, archibald := 2, garibaldi := 3, if (stock_isdefined(gerald)) print("woo") else print("aw"))
+        g3_with(archibald := 2, garibaldi := 3, if (stock_isdefined(gerald)) print("woo") else print("aw"))
+    }), quote({
+        g3_with(gerald := 1, archibald := 2, garibaldi := 3, print("woo"))
+        g3_with(archibald := 2, garibaldi := 3, print("aw"))
+    }), optimize = FALSE), "stock_isdefined nested in g3_with, defines don't leak")
+})

--- a/tests/test-stock_tag.R
+++ b/tests/test-stock_tag.R
@@ -29,3 +29,61 @@ ok(ut_cmp_identical(
     tag_ids(s),
     gadget3:::force_vector("y" = 2L, "nowt" = 0L, "x" = 1L)), "Existing untagged is not disturbed")
 ok(ut_cmp_identical(untagged_idx(s), quote(g3_idx(2L))), "Untagged is middle item")
+
+tags <- c(a = 1L, b = 2L, c = 3L, d = 4L)
+stock_notag <- g3_stock('stock_notag', c(10))
+stock_a <- g3_stock('stock_a', c(10)) %>% g3s_tag(tags[c('a')])
+stock_ac <- g3_stock('stock_ac', c(10)) %>% g3s_tag(tags[c('a', 'c')])
+stock_bcd <- g3_stock('stock_bcd', c(10)) %>% g3s_tag(tags[c('b', 'c', 'd')])
+
+actions <- list(
+    g3a_time(1999, 1999),
+    g3a_otherfood(stock_notag, ~1 + stock_ac__minlen, 0),
+    # NB: Roll our own so we get something in all tags
+    "0:stock_a" = gadget3:::g3_step(g3_formula({
+        stock_iterate(stock_a, stock_ss(stock_a__num) <- tag * 100 + stock_a__minlen)
+    }, stock_a = stock_a, stock_a__num = g3_stock_instance(stock_a, 0))),
+    "0:stock_ac" = gadget3:::g3_step(g3_formula({
+        stock_iterate(stock_ac, stock_ss(stock_ac__num) <- tag * 100 + stock_ac__minlen)
+    }, stock_ac = stock_ac, stock_ac__num = g3_stock_instance(stock_ac, 0))),
+    "0:stock_bcd" = gadget3:::g3_step(g3_formula({
+        stock_iterate(stock_bcd, stock_ss(stock_bcd__num) <- tag * 100 + stock_bcd__minlen)
+    }, stock_bcd = stock_bcd, stock_bcd__num = g3_stock_instance(stock_bcd, 0))),
+    list(
+        '5:sum_ac_notag' = gadget3:::g3_step(g3_formula({
+            comment("sum_ac_notag")
+            stock_iterate(stock_ac, stock_intersect(stock_notag, {
+                sum_ac_notag <- sum_ac_notag +
+                    sum(stock_ss(stock_ac__num)) + sum(stock_ss(stock_notag__num))
+            }))
+            REPORT(sum_ac_notag)
+        }, sum_ac_notag = 0.0, stock_ac = stock_ac, stock_notag = stock_notag) ),
+        '5:sum_notag_bcd' = gadget3:::g3_step(g3_formula({
+            comment("sum_notag_bcd")
+            stock_iterate(stock_notag, stock_intersect(stock_bcd, {
+                sum_notag_bcd <- sum_notag_bcd +
+                    sum(stock_ss(stock_notag__num)) + sum(stock_ss(stock_bcd__num))
+            }))
+            REPORT(sum_notag_bcd)
+        }, sum_notag_bcd = 0.0, stock_bcd = stock_bcd, stock_notag = stock_notag) ),
+
+        # NB: Dummy parameter so model will compile in TMB
+        ~{nll <- nll + g3_param("x", value = 0)} ))
+actions <- c(actions, list(
+    g3a_report_history(actions, var_re = "__num$", out_prefix = NULL) ))
+model_fn <- g3_to_r(actions)
+model_cpp <- g3_to_tmb(actions)
+
+attr(model_fn, 'parameter_template') |>
+    identity() -> params
+r <- attributes(model_fn(params))
+
+# Intersection between stocks without tag means we iterate over all tags
+ok(ut_cmp_identical(
+    r$sum_notag_bcd,
+    sum(r$stock_bcd__num) + as.vector(r$stock_notag__num) * 4 ), "sum_notag_bcd: summed notag for each of the bcd tags")
+ok(ut_cmp_identical(
+    r$sum_ac_notag,
+    as.vector(r$stock_notag__num) * 3 + sum(r$stock_ac__num) ), "sum_ac_notag: summed notag for each of the ac tags")
+
+gadget3:::ut_tmb_r_compare2(model_fn, model_cpp, params)

--- a/vignettes/introduction-single-stock.Rmd
+++ b/vignettes/introduction-single-stock.Rmd
@@ -630,6 +630,7 @@ The TMB parameter template has the following columns:
 * *lower*: A lower bound for this parameter
 * *upper*: An upper bound for this parameter
 * *parscale*: Relative scale for this parameter vs. others
+* *source*: The action in which the parameter was defined. Look at the help for this function for more information on what the parameter does
 
 The model is expecting 5 parameters, ``fish.M.1`` to ``fish.M.5``, for each age group.
 We can either fix these to known values, or configure bounds to optimise within.


### PR DESCRIPTION
A grab bag of unrelated things that have come up whilst looking at ``g3l_individual``.

Probably most interesting is this adds a extra column to the parameter template, *source*. ``g3_parameterized()`` now looks at the call chain of what called it, finds the first g3-ish thing and adds that to the table. Thus whilst we don't get full help in the table, we at least get a reference to where you can find out more.

* Make sure the description of arrays actually makes it into models (even if we're still not using it yet)
* Add stock_isdefined, so a stock with area can intersect a stock without (which we'll need for g3l_individual, but generally useful)
* Use the parameter template as default params if none provided, so you can just call ``model_fn()`` for the R model