### PR TITLE
Templated dif_pmax(), dif_pmin(), dif_pminmax()

### DIFF
--- a/R/aaa_lang.R
+++ b/R/aaa_lang.R
@@ -8,6 +8,7 @@ g3_native <- function(r, cpp, depends = c()) {
     #     Ideally we'd be using a reference to base::as.numeric, but that's causing
     #     unfathomable problems in to_tmb land.
     out <- r
+    for (fn_name in depends) environment(out)[[fn_name]] <- g3_env[[fn_name]]  # Link dependencies for g3_eval
     attr(out, "g3_native_cpp") <- cpp
     # Turn depends vector into something that calls each item, to work with var_defns
     attr(out, "g3_native_depends") <- as.call(c(as.symbol("{"), lapply(depends, as.symbol)))  # }

--- a/R/aab_env.R
+++ b/R/aab_env.R
@@ -54,9 +54,6 @@ g3_env$bounded_vec <- g3_native(r = function (x, a, b) {
     return a + (b-a)/(1+exp(x));
 }')
 
-# vector<Type> form of pow()
-g3_env$pow_vec <- g3_native(r = function(a, b) { a ^ b }, cpp = list('pow', 'vector<Type>', NULL))
-
 # Return first non-null argument. Doesn't really make sense in C++
 g3_env$nvl <- g3_native(r = function(...) {
     for (i in seq_len(...length())) if (!is.null(...elt(i))) return(...elt(i))

--- a/R/aab_env.R
+++ b/R/aab_env.R
@@ -45,23 +45,17 @@ g3_env$logspace_minmax_vec <- g3_native(r = function(vec, lower, upper, scale) {
 # NB: We have to have avoid_zero in our namespace so CMD check doesn't complain about it's use
 #     in surveyindices_linreg(). Maybe g3_env should just go away and use the package
 #     namespace instead?
-g3_env$avoid_zero <- avoid_zero <- g3_native(r = function (a) {
-    # https://github.com/kaskr/adcomp/issues/7#issuecomment-642559660
-    ( pmax(a * 1000, 0) + log1p(exp(pmin(a * 1000, 0) - pmax(a * 1000, 0))) ) / 1000
-}, cpp = '[](Type a) -> Type {
-    return logspace_add(a * 1000.0, (Type)0.0) / 1000.0;
-}')
+g3_env$avoid_zero <- g3_native(r = function(a) {
+    dif_pmax(a, 0.0, 1e3)
+}, cpp = '
+template<typename X>
+auto __fn__(X a) {
+    return dif_pmax(a, 0.0, 1e3);
+}
+', depends = c("dif_pmax"))
 
-g3_env$avoid_zero_vec <- g3_native(r = function (a) {
-    # https://github.com/kaskr/adcomp/issues/7#issuecomment-642559660
-    ( pmax(a * 1000, 0) + log1p(exp(pmin(a * 1000, 0) - pmax(a * 1000, 0))) ) / 1000
-}, cpp = '[](vector<Type> a) -> vector<Type> {
-    vector<Type> res(a.size());
-    for(int i = 0; i < a.size(); i++) {
-        res[i] = logspace_add(a[i] * 1000.0, (Type)0.0) / 1000.0;
-    }
-    return res;
-}')
+# Now-redundant alias
+g3_env$avoid_zero_vec <- g3_env$avoid_zero
 
 # Divide a vector by it's sum, i.e. so it now sums to 1
 g3_env$normalize_vec <- g3_native(r = function (a) {
@@ -164,10 +158,10 @@ g3_env$as_numeric_vec <- g3_native(r = function (x) x, cpp = '[](vector<Type> x)
 
 # Sum (orig_vec) & (new_vec) according to ratio of (orig_amount) & (new_amount)
 g3_env$ratio_add_vec <- g3_native(r = function(orig_vec, orig_amount, new_vec, new_amount) {
-    (orig_vec * orig_amount + new_vec * new_amount) / avoid_zero_vec(orig_amount + new_amount)
-}, cpp = '[&avoid_zero_vec](vector<Type> orig_vec, vector<Type> orig_amount, vector<Type> new_vec, vector<Type> new_amount) -> vector<Type> {
-    return (orig_vec * orig_amount + new_vec * new_amount) / avoid_zero_vec(orig_amount + new_amount);
-}', depends = c('avoid_zero_vec'))
+    (orig_vec * orig_amount + new_vec * new_amount) / avoid_zero(orig_amount + new_amount)
+}, cpp = '[](vector<Type> orig_vec, vector<Type> orig_amount, vector<Type> new_vec, vector<Type> new_amount) -> vector<Type> {
+    return (orig_vec * orig_amount + new_vec * new_amount) / avoid_zero(orig_amount + new_amount);
+}', depends = c('avoid_zero'))
 
 
 g3_env$nonconform_add <- g3_native(r = function (base_ar, extra_ar) {

--- a/R/aab_env.R
+++ b/R/aab_env.R
@@ -40,14 +40,14 @@ g3_env$normalize_vec <- g3_native(r = function (a) {
     return a / a.sum();
 }')
 
-# Return scalar (x) bounded between (a) and (b)
+# If (x) positive, return (a). If (x) negative, (b). If (x) -10..10, smoothly transition from (b) to (a)
 g3_env$bounded <- g3_native(r = function (x, a, b) {
   a + (b-a)/(1+exp(x))
 }, cpp = '[](Type x, Type a, Type b) -> Type {
     return a + (b-a)/(1+exp(x));
 }')
 
-# Return vector (x) bounded between (a) and (b)
+# If (x) positive, return (a). If (x) negative, (b). If (x) -10..10, smoothly transition from (b) to (a)
 g3_env$bounded_vec <- g3_native(r = function (x, a, b) {
   a + (b-a)/(1+exp(x))
 }, cpp = '[](vector<Type> x, Type a, Type b) -> vector<Type> {

--- a/R/aab_env.R
+++ b/R/aab_env.R
@@ -31,17 +31,6 @@ g3_env$logspace_add_vec <- g3_native(r = function(a,b) {
     return res;
 }')
 
-# differentiable equivalent of pmax(pmin(vec, upper), lower)
-g3_env$logspace_minmax_vec <- g3_native(r = function(vec, lower, upper, scale) {
-    vec <- -(g3_env$logspace_add(-vec * scale, -upper * scale) / scale)
-    vec <- g3_env$logspace_add(vec * scale, lower * scale) / scale
-    return(vec)
-}, cpp = '[&logspace_add_vec](vector<Type> vec, Type lower, Type upper, double scale) -> vector<Type> {
-    vec = -(logspace_add_vec(-vec * scale, -upper * scale) / scale);
-    vec = logspace_add_vec(vec * scale, lower * scale) / scale;
-    return(vec);
-}', depends = c("logspace_add_vec"))
-
 # NB: We have to have avoid_zero in our namespace so CMD check doesn't complain about it's use
 #     in surveyindices_linreg(). Maybe g3_env should just go away and use the package
 #     namespace instead?

--- a/R/aab_env.R
+++ b/R/aab_env.R
@@ -18,19 +18,6 @@ g3_env$logspace_add <- g3_native(r = function(a,b) {
     pmax(a, b) + log1p(exp(pmin(a,b) - pmax(a, b)))
 }, cpp = list("logspace_add", "Type", "Type"))  # TMB-native, but arguments have to be cast to Type
 
-
-# vector<Type> form of logspace_add
-g3_env$logspace_add_vec <- g3_native(r = function(a,b) {
-    # https://github.com/kaskr/adcomp/issues/7#issuecomment-642559660
-    pmax(a, b) + log1p(exp(pmin(a,b) - pmax(a, b)))
-}, cpp = '[](vector<Type> a, Type b) -> vector<Type> {
-    vector<Type> res(a.size());
-    for(int i = 0; i < a.size(); i++) {
-        res[i] = logspace_add(a[i], b);
-    }
-    return res;
-}')
-
 # NB: We have to have avoid_zero in our namespace so CMD check doesn't complain about it's use
 #     in surveyindices_linreg(). Maybe g3_env should just go away and use the package
 #     namespace instead?

--- a/R/action_grow.R
+++ b/R/action_grow.R
@@ -98,7 +98,7 @@ g3a_grow_length_weightjones <- function(
               (p0 + stock_ss(stock__feedinglevel) * (p1 + p2 * stock_ss(stock__feedinglevel))) * reference_weight
           ) / stock_ss(stock__wgt)  # No, this is not a regex /
     # NB: All of growth_delta_w is equal, as it doesn't depend on length
-    ~logspace_minmax_vec(p3 + p4 * r, 0, p5, 1e5) * growth_delta_w[,1] / (p6 * p7 * stock__midlen^(p7 - 1))
+    ~dif_pminmax(p3 + p4 * r, 0, p5, 1e5) * growth_delta_w[,1] / (p6 * p7 * stock__midlen^(p7 - 1))
 }
 
 g3a_grow_weight_weightjones <- function(

--- a/R/action_grow.R
+++ b/R/action_grow.R
@@ -28,11 +28,11 @@ g3a_grow_lengthvbsimple <- function (
         kappa_f = g3_parameterized('K', by_stock = by_stock),
         by_stock = TRUE) {
     # See src/growthcalc.cc:GrowthCalcH::calcGrowth
-    # NB: avoid_zero_vec() converts negative growth into zero-growth, due to
+    # NB: avoid_zero() converts negative growth into zero-growth, due to
     #     https://github.com/gadget-framework/gadget3/issues/18
     #     but zero-growth is a valid result here
     f_substitute(
-        ~avoid_zero_vec((linf_f - stock__midlen) * (1 - exp(-(kappa_f) * cur_step_size))),
+        ~avoid_zero((linf_f - stock__midlen) * (1 - exp(-(kappa_f) * cur_step_size))),
         list(linf_f = linf_f, kappa_f = kappa_f))
 }
 
@@ -117,8 +117,8 @@ g3a_grow_weight_weightjones <- function(
         predator_length = function(x) quote( stock__midlen ),
         predstock = function(x) quote( stock ),
         end = NULL )
-    # NB: Pretty easy to have negative growth with nonsense parameters, thus avoid_zero_vec()
-    ~g3a_grow_vec_extrude(avoid_zero_vec(cur_step_size * (
+    # NB: Pretty easy to have negative growth with nonsense parameters, thus avoid_zero()
+    ~g3a_grow_vec_extrude(avoid_zero(cur_step_size * (
         (max_consumption / (q0 * (stock_ss(stock__wgt))^q1)) -
         q2 * (stock_ss(stock__wgt))^q3 * exp(q4 * temperature + q5) )), maxlengthgroupgrowth + 1)
 }
@@ -197,10 +197,10 @@ g3a_grow_impl_bbinom <- function (
     list(
         delta_dim = seq(0, maxlengthgroupgrowth),
         len = f_substitute(
-            # NB: avoid_zero_vec() means zero-growth doesn't result in NaN
+            # NB: avoid_zero() means zero-growth doesn't result in NaN
             # NB: We convert delta_len_f into # of length groups to jump, but badly by assuming length groups
             #     are evenly sized
-            ~growth_bbinom(avoid_zero_vec((delta_len_f) / stock__plusdl), maxlengthgroupgrowth, avoid_zero(beta_f)),
+            ~growth_bbinom(avoid_zero((delta_len_f) / stock__plusdl), maxlengthgroupgrowth, avoid_zero(beta_f)),
             list(
                 delta_len_f = delta_len_f,
                 maxlengthgroupgrowth = maxlengthgroupgrowth,
@@ -292,10 +292,6 @@ g3a_grow_apply <- g3_native(r = function (growth.matrix, wgt.matrix, input_num, 
     na <- dim(growth.matrix)[[1]]  # Number of length groups
     # See stockmemberfunctions.cc:121, grow.cc:25
 
-    avoid_zero_vec <- function(a) {
-        ( pmax(a * 1000, 0) + log1p(exp(pmin(a * 1000, 0) - pmax(a * 1000, 0))) ) / 1000
-    }
-
     # Apply matrices to stock
     growth.matrix <- growth.matrix * as.vector(input_num)  # NB: Cant matrix-multiply with a 1xn array
     wgt.matrix <- growth.matrix * (wgt.matrix + as.vector(input_wgt))
@@ -304,17 +300,9 @@ g3a_grow_apply <- g3_native(r = function (growth.matrix, wgt.matrix, input_num, 
     growth.matrix.sum <- colSums(growth.matrix)
     return(array(c(
         growth.matrix.sum,
-        colSums(wgt.matrix) / avoid_zero_vec(growth.matrix.sum) ), dim = c(na, 2)))
+        colSums(wgt.matrix) / avoid_zero(growth.matrix.sum) ), dim = c(na, 2)))
 }, cpp = '[](matrix<Type> growth_matrix, matrix<Type> weight_matrix, vector<Type> input_num, vector<Type> input_wgt) -> array<Type> {
     int total_lgs = growth_matrix.cols(); // # Length groups
-
-    auto avoid_zero_vec = [](vector<Type> a) -> vector<Type> {
-        vector<Type> res(a.size());
-        for(int i = 0; i < a.size(); i++) {
-            res[i] = logspace_add(a[i] * 1000.0, (Type)0.0) / 1000.0;
-        }
-        return res;
-    };
 
     // Apply matrices to stock
     // NB: Cast to array to get elementwise multiplication
@@ -324,9 +312,9 @@ g3a_grow_apply <- g3_native(r = function (growth.matrix, wgt.matrix, input_num, 
     // Sum together all length group brackets for both length & weight
     array<Type> combined(total_lgs,2);
     combined.col(0) = growth_matrix.colwise().sum();
-    combined.col(1) = weight_matrix.colwise().sum().array().rowwise() / avoid_zero_vec(growth_matrix.colwise().sum()).array().transpose();
+    combined.col(1) = weight_matrix.colwise().sum().array().rowwise() / avoid_zero(growth_matrix.colwise().sum()).array().transpose();
     return combined;
-}')
+}', depends = c("avoid_zero"))
 
 # Combined growth / maturity step for a stock
 # - impl_f: formulae for growth implmentation, e.g. g3a_grow_impl_bbinom()

--- a/R/action_grow.R
+++ b/R/action_grow.R
@@ -47,8 +47,8 @@ g3a_grow_weightsimple <- function (
     # growmemberfunctions.cc:61 - Make a l --> l' matrix of weight increases,
     # NB: Have to multiply by alpha_f last, otherwise TMB thinks the result should be scalar
     f_substitute(~(
-        g3a_grow_vec_rotate(pow_vec(stock__midlen, beta_f), maxlengthgroupgrowth + 1) -
-        g3a_grow_vec_extrude(pow_vec(stock__midlen, beta_f), maxlengthgroupgrowth + 1)
+        g3a_grow_vec_rotate(stock__midlen^beta_f, maxlengthgroupgrowth + 1) -
+        g3a_grow_vec_extrude(stock__midlen^beta_f, maxlengthgroupgrowth + 1)
     ) * (alpha_f), list(alpha_f = alpha_f, beta_f = beta_f))
 }
 

--- a/R/action_mature.R
+++ b/R/action_mature.R
@@ -93,7 +93,7 @@ g3a_step_transition <- function(input_stock,
                 # NB: Assuming that there won't be leftover length
                 if (move_remainder) stock_ss(input_stock__transitioning_num) <- stock_ss(input_stock__transitioning_num) - stock_ss(input_stock__transitioning_num) * output_ratio
                 # Back down to mean biomass
-                stock_ss(output_stock__wgt) <- stock_ss(output_stock__wgt) / avoid_zero_vec(stock_ss(output_stock__num))
+                stock_ss(output_stock__wgt) <- stock_ss(output_stock__wgt) / avoid_zero(stock_ss(output_stock__num))
             }))
 
             if (move_remainder) {
@@ -132,7 +132,7 @@ g3a_step_transition <- function(input_stock,
                     # NB: Assuming that there won't be leftover length
                     if (move_remainder) stock_ss(input_stock__transitioning_remainder) <- stock_ss(input_stock__transitioning_remainder) - stock_ss(input_stock__transitioning_num) * output_ratio
                     # Back down to mean biomass
-                    stock_ss(output_stock__wgt) <- stock_ss(output_stock__wgt) / avoid_zero_vec(stock_ss(output_stock__num))
+                    stock_ss(output_stock__wgt) <- stock_ss(output_stock__wgt) / avoid_zero(stock_ss(output_stock__num))
                 }))
             }, list(
                 output_ratio = output_ratios[[n]],

--- a/R/action_predate.R
+++ b/R/action_predate.R
@@ -152,9 +152,7 @@ g3a_predate <- function (
         prey_stocks,
         suitabilities,
         catchability_f,
-        overconsumption_f = quote(
-            logspace_add_vec(stock__consratio * -1e3, 0.95 * -1e3) / -1e3
-        ),
+        overconsumption_f = quote( dif_pmin(stock__consratio, 0.95, 1e3) ),
         run_f = ~TRUE,
         run_at = g3_action_order$predate ) {
     out <- new.env(parent = emptyenv())
@@ -335,7 +333,7 @@ g3a_predate_fleet <- function (fleet_stock,
                                     prey_stocks,
                                     suitabilities,
                                     catchability_f,
-                                    overconsumption_f = quote( logspace_add_vec(stock__consratio * -1e3, 0.95 * -1e3) / -1e3 ),
+                                    overconsumption_f = quote( dif_pmin(stock__consratio, 0.95, 1e3) ),
                                     run_f = ~TRUE,
                                     run_at = g3_action_order$predate) {
     predstock <- fleet_stock
@@ -391,7 +389,7 @@ g3a_predate_totalfleet <- function (fleet_stock,
                                     prey_stocks,
                                     suitabilities,
                                     amount_f,
-                                    overconsumption_f = quote( logspace_add_vec(stock__consratio * -1e3, 0.95 * -1e3) / -1e3 ),
+                                    overconsumption_f = quote( dif_pmin(stock__consratio, 0.95, 1e3) ),
                                     run_f = ~TRUE,
                                     run_at = g3_action_order$predate) {
     g3a_predate_fleet(fleet_stock, prey_stocks, suitabilities, overconsumption_f = overconsumption_f, run_f = run_f, run_at = run_at,

--- a/R/action_predate.R
+++ b/R/action_predate.R
@@ -297,14 +297,14 @@ g3a_predate <- function (
                 # NB: See prey.cc::208
                 # stock__consratio == ratio
                 # stock__consratio proportion of prey that we're about to consume
-                stock__consratio <- stock__totalpredate / avoid_zero_vec(stock__num * stock__wgt)
+                stock__consratio <- stock__totalpredate / avoid_zero(stock__num * stock__wgt)
                 stock__consratio <- overconsumption_f
 
                 # stock__overconsumption: biomass over overconsumption limit.  This is used by g3l_understocking()
                 stock__overconsumption <- sum(stock__totalpredate)
 
                 # Apply overconsumption to stock__totalpredate, work out conversion factor for predprey__cons
-                stock__consconv <- 1 / avoid_zero_vec(stock__totalpredate)
+                stock__consconv <- 1 / avoid_zero(stock__totalpredate)
                 stock__totalpredate <- (stock__num * stock__wgt) * stock__consratio
                 stock__overconsumption <- stock__overconsumption - sum(stock__totalpredate)
                 stock__consconv <- stock__consconv * stock__totalpredate

--- a/R/action_tagging.R
+++ b/R/action_tagging.R
@@ -39,7 +39,7 @@ g3a_predate_tagrelease <- function (
             stock_iterate(stock, stock_intersect(fleet_stock, stock_with(predprey, if (run_f) g3_with(
                     # Numbers caught (predstock_stock__cons is total weight)
                     output_tag_idx := tag_idx_f,
-                    tagged_num := stock_ss(predprey__cons) / avoid_zero_vec(stock_ss(stock__wgt)), {
+                    tagged_num := stock_ss(predprey__cons) / avoid_zero(stock_ss(stock__wgt)), {
                 stock_ss(stock__wgt, tag = output_tag_idx) <- ratio_add_vec(
                     stock_ss(stock__wgt, tag = output_tag_idx), stock_ss(stock__num, tag = output_tag_idx),
                     stock_ss(stock__wgt), (1.0 - mortality_f) * tagged_num)

--- a/R/action_weightloss.R
+++ b/R/action_weightloss.R
@@ -27,7 +27,7 @@ g3a_weightloss <- function (
         list(wl_f = wl_f) )
     if (!is.null(abs_loss)) wl_f <- f_substitute(
         g3_formula(
-            quote( logspace_add_vec((wl_f - abs_loss) * 1e7, min_weight) / 1e7 ),
+            quote( dif_pmax((wl_f - abs_loss), min_weight, 1e7) ),
             min_weight = min_weight,
             abs_loss = abs_loss ),
         list(wl_f = wl_f) )

--- a/R/env_dif.R
+++ b/R/env_dif.R
@@ -54,14 +54,14 @@ auto __fn__(X a, Y b, double scale) {
 
 # pminmax does both pmin & pmax
 g3_env$dif_pminmax <- g3_native(r = function(a, lower, upper, scale) {
-    a <- dif_pmax(a, upper, -scale)
-    a <- dif_pmax(a, lower, scale)
-    return(a)
+    out <- dif_pmax(a, upper, -scale)
+    out <- dif_pmax(out, lower, scale)
+    return(out)
 }, cpp = '
-template<typename X, typename Y>
-auto __fn__(X a, Y lower, Y upper, double scale) {
-    a = dif_pmax(a, upper, -scale);
-    a = dif_pmax(a, lower, scale);
-    return a;
+template<typename X, typename Y, typename Z>
+auto __fn__(X a, Y lower, Z upper, double scale) {
+    auto out = dif_pmax(a, upper, -scale);
+    out = dif_pmax(out, lower, scale);
+    return out;
 }
 ', depends = c("dif_pmax"))

--- a/R/env_dif.R
+++ b/R/env_dif.R
@@ -1,0 +1,67 @@
+g3_env$dif_pmax <- g3_native(r = function(a, b, scale) {
+    # https://github.com/kaskr/adcomp/issues/7#issuecomment-642559660
+    logspace_add <- function(a, b) pmax(a, b) + log1p(exp(pmin(a,b) - pmax(a, b)))
+
+    b <- as.vector(b)
+    logspace_add(a * scale, b * scale) / scale
+}, cpp = '
+// Scalar templates
+template<typename T, typename LimitT, TYPE_IS_SCALAR(T), TYPE_IS_SCALAR(LimitT)>
+T __fn__(T a, LimitT b, double scale) {
+    return logspace_add(a * scale, (T)b * scale) / scale;
+}
+// templates for vector<Type>s & Eigen derived vectors
+template<typename LimitT, typename Derived, TYPE_IS_SCALAR(LimitT)>
+vector<typename Derived::value_type> __fn__(const Eigen::DenseBase<Derived>& a, LimitT b, double scale) {
+    vector<typename Derived::value_type> out(a.size());
+    for(int i = 0; i < a.size(); i++) out[i] = logspace_add(a[i] * scale, (typename Derived::value_type)b * scale) / scale;
+    return out;
+}
+template<typename LimitT, typename Derived>
+vector<typename Derived::value_type> __fn__(const Eigen::DenseBase<Derived>& a, const Eigen::DenseBase<LimitT>& b, double scale) {
+    assert(a.size() % b.size() == 0);
+
+    vector<typename Derived::value_type> out(a.size());
+    for(int i = 0; i < a.size(); i++) out[i] = logspace_add(a[i] * scale, (typename Derived::value_type)(b[i % b.size()]) * scale) / scale;
+    return out;
+}
+// Templates for Eigen derived arrays
+template<typename LimitT, typename Derived, TYPE_IS_SCALAR(LimitT)>
+array<typename Derived::value_type> __fn__(const Eigen::Map<Eigen::DenseBase<Derived>>& a, LimitT b, double scale) {
+    array<typename Derived::value_type> out(a.size());
+    for(int i = 0; i < a.size(); i++) out[i] = logspace_add(a[i] * scale, (typename Derived::value_type)b * scale) / scale;
+    return out;
+}
+template<typename LimitT, typename Derived>
+array<typename Derived::value_type> __fn__(const Eigen::Map<Eigen::DenseBase<Derived>>& a, const Eigen::DenseBase<LimitT>& b, double scale) {
+    assert(a.size() % b.size() == 0);
+
+    array<typename Derived::value_type> out(a.size());
+    for(int i = 0; i < a.size(); i++) out[i] = logspace_add(a[i] * scale, (typename Derived::value_type)(b[i % b.size()]) * scale) / scale;
+    return out;
+}
+')
+
+# pmin is pmax with a negative scale
+g3_env$dif_pmin <- g3_native(r = function(a, b, scale) {
+    dif_pmax(a, b, -scale)
+}, cpp = '
+template<typename X, typename Y>
+auto __fn__(X a, Y b, double scale) {
+    return dif_pmax(a, b, -scale);
+}
+', depends = c("dif_pmax"))
+
+# pminmax does both pmin & pmax
+g3_env$dif_pminmax <- g3_native(r = function(a, lower, upper, scale) {
+    a <- dif_pmax(a, upper, -scale)
+    a <- dif_pmax(a, lower, scale)
+    return(a)
+}, cpp = '
+template<typename X, typename Y>
+auto __fn__(X a, Y lower, Y upper, double scale) {
+    a = dif_pmax(a, upper, -scale);
+    a = dif_pmax(a, lower, scale);
+    return a;
+}
+', depends = c("dif_pmax"))

--- a/R/likelihood_distribution.R
+++ b/R/likelihood_distribution.R
@@ -46,9 +46,10 @@ g3l_distribution_multinomial <- function (epsilon = 10) {
             data = quote(stock_ss(obsstock__x))))
 
     likely <- substitute(
-        -sum(data * log(logspace_add_vec(
-            dist / avoid_zero(sum(dist)) * 10000,
-            (1 / (length(data) * epsilon)) * 10000) / 10000)), list(
+        -sum(data * log(dif_pmax(
+            dist / avoid_zero(sum(dist)),
+            1 / (length(data) * epsilon),
+            10000 ))), list(
                 data = quote(stock_ss(obsstock__x)),
                 dist = quote(stock_ss(modelstock__x)),
                 epsilon = epsilon))

--- a/R/likelihood_distribution.R
+++ b/R/likelihood_distribution.R
@@ -11,7 +11,7 @@ dist_prop <- function (var_name, over) {
             x = call("stock_ss", var_sym, length = length_idx_sym),
             total = as.symbol(total_var_name),
             idx = as.symbol(gsub('__x$', '__length_idx', var_name))))
-        total_call <- substitute(avoid_zero_vec(rowSums(x)), list(
+        total_call <- substitute(avoid_zero(rowSums(x)), list(
             x = call_append(call("stock_ssinv", var_sym), over[over != 'length'])))
     } else {
         out <- substitute(x / total, list(
@@ -81,16 +81,17 @@ g3l_distribution_multivariate <- function (rho_f, sigma_f, over = c('area')) {
 g3l_distribution_surveyindices <- function (fit = 'log', alpha = NULL, beta = NULL) {
     stopifnot(fit == 'linear' || fit == 'log')
 
-    N <- if(fit == 'log') ~log(avoid_zero_vec(stock_ss(modelstock__x, time =))) else ~stock_ss(modelstock__x, time = )
-    I <- if(fit == 'log') ~log(avoid_zero_vec(stock_ss(obsstock__x, time =))) else ~stock_ss(obsstock__x, time = )
+    N <- if(fit == 'log') ~log(avoid_zero(stock_ss(modelstock__x, time =))) else ~stock_ss(modelstock__x, time = )
+    I <- if(fit == 'log') ~log(avoid_zero(stock_ss(obsstock__x, time =))) else ~stock_ss(obsstock__x, time = )
 
+    avoid_zero <- g3_env$avoid_zero  # Quell CRAN warning
     surveyindices_linreg <- g3_native(r = function (N, I, fixed_alpha, fixed_beta) {
         meanI <- mean(I)
         meanN <- mean(N)
         beta <- if (is.nan(fixed_beta)) sum((I - meanI) * (N - meanN)) / avoid_zero(sum((N - meanN)**2)) else fixed_beta
         alpha <- if (is.nan(fixed_alpha)) meanI - beta * meanN else fixed_alpha
         return(c(alpha, beta))
-    }, cpp = '[&avoid_zero](vector<Type> N, vector<Type> I, Type fixed_alpha, Type fixed_beta) -> vector<Type> {
+    }, cpp = '[](vector<Type> N, vector<Type> I, Type fixed_alpha, Type fixed_beta) -> vector<Type> {
         vector<Type> out(2);
 
         auto meanI = I.mean();
@@ -287,7 +288,7 @@ g3l_distribution <- function (
                     end = NULL )[[obs_name]]
             } else {
                 collect_fs[[obs_name]] <- list(
-                    num = quote( stock_ss(predprey__cons) / avoid_zero_vec(stock_ss(prey_stock__wgt)) ),
+                    num = quote( stock_ss(predprey__cons) / avoid_zero(stock_ss(prey_stock__wgt)) ),
                     wgt = quote( stock_ss(predprey__cons) ),
                     end = NULL )[[obs_name]]
             }

--- a/R/likelihood_tagging_ckmr.R
+++ b/R/likelihood_tagging_ckmr.R
@@ -73,7 +73,7 @@ g3l_tagging_ckmr <- function (
                 stock_iterate(prey_stock, stock_interact(predstock, stock_intersect(modelhist, stock_with(predprey, {
                     stock_with(predstock, debug_trace("Convert ", predstock, " catch of ", prey_stock, " to numbers, add it to our total"))
                     stock_ss(modelhist__catch) <- stock_ss(modelhist__catch) +
-                        stock_reshape(modelhist, stock_ss(predprey__cons) / avoid_zero_vec(stock_ss(prey_stock__wgt)))
+                        stock_reshape(modelhist, stock_ss(predprey__cons) / avoid_zero(stock_ss(prey_stock__wgt)))
                 }))))
             }, list(
                 end = NULL)))))
@@ -96,7 +96,7 @@ g3l_tagging_ckmr <- function (
                   modelhist__offspring_idx := g3_idx(offspring_age - modelhist__minage + 1),
                   mopairs := as_integer(obsdata_pairs[[g3_idx(4), pairs_idx]]),
                   # i.e. # spawned per-parent at this time
-                  fecundity_of_parents := modelhist__spawned[,modelhist__offspring_idx] / avoid_zero_vec(modelhist__spawning[,modelhist__offspring_idx]),
+                  fecundity_of_parents := modelhist__spawned[,modelhist__offspring_idx] / avoid_zero(modelhist__spawning[,modelhist__offspring_idx]),
                   # Convert to a probability using (3.4):-
                   cur_ckmr_p := (fecundity_of_parents[[modelhist__parent_idx]] / modelhist__catch[[modelhist__parent_idx]]) / sum(fecundity_of_parents), {
                     # Pseudo-likelihood as per (4.1)

--- a/R/suitability.R
+++ b/R/suitability.R
@@ -16,10 +16,10 @@ g3_suitability_andersen <- function (p0, p1, p2, p3 = p4, p4, p5 = quote(predato
   # NB: We need to cast this to vector<Type>, otherwise TMBad fails when trying to form the tape:
   #     https://github.com/gadget-framework/gadget3/issues/161
   f_substitute(~g3_cast_vector(p0 +
-                 avoid_zero(p2) * exp(-(log(avoid_zero_vec(p5/stock__midlen)) - p1)**2/avoid_zero(p3)) *
-                 bounded_vec(1000*(p1 - log(avoid_zero_vec(p5/stock__midlen))),0,1) +
-                 avoid_zero(p2) * exp(-(log(avoid_zero_vec(p5/stock__midlen)) - p1)**2/avoid_zero(p4)) *
-                 bounded_vec(1000*(log(avoid_zero_vec(p5/stock__midlen)) - p1),0,1)),
+                 avoid_zero(p2) * exp(-(log(avoid_zero(p5/stock__midlen)) - p1)**2/avoid_zero(p3)) *
+                 bounded_vec(1000*(p1 - log(avoid_zero(p5/stock__midlen))),0,1) +
+                 avoid_zero(p2) * exp(-(log(avoid_zero(p5/stock__midlen)) - p1)**2/avoid_zero(p4)) *
+                 bounded_vec(1000*(log(avoid_zero(p5/stock__midlen)) - p1),0,1)),
                list(
                  p0 = p0,
                  p1 = p1,

--- a/baseline/introduction-single-stock.cpp
+++ b/baseline/introduction-single-stock.cpp
@@ -75,6 +75,10 @@ template<typename X>
 auto avoid_zero(X a) {
     return dif_pmax(a, 0.0, 1e3);
 }
+template<typename X, typename Y>
+auto dif_pmin(X a, Y b, double scale) {
+    return dif_pmax(a, b, -scale);
+}
 template<typename T> std::map<int, T> intlookup_zip(vector<int> keys, vector<T> values) {
             std::map<int, T> lookup = {};
 
@@ -329,13 +333,6 @@ Type objective_function<Type>::operator() () {
     auto nonconform_add = [](array<Type> base_ar, array<Type> extra_ar) -> array<Type> {
     assert(base_ar.size() % extra_ar.size() == 0);
     return base_ar + (extra_ar.replicate(base_ar.size() / extra_ar.size(), 1));
-};
-    auto logspace_add_vec = [](vector<Type> a, Type b) -> vector<Type> {
-    vector<Type> res(a.size());
-    for(int i = 0; i < a.size(); i++) {
-        res[i] = logspace_add(a[i], b);
-    }
-    return res;
 };
     auto nonconform_mult = [](array<Type> base_ar, array<Type> extra_ar) -> array<Type> {
     assert(base_ar.size() % extra_ar.size() == 0);
@@ -714,7 +711,7 @@ Type objective_function<Type>::operator() () {
             // Calculate fish overconsumption coefficient;
             // Apply overconsumption to fish;
             fish__consratio = fish__totalpredate / avoid_zero(fish__num*fish__wgt);
-            fish__consratio = logspace_add_vec(fish__consratio*-(double)(1000), (double)(0.95)*-(double)(1000)) / -(double)(1000);
+            fish__consratio = dif_pmin(fish__consratio, (double)(0.95), (double)(1000));
             fish__overconsumption = (fish__totalpredate).sum();
             fish__consconv = (double)(1) / avoid_zero(fish__totalpredate);
             fish__totalpredate = (fish__num*fish__wgt)*fish__consratio;

--- a/baseline/introduction-single-stock.cpp
+++ b/baseline/introduction-single-stock.cpp
@@ -411,10 +411,10 @@ Type objective_function<Type>::operator() () {
     combined.col(1) = weight_matrix.colwise().sum().array().rowwise() / avoid_zero_vec(growth_matrix.colwise().sum()).array().transpose();
     return combined;
 };
-    auto ratio_add_vec = [&avoid_zero_vec](vector<Type> orig_vec, vector<Type> orig_amount, vector<Type> new_vec, vector<Type> new_amount) -> vector<Type> {
+    auto ratio_add_vec = [](vector<Type> orig_vec, vector<Type> orig_amount, vector<Type> new_vec, vector<Type> new_amount) -> vector<Type> {
     return (orig_vec * orig_amount + new_vec * new_amount) / avoid_zero_vec(orig_amount + new_amount);
 };
-    auto surveyindices_linreg = [&avoid_zero](vector<Type> N, vector<Type> I, Type fixed_alpha, Type fixed_beta) -> vector<Type> {
+    auto surveyindices_linreg = [](vector<Type> N, vector<Type> I, Type fixed_alpha, Type fixed_beta) -> vector<Type> {
         vector<Type> out(2);
 
         auto meanI = I.mean();

--- a/baseline/introduction-single-stock.cpp
+++ b/baseline/introduction-single-stock.cpp
@@ -742,7 +742,7 @@ Type objective_function<Type>::operator() () {
         {
             auto growth_delta_l = (fish__growth_lastcalc == std::floor(cur_step_size*12) ? fish__growth_l : (fish__growth_l = growth_bbinom(avoid_zero(avoid_zero((fish__Linf - fish__midlen)*((double)(1) - exp(-(fish__K)*cur_step_size))) / fish__plusdl), 4, avoid_zero(fish__bbin))));
 
-            auto growth_delta_w = (fish__growth_lastcalc == std::floor(cur_step_size*12) ? fish__growth_w : (fish__growth_w = (g3a_grow_vec_rotate(pow((vector<Type>)(fish__midlen), fish__wbeta), 4 + (double)(1)) - g3a_grow_vec_extrude(pow((vector<Type>)(fish__midlen), fish__wbeta), 4 + (double)(1)))*fish__walpha));
+            auto growth_delta_w = (fish__growth_lastcalc == std::floor(cur_step_size*12) ? fish__growth_w : (fish__growth_w = (g3a_grow_vec_rotate((fish__midlen).pow(fish__wbeta), 4 + (double)(1)) - g3a_grow_vec_extrude((fish__midlen).pow(fish__wbeta), 4 + (double)(1)))*fish__walpha));
 
             auto growthmat_w = g3a_grow_matrix_wgt(growth_delta_w);
 

--- a/baseline/introduction-single-stock.cpp
+++ b/baseline/introduction-single-stock.cpp
@@ -23,9 +23,58 @@ namespace map_extras {
     }
 }
 
+
+#ifndef TYPE_IS_SCALAR
+#ifdef TMBAD_FRAMEWORK
+#define TYPE_IS_SCALAR(TestT) typename = std::enable_if_t<std::is_same<TestT, int>::value || std::is_same<TestT, double>::value || std::is_same<TestT, TMBad::global::ad_aug>::value>
+#endif // TMBAD_FRAMEWORK
+#ifdef CPPAD_FRAMEWORK
+#define TYPE_IS_SCALAR(TestT) typename = std::enable_if_t<std::is_same<TestT, int>::value || std::is_same<TestT, double>::value || std::is_same<TestT, CppAD::AD>::value>
+#endif // CPPAD_FRAMEWORK
+#endif // TYPE_IS_SCALAR
+
 template<typename T, typename DefT> T intlookup_getdefault(std::map<int, T> lookup, int key, DefT def) {
             return lookup.count(key) > 0 ? lookup[key] : (T)def;
         }
+// Scalar templates
+template<typename T, typename LimitT, TYPE_IS_SCALAR(T), TYPE_IS_SCALAR(LimitT)>
+T dif_pmax(T a, LimitT b, double scale) {
+    return logspace_add(a * scale, (T)b * scale) / scale;
+}
+// templates for vector<Type>s & Eigen derived vectors
+template<typename LimitT, typename Derived, TYPE_IS_SCALAR(LimitT)>
+vector<typename Derived::value_type> dif_pmax(const Eigen::DenseBase<Derived>& a, LimitT b, double scale) {
+    vector<typename Derived::value_type> out(a.size());
+    for(int i = 0; i < a.size(); i++) out[i] = logspace_add(a[i] * scale, (typename Derived::value_type)b * scale) / scale;
+    return out;
+}
+template<typename LimitT, typename Derived>
+vector<typename Derived::value_type> dif_pmax(const Eigen::DenseBase<Derived>& a, const Eigen::DenseBase<LimitT>& b, double scale) {
+    assert(a.size() % b.size() == 0);
+
+    vector<typename Derived::value_type> out(a.size());
+    for(int i = 0; i < a.size(); i++) out[i] = logspace_add(a[i] * scale, (typename Derived::value_type)(b[i % b.size()]) * scale) / scale;
+    return out;
+}
+// Templates for Eigen derived arrays
+template<typename LimitT, typename Derived, TYPE_IS_SCALAR(LimitT)>
+array<typename Derived::value_type> dif_pmax(const Eigen::Map<Eigen::DenseBase<Derived>>& a, LimitT b, double scale) {
+    array<typename Derived::value_type> out(a.size());
+    for(int i = 0; i < a.size(); i++) out[i] = logspace_add(a[i] * scale, (typename Derived::value_type)b * scale) / scale;
+    return out;
+}
+template<typename LimitT, typename Derived>
+array<typename Derived::value_type> dif_pmax(const Eigen::Map<Eigen::DenseBase<Derived>>& a, const Eigen::DenseBase<LimitT>& b, double scale) {
+    assert(a.size() % b.size() == 0);
+
+    array<typename Derived::value_type> out(a.size());
+    for(int i = 0; i < a.size(); i++) out[i] = logspace_add(a[i] * scale, (typename Derived::value_type)(b[i % b.size()]) * scale) / scale;
+    return out;
+}
+template<typename X>
+auto avoid_zero(X a) {
+    return dif_pmax(a, 0.0, 1e3);
+}
 template<typename T> std::map<int, T> intlookup_zip(vector<int> keys, vector<T> values) {
             std::map<int, T> lookup = {};
 
@@ -281,13 +330,6 @@ Type objective_function<Type>::operator() () {
     assert(base_ar.size() % extra_ar.size() == 0);
     return base_ar + (extra_ar.replicate(base_ar.size() / extra_ar.size(), 1));
 };
-    auto avoid_zero_vec = [](vector<Type> a) -> vector<Type> {
-    vector<Type> res(a.size());
-    for(int i = 0; i < a.size(); i++) {
-        res[i] = logspace_add(a[i] * 1000.0, (Type)0.0) / 1000.0;
-    }
-    return res;
-};
     auto logspace_add_vec = [](vector<Type> a, Type b) -> vector<Type> {
     vector<Type> res(a.size());
     for(int i = 0; i < a.size(); i++) {
@@ -331,9 +373,6 @@ Type objective_function<Type>::operator() () {
             lgamma(alpha)).exp();
         return(val);
     };
-    auto avoid_zero = [](Type a) -> Type {
-    return logspace_add(a * 1000.0, (Type)0.0) / 1000.0;
-};
     auto g3a_grow_vec_rotate = [](vector<Type> vec, int a) -> array<Type> {
     array<Type> out(vec.size(), a);
     for (int i = 0 ; i < vec.size(); i++) {
@@ -392,14 +431,6 @@ Type objective_function<Type>::operator() () {
     auto g3a_grow_apply = [](matrix<Type> growth_matrix, matrix<Type> weight_matrix, vector<Type> input_num, vector<Type> input_wgt) -> array<Type> {
     int total_lgs = growth_matrix.cols(); // # Length groups
 
-    auto avoid_zero_vec = [](vector<Type> a) -> vector<Type> {
-        vector<Type> res(a.size());
-        for(int i = 0; i < a.size(); i++) {
-            res[i] = logspace_add(a[i] * 1000.0, (Type)0.0) / 1000.0;
-        }
-        return res;
-    };
-
     // Apply matrices to stock
     // NB: Cast to array to get elementwise multiplication
     growth_matrix = growth_matrix.array().colwise() * input_num.array();
@@ -408,11 +439,11 @@ Type objective_function<Type>::operator() () {
     // Sum together all length group brackets for both length & weight
     array<Type> combined(total_lgs,2);
     combined.col(0) = growth_matrix.colwise().sum();
-    combined.col(1) = weight_matrix.colwise().sum().array().rowwise() / avoid_zero_vec(growth_matrix.colwise().sum()).array().transpose();
+    combined.col(1) = weight_matrix.colwise().sum().array().rowwise() / avoid_zero(growth_matrix.colwise().sum()).array().transpose();
     return combined;
 };
     auto ratio_add_vec = [](vector<Type> orig_vec, vector<Type> orig_amount, vector<Type> new_vec, vector<Type> new_amount) -> vector<Type> {
-    return (orig_vec * orig_amount + new_vec * new_amount) / avoid_zero_vec(orig_amount + new_amount);
+    return (orig_vec * orig_amount + new_vec * new_amount) / avoid_zero(orig_amount + new_amount);
 };
     auto surveyindices_linreg = [](vector<Type> N, vector<Type> I, Type fixed_alpha, Type fixed_beta) -> vector<Type> {
         vector<Type> out(2);
@@ -540,7 +571,7 @@ Type objective_function<Type>::operator() () {
 
                 auto dnorm = ((fish__midlen - (fish__Linf*((double)(1) - exp(-(double)(1)*fish__K*((age - cur_step_size) - fish__t0))))) / ((fish__Linf*((double)(1) - exp(-(double)(1)*fish__K*((age - cur_step_size) - fish__t0))))*fish__lencv));
 
-                auto factor = (fish__init__scalar*map_extras::at_throw(pt__fish__init, std::make_tuple(age), "fish.init")*exp(-(double)(1)*(map_extras::at_throw(pt__fish__M, std::make_tuple(age), "fish.M") + init__F)*(age - recage)));
+                auto factor = (fish__init__scalar*(map_extras::at_throw(pt__fish__init, std::make_tuple(age), "fish.init") + (double)(0)*age)*exp(-(double)(1)*((map_extras::at_throw(pt__fish__M, std::make_tuple(age), "fish.M") + (double)(0)*age) + init__F)*(age - recage)));
 
                 {
                     fish__num.col(fish__age_idx).col(fish__area_idx) = normalize_vec(exp(-((dnorm).pow((double)(2)))*(double)(0.5)))*(double)(10000)*factor;
@@ -682,10 +713,10 @@ Type objective_function<Type>::operator() () {
         {
             // Calculate fish overconsumption coefficient;
             // Apply overconsumption to fish;
-            fish__consratio = fish__totalpredate / avoid_zero_vec(fish__num*fish__wgt);
+            fish__consratio = fish__totalpredate / avoid_zero(fish__num*fish__wgt);
             fish__consratio = logspace_add_vec(fish__consratio*-(double)(1000), (double)(0.95)*-(double)(1000)) / -(double)(1000);
             fish__overconsumption = (fish__totalpredate).sum();
-            fish__consconv = (double)(1) / avoid_zero_vec(fish__totalpredate);
+            fish__consconv = (double)(1) / avoid_zero(fish__totalpredate);
             fish__totalpredate = (fish__num*fish__wgt)*fish__consratio;
             fish__overconsumption -= (fish__totalpredate).sum();
             fish__consconv *= fish__totalpredate;
@@ -708,11 +739,11 @@ Type objective_function<Type>::operator() () {
 
                 auto fish__area_idx = 0;
 
-                fish__num.col(fish__age_idx).col(fish__area_idx) *= exp(-(map_extras::at_throw(pt__fish__M, std::make_tuple(age), "fish.M"))*cur_step_size);
+                fish__num.col(fish__age_idx).col(fish__area_idx) *= exp(-((map_extras::at_throw(pt__fish__M, std::make_tuple(age), "fish.M") + (double)(0)*age))*cur_step_size);
             }
         }
         {
-            auto growth_delta_l = (fish__growth_lastcalc == std::floor(cur_step_size*12) ? fish__growth_l : (fish__growth_l = growth_bbinom(avoid_zero_vec(avoid_zero_vec((fish__Linf - fish__midlen)*((double)(1) - exp(-(fish__K)*cur_step_size))) / fish__plusdl), 4, avoid_zero(fish__bbin))));
+            auto growth_delta_l = (fish__growth_lastcalc == std::floor(cur_step_size*12) ? fish__growth_l : (fish__growth_l = growth_bbinom(avoid_zero(avoid_zero((fish__Linf - fish__midlen)*((double)(1) - exp(-(fish__K)*cur_step_size))) / fish__plusdl), 4, avoid_zero(fish__bbin))));
 
             auto growth_delta_w = (fish__growth_lastcalc == std::floor(cur_step_size*12) ? fish__growth_w : (fish__growth_w = (g3a_grow_vec_rotate(pow((vector<Type>)(fish__midlen), fish__wbeta), 4 + (double)(1)) - g3a_grow_vec_extrude(pow((vector<Type>)(fish__midlen), fish__wbeta), 4 + (double)(1)))*fish__walpha));
 
@@ -1252,9 +1283,9 @@ Type objective_function<Type>::operator() () {
                             auto adist_surveyindices_log_dist_si_cpue_obs__area_idx = 0;
 
                             {
-                                adist_surveyindices_log_dist_si_cpue_model__params = (adist_surveyindices_log_dist_si_cpue_model__time_idx != adist_surveyindices_log_dist_si_cpue_model__max_time_idx ? adist_surveyindices_log_dist_si_cpue_model__params : surveyindices_linreg(log(avoid_zero_vec(adist_surveyindices_log_dist_si_cpue_model__wgt.col(adist_surveyindices_log_dist_si_cpue_model__area_idx))), log(avoid_zero_vec(adist_surveyindices_log_dist_si_cpue_obs__wgt.col(adist_surveyindices_log_dist_si_cpue_obs__area_idx))), NAN, (double)(1)));
+                                adist_surveyindices_log_dist_si_cpue_model__params = (adist_surveyindices_log_dist_si_cpue_model__time_idx != adist_surveyindices_log_dist_si_cpue_model__max_time_idx ? adist_surveyindices_log_dist_si_cpue_model__params : surveyindices_linreg(log(avoid_zero(adist_surveyindices_log_dist_si_cpue_model__wgt.col(adist_surveyindices_log_dist_si_cpue_model__area_idx))), log(avoid_zero(adist_surveyindices_log_dist_si_cpue_obs__wgt.col(adist_surveyindices_log_dist_si_cpue_obs__area_idx))), NAN, (double)(1)));
                                 {
-                                    auto cur_cdist_nll = (adist_surveyindices_log_dist_si_cpue_model__time_idx != adist_surveyindices_log_dist_si_cpue_model__max_time_idx ? (double)(0) : (pow((adist_surveyindices_log_dist_si_cpue_model__params ( 0 ) + adist_surveyindices_log_dist_si_cpue_model__params ( 1 )*log(avoid_zero_vec(adist_surveyindices_log_dist_si_cpue_model__wgt.col(adist_surveyindices_log_dist_si_cpue_model__area_idx))) - log(avoid_zero_vec(adist_surveyindices_log_dist_si_cpue_obs__wgt.col(adist_surveyindices_log_dist_si_cpue_obs__area_idx)))), (Type)(double)(2))).sum());
+                                    auto cur_cdist_nll = (adist_surveyindices_log_dist_si_cpue_model__time_idx != adist_surveyindices_log_dist_si_cpue_model__max_time_idx ? (double)(0) : (pow((adist_surveyindices_log_dist_si_cpue_model__params ( 0 ) + adist_surveyindices_log_dist_si_cpue_model__params ( 1 )*log(avoid_zero(adist_surveyindices_log_dist_si_cpue_model__wgt.col(adist_surveyindices_log_dist_si_cpue_model__area_idx))) - log(avoid_zero(adist_surveyindices_log_dist_si_cpue_obs__wgt.col(adist_surveyindices_log_dist_si_cpue_obs__area_idx)))), (Type)(double)(2))).sum());
 
                                     {
                                         nll += adist_surveyindices_log_dist_si_cpue_weight*cur_cdist_nll;
@@ -1285,7 +1316,7 @@ Type objective_function<Type>::operator() () {
 
                         {
                             // Convert fish_f_surv to num;
-                            cdist_sumofsquares_aldist_f_surv_model__num.col(cdist_sumofsquares_aldist_f_surv_model__time_idx).col(cdist_sumofsquares_aldist_f_surv_model__age_idx) += ((matrix<Type>)(fish_f_surv_cdist_sumofsquares_aldist_f_surv_model_lgmatrix.matrix() * ((fish_f_surv__cons.col(fish__age_idx).col(fish__area_idx) / avoid_zero_vec(fish__wgt.col(fish__age_idx).col(fish__area_idx)))).matrix())).vec();
+                            cdist_sumofsquares_aldist_f_surv_model__num.col(cdist_sumofsquares_aldist_f_surv_model__time_idx).col(cdist_sumofsquares_aldist_f_surv_model__age_idx) += ((matrix<Type>)(fish_f_surv_cdist_sumofsquares_aldist_f_surv_model_lgmatrix.matrix() * ((fish_f_surv__cons.col(fish__age_idx).col(fish__area_idx) / avoid_zero(fish__wgt.col(fish__age_idx).col(fish__area_idx)))).matrix())).vec();
                         }
                     }
                 }
@@ -1336,7 +1367,7 @@ Type objective_function<Type>::operator() () {
 
                 if ( cdist_sumofsquares_ldist_f_surv_model__time_idx >= 0 ) {
                     // Convert fish_f_surv to num;
-                    cdist_sumofsquares_ldist_f_surv_model__num.col(cdist_sumofsquares_ldist_f_surv_model__time_idx) += ((matrix<Type>)(fish_f_surv_cdist_sumofsquares_ldist_f_surv_model_lgmatrix.matrix() * ((fish_f_surv__cons.col(fish__age_idx).col(fish__area_idx) / avoid_zero_vec(fish__wgt.col(fish__age_idx).col(fish__area_idx)))).matrix())).vec();
+                    cdist_sumofsquares_ldist_f_surv_model__num.col(cdist_sumofsquares_ldist_f_surv_model__time_idx) += ((matrix<Type>)(fish_f_surv_cdist_sumofsquares_ldist_f_surv_model_lgmatrix.matrix() * ((fish_f_surv__cons.col(fish__age_idx).col(fish__area_idx) / avoid_zero(fish__wgt.col(fish__age_idx).col(fish__area_idx)))).matrix())).vec();
                 }
             }
         }

--- a/baseline/multiple-substocks.cpp
+++ b/baseline/multiple-substocks.cpp
@@ -75,6 +75,10 @@ template<typename X>
 auto avoid_zero(X a) {
     return dif_pmax(a, 0.0, 1e3);
 }
+template<typename X, typename Y>
+auto dif_pmin(X a, Y b, double scale) {
+    return dif_pmax(a, b, -scale);
+}
 template<typename T> std::map<int, T> intlookup_zip(vector<int> keys, vector<T> values) {
             std::map<int, T> lookup = {};
 
@@ -409,13 +413,6 @@ Type objective_function<Type>::operator() () {
     auto nonconform_add = [](array<Type> base_ar, array<Type> extra_ar) -> array<Type> {
     assert(base_ar.size() % extra_ar.size() == 0);
     return base_ar + (extra_ar.replicate(base_ar.size() / extra_ar.size(), 1));
-};
-    auto logspace_add_vec = [](vector<Type> a, Type b) -> vector<Type> {
-    vector<Type> res(a.size());
-    for(int i = 0; i < a.size(); i++) {
-        res[i] = logspace_add(a[i], b);
-    }
-    return res;
 };
     auto nonconform_mult = [](array<Type> base_ar, array<Type> extra_ar) -> array<Type> {
     assert(base_ar.size() % extra_ar.size() == 0);
@@ -932,7 +929,7 @@ Type objective_function<Type>::operator() () {
             // Calculate fish_imm overconsumption coefficient;
             // Apply overconsumption to fish_imm;
             fish_imm__consratio = fish_imm__totalpredate / avoid_zero(fish_imm__num*fish_imm__wgt);
-            fish_imm__consratio = logspace_add_vec(fish_imm__consratio*-(double)(1000), (double)(0.95)*-(double)(1000)) / -(double)(1000);
+            fish_imm__consratio = dif_pmin(fish_imm__consratio, (double)(0.95), (double)(1000));
             fish_imm__overconsumption = (fish_imm__totalpredate).sum();
             fish_imm__consconv = (double)(1) / avoid_zero(fish_imm__totalpredate);
             fish_imm__totalpredate = (fish_imm__num*fish_imm__wgt)*fish_imm__consratio;
@@ -944,7 +941,7 @@ Type objective_function<Type>::operator() () {
             // Calculate fish_mat overconsumption coefficient;
             // Apply overconsumption to fish_mat;
             fish_mat__consratio = fish_mat__totalpredate / avoid_zero(fish_mat__num*fish_mat__wgt);
-            fish_mat__consratio = logspace_add_vec(fish_mat__consratio*-(double)(1000), (double)(0.95)*-(double)(1000)) / -(double)(1000);
+            fish_mat__consratio = dif_pmin(fish_mat__consratio, (double)(0.95), (double)(1000));
             fish_mat__overconsumption = (fish_mat__totalpredate).sum();
             fish_mat__consconv = (double)(1) / avoid_zero(fish_mat__totalpredate);
             fish_mat__totalpredate = (fish_mat__num*fish_mat__wgt)*fish_mat__consratio;

--- a/baseline/multiple-substocks.cpp
+++ b/baseline/multiple-substocks.cpp
@@ -23,9 +23,58 @@ namespace map_extras {
     }
 }
 
+
+#ifndef TYPE_IS_SCALAR
+#ifdef TMBAD_FRAMEWORK
+#define TYPE_IS_SCALAR(TestT) typename = std::enable_if_t<std::is_same<TestT, int>::value || std::is_same<TestT, double>::value || std::is_same<TestT, TMBad::global::ad_aug>::value>
+#endif // TMBAD_FRAMEWORK
+#ifdef CPPAD_FRAMEWORK
+#define TYPE_IS_SCALAR(TestT) typename = std::enable_if_t<std::is_same<TestT, int>::value || std::is_same<TestT, double>::value || std::is_same<TestT, CppAD::AD>::value>
+#endif // CPPAD_FRAMEWORK
+#endif // TYPE_IS_SCALAR
+
 template<typename T, typename DefT> T intlookup_getdefault(std::map<int, T> lookup, int key, DefT def) {
             return lookup.count(key) > 0 ? lookup[key] : (T)def;
         }
+// Scalar templates
+template<typename T, typename LimitT, TYPE_IS_SCALAR(T), TYPE_IS_SCALAR(LimitT)>
+T dif_pmax(T a, LimitT b, double scale) {
+    return logspace_add(a * scale, (T)b * scale) / scale;
+}
+// templates for vector<Type>s & Eigen derived vectors
+template<typename LimitT, typename Derived, TYPE_IS_SCALAR(LimitT)>
+vector<typename Derived::value_type> dif_pmax(const Eigen::DenseBase<Derived>& a, LimitT b, double scale) {
+    vector<typename Derived::value_type> out(a.size());
+    for(int i = 0; i < a.size(); i++) out[i] = logspace_add(a[i] * scale, (typename Derived::value_type)b * scale) / scale;
+    return out;
+}
+template<typename LimitT, typename Derived>
+vector<typename Derived::value_type> dif_pmax(const Eigen::DenseBase<Derived>& a, const Eigen::DenseBase<LimitT>& b, double scale) {
+    assert(a.size() % b.size() == 0);
+
+    vector<typename Derived::value_type> out(a.size());
+    for(int i = 0; i < a.size(); i++) out[i] = logspace_add(a[i] * scale, (typename Derived::value_type)(b[i % b.size()]) * scale) / scale;
+    return out;
+}
+// Templates for Eigen derived arrays
+template<typename LimitT, typename Derived, TYPE_IS_SCALAR(LimitT)>
+array<typename Derived::value_type> dif_pmax(const Eigen::Map<Eigen::DenseBase<Derived>>& a, LimitT b, double scale) {
+    array<typename Derived::value_type> out(a.size());
+    for(int i = 0; i < a.size(); i++) out[i] = logspace_add(a[i] * scale, (typename Derived::value_type)b * scale) / scale;
+    return out;
+}
+template<typename LimitT, typename Derived>
+array<typename Derived::value_type> dif_pmax(const Eigen::Map<Eigen::DenseBase<Derived>>& a, const Eigen::DenseBase<LimitT>& b, double scale) {
+    assert(a.size() % b.size() == 0);
+
+    array<typename Derived::value_type> out(a.size());
+    for(int i = 0; i < a.size(); i++) out[i] = logspace_add(a[i] * scale, (typename Derived::value_type)(b[i % b.size()]) * scale) / scale;
+    return out;
+}
+template<typename X>
+auto avoid_zero(X a) {
+    return dif_pmax(a, 0.0, 1e3);
+}
 template<typename T> std::map<int, T> intlookup_zip(vector<int> keys, vector<T> values) {
             std::map<int, T> lookup = {};
 
@@ -361,13 +410,6 @@ Type objective_function<Type>::operator() () {
     assert(base_ar.size() % extra_ar.size() == 0);
     return base_ar + (extra_ar.replicate(base_ar.size() / extra_ar.size(), 1));
 };
-    auto avoid_zero_vec = [](vector<Type> a) -> vector<Type> {
-    vector<Type> res(a.size());
-    for(int i = 0; i < a.size(); i++) {
-        res[i] = logspace_add(a[i] * 1000.0, (Type)0.0) / 1000.0;
-    }
-    return res;
-};
     auto logspace_add_vec = [](vector<Type> a, Type b) -> vector<Type> {
     vector<Type> res(a.size());
     for(int i = 0; i < a.size(); i++) {
@@ -411,9 +453,6 @@ Type objective_function<Type>::operator() () {
             lgamma(alpha)).exp();
         return(val);
     };
-    auto avoid_zero = [](Type a) -> Type {
-    return logspace_add(a * 1000.0, (Type)0.0) / 1000.0;
-};
     auto g3a_grow_vec_rotate = [](vector<Type> vec, int a) -> array<Type> {
     array<Type> out(vec.size(), a);
     for (int i = 0 ; i < vec.size(); i++) {
@@ -463,14 +502,6 @@ Type objective_function<Type>::operator() () {
     auto g3a_grow_apply = [](matrix<Type> growth_matrix, matrix<Type> weight_matrix, vector<Type> input_num, vector<Type> input_wgt) -> array<Type> {
     int total_lgs = growth_matrix.cols(); // # Length groups
 
-    auto avoid_zero_vec = [](vector<Type> a) -> vector<Type> {
-        vector<Type> res(a.size());
-        for(int i = 0; i < a.size(); i++) {
-            res[i] = logspace_add(a[i] * 1000.0, (Type)0.0) / 1000.0;
-        }
-        return res;
-    };
-
     // Apply matrices to stock
     // NB: Cast to array to get elementwise multiplication
     growth_matrix = growth_matrix.array().colwise() * input_num.array();
@@ -479,7 +510,7 @@ Type objective_function<Type>::operator() () {
     // Sum together all length group brackets for both length & weight
     array<Type> combined(total_lgs,2);
     combined.col(0) = growth_matrix.colwise().sum();
-    combined.col(1) = weight_matrix.colwise().sum().array().rowwise() / avoid_zero_vec(growth_matrix.colwise().sum()).array().transpose();
+    combined.col(1) = weight_matrix.colwise().sum().array().rowwise() / avoid_zero(growth_matrix.colwise().sum()).array().transpose();
     return combined;
 };
     auto g3a_grow_matrix_len = [](array<Type> delta_l_ar) -> matrix<Type> {
@@ -503,10 +534,10 @@ Type objective_function<Type>::operator() () {
     }
     return(growth_matrix);
 };
-    auto ratio_add_vec = [&avoid_zero_vec](vector<Type> orig_vec, vector<Type> orig_amount, vector<Type> new_vec, vector<Type> new_amount) -> vector<Type> {
-    return (orig_vec * orig_amount + new_vec * new_amount) / avoid_zero_vec(orig_amount + new_amount);
+    auto ratio_add_vec = [](vector<Type> orig_vec, vector<Type> orig_amount, vector<Type> new_vec, vector<Type> new_amount) -> vector<Type> {
+    return (orig_vec * orig_amount + new_vec * new_amount) / avoid_zero(orig_amount + new_amount);
 };
-    auto surveyindices_linreg = [&avoid_zero](vector<Type> N, vector<Type> I, Type fixed_alpha, Type fixed_beta) -> vector<Type> {
+    auto surveyindices_linreg = [](vector<Type> N, vector<Type> I, Type fixed_alpha, Type fixed_beta) -> vector<Type> {
         vector<Type> out(2);
 
         auto meanI = I.mean();
@@ -665,7 +696,7 @@ Type objective_function<Type>::operator() () {
 
                 auto dnorm = ((fish_imm__midlen - (fish_imm__Linf*((double)(1) - exp(-(double)(1)*fish_imm__K*((age - cur_step_size) - fish_imm__t0))))) / ((fish_imm__Linf*((double)(1) - exp(-(double)(1)*fish_imm__K*((age - cur_step_size) - fish_imm__t0))))*fish_imm__lencv));
 
-                auto factor = (fish_imm__init__scalar*map_extras::at_throw(pt__fish_imm__init, std::make_tuple(age), "fish_imm.init")*exp(-(double)(1)*(map_extras::at_throw(pt__fish_imm__M, std::make_tuple(age), "fish_imm.M") + init__F)*(age - recage)));
+                auto factor = (fish_imm__init__scalar*(map_extras::at_throw(pt__fish_imm__init, std::make_tuple(age), "fish_imm.init") + (double)(0)*age)*exp(-(double)(1)*((map_extras::at_throw(pt__fish_imm__M, std::make_tuple(age), "fish_imm.M") + (double)(0)*age) + init__F)*(age - recage)));
 
                 {
                     fish_imm__num.col(fish_imm__age_idx).col(fish_imm__area_idx) = normalize_vec(exp(-((dnorm).pow((double)(2)))*(double)(0.5)))*(double)(10000)*factor;
@@ -684,7 +715,7 @@ Type objective_function<Type>::operator() () {
 
                 auto dnorm = ((fish_mat__midlen - (fish_mat__Linf*((double)(1) - exp(-(double)(1)*fish_mat__K*((age - cur_step_size) - fish_mat__t0))))) / ((fish_mat__Linf*((double)(1) - exp(-(double)(1)*fish_mat__K*((age - cur_step_size) - fish_mat__t0))))*fish_mat__lencv));
 
-                auto factor = (fish_mat__init__scalar*map_extras::at_throw(pt__fish_mat__init, std::make_tuple(age), "fish_mat.init")*exp(-(double)(1)*(map_extras::at_throw(pt__fish_mat__M, std::make_tuple(age), "fish_mat.M") + init__F)*(age - recage)));
+                auto factor = (fish_mat__init__scalar*(map_extras::at_throw(pt__fish_mat__init, std::make_tuple(age), "fish_mat.init") + (double)(0)*age)*exp(-(double)(1)*((map_extras::at_throw(pt__fish_mat__M, std::make_tuple(age), "fish_mat.M") + (double)(0)*age) + init__F)*(age - recage)));
 
                 {
                     fish_mat__num.col(fish_mat__age_idx).col(fish_mat__area_idx) = normalize_vec(exp(-((dnorm).pow((double)(2)))*(double)(0.5)))*(double)(10000)*factor;
@@ -900,10 +931,10 @@ Type objective_function<Type>::operator() () {
         {
             // Calculate fish_imm overconsumption coefficient;
             // Apply overconsumption to fish_imm;
-            fish_imm__consratio = fish_imm__totalpredate / avoid_zero_vec(fish_imm__num*fish_imm__wgt);
+            fish_imm__consratio = fish_imm__totalpredate / avoid_zero(fish_imm__num*fish_imm__wgt);
             fish_imm__consratio = logspace_add_vec(fish_imm__consratio*-(double)(1000), (double)(0.95)*-(double)(1000)) / -(double)(1000);
             fish_imm__overconsumption = (fish_imm__totalpredate).sum();
-            fish_imm__consconv = (double)(1) / avoid_zero_vec(fish_imm__totalpredate);
+            fish_imm__consconv = (double)(1) / avoid_zero(fish_imm__totalpredate);
             fish_imm__totalpredate = (fish_imm__num*fish_imm__wgt)*fish_imm__consratio;
             fish_imm__overconsumption -= (fish_imm__totalpredate).sum();
             fish_imm__consconv *= fish_imm__totalpredate;
@@ -912,10 +943,10 @@ Type objective_function<Type>::operator() () {
         {
             // Calculate fish_mat overconsumption coefficient;
             // Apply overconsumption to fish_mat;
-            fish_mat__consratio = fish_mat__totalpredate / avoid_zero_vec(fish_mat__num*fish_mat__wgt);
+            fish_mat__consratio = fish_mat__totalpredate / avoid_zero(fish_mat__num*fish_mat__wgt);
             fish_mat__consratio = logspace_add_vec(fish_mat__consratio*-(double)(1000), (double)(0.95)*-(double)(1000)) / -(double)(1000);
             fish_mat__overconsumption = (fish_mat__totalpredate).sum();
-            fish_mat__consconv = (double)(1) / avoid_zero_vec(fish_mat__totalpredate);
+            fish_mat__consconv = (double)(1) / avoid_zero(fish_mat__totalpredate);
             fish_mat__totalpredate = (fish_mat__num*fish_mat__wgt)*fish_mat__consratio;
             fish_mat__overconsumption -= (fish_mat__totalpredate).sum();
             fish_mat__consconv *= fish_mat__totalpredate;
@@ -946,7 +977,7 @@ Type objective_function<Type>::operator() () {
 
                 auto fish_imm__area_idx = 0;
 
-                fish_imm__num.col(fish_imm__age_idx).col(fish_imm__area_idx) *= exp(-(map_extras::at_throw(pt__fish_imm__M, std::make_tuple(age), "fish_imm.M"))*cur_step_size);
+                fish_imm__num.col(fish_imm__age_idx).col(fish_imm__area_idx) *= exp(-((map_extras::at_throw(pt__fish_imm__M, std::make_tuple(age), "fish_imm.M") + (double)(0)*age))*cur_step_size);
             }
         }
         {
@@ -958,7 +989,7 @@ Type objective_function<Type>::operator() () {
 
                 auto fish_mat__area_idx = 0;
 
-                fish_mat__num.col(fish_mat__age_idx).col(fish_mat__area_idx) *= exp(-(map_extras::at_throw(pt__fish_mat__M, std::make_tuple(age), "fish_mat.M"))*cur_step_size);
+                fish_mat__num.col(fish_mat__age_idx).col(fish_mat__area_idx) *= exp(-((map_extras::at_throw(pt__fish_mat__M, std::make_tuple(age), "fish_mat.M") + (double)(0)*age))*cur_step_size);
             }
         }
         {
@@ -967,7 +998,7 @@ Type objective_function<Type>::operator() () {
             fish_imm__transitioning_wgt = fish_imm__wgt;
         }
         {
-            auto growth_delta_l = (fish_imm__growth_lastcalc == std::floor(cur_step_size*12) ? fish_imm__growth_l : (fish_imm__growth_l = growth_bbinom(avoid_zero_vec(avoid_zero_vec((fish_imm__Linf - fish_imm__midlen)*((double)(1) - exp(-(fish_imm__K)*cur_step_size))) / fish_imm__plusdl), 4, avoid_zero(fish_imm__bbin))));
+            auto growth_delta_l = (fish_imm__growth_lastcalc == std::floor(cur_step_size*12) ? fish_imm__growth_l : (fish_imm__growth_l = growth_bbinom(avoid_zero(avoid_zero((fish_imm__Linf - fish_imm__midlen)*((double)(1) - exp(-(fish_imm__K)*cur_step_size))) / fish_imm__plusdl), 4, avoid_zero(fish_imm__bbin))));
 
             auto growth_delta_w = (fish_imm__growth_lastcalc == std::floor(cur_step_size*12) ? fish_imm__growth_w : (fish_imm__growth_w = (g3a_grow_vec_rotate(pow((vector<Type>)(fish_imm__midlen), fish_imm__wbeta), 4 + (double)(1)) - g3a_grow_vec_extrude(pow((vector<Type>)(fish_imm__midlen), fish_imm__wbeta), 4 + (double)(1)))*fish_imm__walpha));
 
@@ -1007,7 +1038,7 @@ Type objective_function<Type>::operator() () {
             }
         }
         {
-            auto growth_delta_l = (fish_mat__growth_lastcalc == std::floor(cur_step_size*12) ? fish_mat__growth_l : (fish_mat__growth_l = growth_bbinom(avoid_zero_vec(avoid_zero_vec((fish_mat__Linf - fish_mat__midlen)*((double)(1) - exp(-(fish_mat__K)*cur_step_size))) / fish_mat__plusdl), 4, avoid_zero(fish_mat__bbin))));
+            auto growth_delta_l = (fish_mat__growth_lastcalc == std::floor(cur_step_size*12) ? fish_mat__growth_l : (fish_mat__growth_l = growth_bbinom(avoid_zero(avoid_zero((fish_mat__Linf - fish_mat__midlen)*((double)(1) - exp(-(fish_mat__K)*cur_step_size))) / fish_mat__plusdl), 4, avoid_zero(fish_mat__bbin))));
 
             auto growth_delta_w = (fish_mat__growth_lastcalc == std::floor(cur_step_size*12) ? fish_mat__growth_w : (fish_mat__growth_w = (g3a_grow_vec_rotate(pow((vector<Type>)(fish_mat__midlen), fish_mat__wbeta), 4 + (double)(1)) - g3a_grow_vec_extrude(pow((vector<Type>)(fish_mat__midlen), fish_mat__wbeta), 4 + (double)(1)))*fish_mat__walpha));
 
@@ -1060,7 +1091,7 @@ Type objective_function<Type>::operator() () {
                             fish_mat__wgt.col(fish_mat__age_idx).col(fish_mat__area_idx) = (fish_mat__wgt.col(fish_mat__age_idx).col(fish_mat__area_idx)*fish_mat__num.col(fish_mat__age_idx).col(fish_mat__area_idx)) + fish_imm__transitioning_wgt.col(fish_imm__age_idx).col(fish_imm__area_idx)*fish_imm__transitioning_num.col(fish_imm__age_idx).col(fish_imm__area_idx);
                             fish_mat__num.col(fish_mat__age_idx).col(fish_mat__area_idx) += fish_imm__transitioning_num.col(fish_imm__age_idx).col(fish_imm__area_idx);
                             fish_imm__transitioning_num.col(fish_imm__age_idx).col(fish_imm__area_idx) -= fish_imm__transitioning_num.col(fish_imm__age_idx).col(fish_imm__area_idx);
-                            fish_mat__wgt.col(fish_mat__age_idx).col(fish_mat__area_idx) /= avoid_zero_vec(fish_mat__num.col(fish_mat__age_idx).col(fish_mat__area_idx));
+                            fish_mat__wgt.col(fish_mat__age_idx).col(fish_mat__area_idx) /= avoid_zero(fish_mat__num.col(fish_mat__age_idx).col(fish_mat__area_idx));
                         }
                     }
                 }
@@ -1751,9 +1782,9 @@ Type objective_function<Type>::operator() () {
                             auto adist_surveyindices_log_dist_si_cpue_obs__area_idx = 0;
 
                             {
-                                adist_surveyindices_log_dist_si_cpue_model__params = (adist_surveyindices_log_dist_si_cpue_model__time_idx != adist_surveyindices_log_dist_si_cpue_model__max_time_idx ? adist_surveyindices_log_dist_si_cpue_model__params : surveyindices_linreg(log(avoid_zero_vec(adist_surveyindices_log_dist_si_cpue_model__wgt.col(adist_surveyindices_log_dist_si_cpue_model__area_idx))), log(avoid_zero_vec(adist_surveyindices_log_dist_si_cpue_obs__wgt.col(adist_surveyindices_log_dist_si_cpue_obs__area_idx))), NAN, (double)(1)));
+                                adist_surveyindices_log_dist_si_cpue_model__params = (adist_surveyindices_log_dist_si_cpue_model__time_idx != adist_surveyindices_log_dist_si_cpue_model__max_time_idx ? adist_surveyindices_log_dist_si_cpue_model__params : surveyindices_linreg(log(avoid_zero(adist_surveyindices_log_dist_si_cpue_model__wgt.col(adist_surveyindices_log_dist_si_cpue_model__area_idx))), log(avoid_zero(adist_surveyindices_log_dist_si_cpue_obs__wgt.col(adist_surveyindices_log_dist_si_cpue_obs__area_idx))), NAN, (double)(1)));
                                 {
-                                    auto cur_cdist_nll = (adist_surveyindices_log_dist_si_cpue_model__time_idx != adist_surveyindices_log_dist_si_cpue_model__max_time_idx ? (double)(0) : (pow((adist_surveyindices_log_dist_si_cpue_model__params ( 0 ) + adist_surveyindices_log_dist_si_cpue_model__params ( 1 )*log(avoid_zero_vec(adist_surveyindices_log_dist_si_cpue_model__wgt.col(adist_surveyindices_log_dist_si_cpue_model__area_idx))) - log(avoid_zero_vec(adist_surveyindices_log_dist_si_cpue_obs__wgt.col(adist_surveyindices_log_dist_si_cpue_obs__area_idx)))), (Type)(double)(2))).sum());
+                                    auto cur_cdist_nll = (adist_surveyindices_log_dist_si_cpue_model__time_idx != adist_surveyindices_log_dist_si_cpue_model__max_time_idx ? (double)(0) : (pow((adist_surveyindices_log_dist_si_cpue_model__params ( 0 ) + adist_surveyindices_log_dist_si_cpue_model__params ( 1 )*log(avoid_zero(adist_surveyindices_log_dist_si_cpue_model__wgt.col(adist_surveyindices_log_dist_si_cpue_model__area_idx))) - log(avoid_zero(adist_surveyindices_log_dist_si_cpue_obs__wgt.col(adist_surveyindices_log_dist_si_cpue_obs__area_idx)))), (Type)(double)(2))).sum());
 
                                     {
                                         nll += adist_surveyindices_log_dist_si_cpue_weight*cur_cdist_nll;
@@ -1784,7 +1815,7 @@ Type objective_function<Type>::operator() () {
 
                         {
                             // Convert fish_imm_f_surv to num;
-                            cdist_sumofsquares_aldist_f_surv_model__num.col(cdist_sumofsquares_aldist_f_surv_model__time_idx).col(cdist_sumofsquares_aldist_f_surv_model__age_idx) += ((matrix<Type>)(fish_imm_f_surv_cdist_sumofsquares_aldist_f_surv_model_lgmatrix.matrix() * ((fish_imm_f_surv__cons.col(fish_imm__age_idx).col(fish_imm__area_idx) / avoid_zero_vec(fish_imm__wgt.col(fish_imm__age_idx).col(fish_imm__area_idx)))).matrix())).vec();
+                            cdist_sumofsquares_aldist_f_surv_model__num.col(cdist_sumofsquares_aldist_f_surv_model__time_idx).col(cdist_sumofsquares_aldist_f_surv_model__age_idx) += ((matrix<Type>)(fish_imm_f_surv_cdist_sumofsquares_aldist_f_surv_model_lgmatrix.matrix() * ((fish_imm_f_surv__cons.col(fish_imm__age_idx).col(fish_imm__area_idx) / avoid_zero(fish_imm__wgt.col(fish_imm__age_idx).col(fish_imm__area_idx)))).matrix())).vec();
                         }
                     }
                 }
@@ -1807,7 +1838,7 @@ Type objective_function<Type>::operator() () {
 
                         {
                             // Convert fish_mat_f_surv to num;
-                            cdist_sumofsquares_aldist_f_surv_model__num.col(cdist_sumofsquares_aldist_f_surv_model__time_idx).col(cdist_sumofsquares_aldist_f_surv_model__age_idx) += ((matrix<Type>)(fish_mat_f_surv_cdist_sumofsquares_aldist_f_surv_model_lgmatrix.matrix() * ((fish_mat_f_surv__cons.col(fish_mat__age_idx).col(fish_mat__area_idx) / avoid_zero_vec(fish_mat__wgt.col(fish_mat__age_idx).col(fish_mat__area_idx)))).matrix())).vec();
+                            cdist_sumofsquares_aldist_f_surv_model__num.col(cdist_sumofsquares_aldist_f_surv_model__time_idx).col(cdist_sumofsquares_aldist_f_surv_model__age_idx) += ((matrix<Type>)(fish_mat_f_surv_cdist_sumofsquares_aldist_f_surv_model_lgmatrix.matrix() * ((fish_mat_f_surv__cons.col(fish_mat__age_idx).col(fish_mat__area_idx) / avoid_zero(fish_mat__wgt.col(fish_mat__age_idx).col(fish_mat__area_idx)))).matrix())).vec();
                         }
                     }
                 }
@@ -1858,7 +1889,7 @@ Type objective_function<Type>::operator() () {
 
                 if ( cdist_sumofsquares_ldist_f_surv_model__time_idx >= 0 ) {
                     // Convert fish_imm_f_surv to num;
-                    cdist_sumofsquares_ldist_f_surv_model__num.col(cdist_sumofsquares_ldist_f_surv_model__time_idx) += ((matrix<Type>)(fish_imm_f_surv_cdist_sumofsquares_ldist_f_surv_model_lgmatrix.matrix() * ((fish_imm_f_surv__cons.col(fish_imm__age_idx).col(fish_imm__area_idx) / avoid_zero_vec(fish_imm__wgt.col(fish_imm__age_idx).col(fish_imm__area_idx)))).matrix())).vec();
+                    cdist_sumofsquares_ldist_f_surv_model__num.col(cdist_sumofsquares_ldist_f_surv_model__time_idx) += ((matrix<Type>)(fish_imm_f_surv_cdist_sumofsquares_ldist_f_surv_model_lgmatrix.matrix() * ((fish_imm_f_surv__cons.col(fish_imm__age_idx).col(fish_imm__area_idx) / avoid_zero(fish_imm__wgt.col(fish_imm__age_idx).col(fish_imm__area_idx)))).matrix())).vec();
                 }
             }
         }
@@ -1875,7 +1906,7 @@ Type objective_function<Type>::operator() () {
 
                 if ( cdist_sumofsquares_ldist_f_surv_model__time_idx >= 0 ) {
                     // Convert fish_mat_f_surv to num;
-                    cdist_sumofsquares_ldist_f_surv_model__num.col(cdist_sumofsquares_ldist_f_surv_model__time_idx) += ((matrix<Type>)(fish_mat_f_surv_cdist_sumofsquares_ldist_f_surv_model_lgmatrix.matrix() * ((fish_mat_f_surv__cons.col(fish_mat__age_idx).col(fish_mat__area_idx) / avoid_zero_vec(fish_mat__wgt.col(fish_mat__age_idx).col(fish_mat__area_idx)))).matrix())).vec();
+                    cdist_sumofsquares_ldist_f_surv_model__num.col(cdist_sumofsquares_ldist_f_surv_model__time_idx) += ((matrix<Type>)(fish_mat_f_surv_cdist_sumofsquares_ldist_f_surv_model_lgmatrix.matrix() * ((fish_mat_f_surv__cons.col(fish_mat__age_idx).col(fish_mat__area_idx) / avoid_zero(fish_mat__wgt.col(fish_mat__age_idx).col(fish_mat__area_idx)))).matrix())).vec();
                 }
             }
         }
@@ -2008,7 +2039,7 @@ Type objective_function<Type>::operator() () {
                             {
                                 fish_mat__wgt.col(fish_mat__age_idx).col(fish_mat__area_idx) = (fish_mat__wgt.col(fish_mat__age_idx).col(fish_mat__area_idx)*fish_mat__num.col(fish_mat__age_idx).col(fish_mat__area_idx)) + fish_imm_movement__transitioning_wgt.col(fish_imm_movement__age_idx).col(fish_imm_movement__area_idx)*fish_imm_movement__transitioning_num.col(fish_imm_movement__age_idx).col(fish_imm_movement__area_idx);
                                 fish_mat__num.col(fish_mat__age_idx).col(fish_mat__area_idx) += fish_imm_movement__transitioning_num.col(fish_imm_movement__age_idx).col(fish_imm_movement__area_idx);
-                                fish_mat__wgt.col(fish_mat__age_idx).col(fish_mat__area_idx) /= avoid_zero_vec(fish_mat__num.col(fish_mat__age_idx).col(fish_mat__area_idx));
+                                fish_mat__wgt.col(fish_mat__age_idx).col(fish_mat__area_idx) /= avoid_zero(fish_mat__num.col(fish_mat__age_idx).col(fish_mat__area_idx));
                             }
                         }
                     }

--- a/baseline/multiple-substocks.cpp
+++ b/baseline/multiple-substocks.cpp
@@ -997,7 +997,7 @@ Type objective_function<Type>::operator() () {
         {
             auto growth_delta_l = (fish_imm__growth_lastcalc == std::floor(cur_step_size*12) ? fish_imm__growth_l : (fish_imm__growth_l = growth_bbinom(avoid_zero(avoid_zero((fish_imm__Linf - fish_imm__midlen)*((double)(1) - exp(-(fish_imm__K)*cur_step_size))) / fish_imm__plusdl), 4, avoid_zero(fish_imm__bbin))));
 
-            auto growth_delta_w = (fish_imm__growth_lastcalc == std::floor(cur_step_size*12) ? fish_imm__growth_w : (fish_imm__growth_w = (g3a_grow_vec_rotate(pow((vector<Type>)(fish_imm__midlen), fish_imm__wbeta), 4 + (double)(1)) - g3a_grow_vec_extrude(pow((vector<Type>)(fish_imm__midlen), fish_imm__wbeta), 4 + (double)(1)))*fish_imm__walpha));
+            auto growth_delta_w = (fish_imm__growth_lastcalc == std::floor(cur_step_size*12) ? fish_imm__growth_w : (fish_imm__growth_w = (g3a_grow_vec_rotate((fish_imm__midlen).pow(fish_imm__wbeta), 4 + (double)(1)) - g3a_grow_vec_extrude((fish_imm__midlen).pow(fish_imm__wbeta), 4 + (double)(1)))*fish_imm__walpha));
 
             auto growthmat_w = g3a_grow_matrix_wgt(growth_delta_w);
 
@@ -1037,7 +1037,7 @@ Type objective_function<Type>::operator() () {
         {
             auto growth_delta_l = (fish_mat__growth_lastcalc == std::floor(cur_step_size*12) ? fish_mat__growth_l : (fish_mat__growth_l = growth_bbinom(avoid_zero(avoid_zero((fish_mat__Linf - fish_mat__midlen)*((double)(1) - exp(-(fish_mat__K)*cur_step_size))) / fish_mat__plusdl), 4, avoid_zero(fish_mat__bbin))));
 
-            auto growth_delta_w = (fish_mat__growth_lastcalc == std::floor(cur_step_size*12) ? fish_mat__growth_w : (fish_mat__growth_w = (g3a_grow_vec_rotate(pow((vector<Type>)(fish_mat__midlen), fish_mat__wbeta), 4 + (double)(1)) - g3a_grow_vec_extrude(pow((vector<Type>)(fish_mat__midlen), fish_mat__wbeta), 4 + (double)(1)))*fish_mat__walpha));
+            auto growth_delta_w = (fish_mat__growth_lastcalc == std::floor(cur_step_size*12) ? fish_mat__growth_w : (fish_mat__growth_w = (g3a_grow_vec_rotate((fish_mat__midlen).pow(fish_mat__wbeta), 4 + (double)(1)) - g3a_grow_vec_extrude((fish_mat__midlen).pow(fish_mat__wbeta), 4 + (double)(1)))*fish_mat__walpha));
 
             auto growthmat_w = g3a_grow_matrix_wgt(growth_delta_w);
 

--- a/inttest/codegeneration-defaults/model.R
+++ b/inttest/codegeneration-defaults/model.R
@@ -118,9 +118,6 @@ structure(function (param = attr(get(sys.call()[[1]]), "parameter_template"))
         out[is.na(out)] <- vec[length(vec)]
         out
     }
-    pow_vec <- function(a, b) {
-        a^b
-    }
     g3a_grow_vec_extrude <- function(vec, a) {
         array(vec, dim = c(length(vec), a))
     }
@@ -415,7 +412,7 @@ structure(function (param = attr(get(sys.call()[[1]]), "parameter_template"))
             else (fish__growth_l[] <- growth_bbinom(avoid_zero(avoid_zero((param[["fish.Linf"]] - fish__midlen) * (1 - exp(-(param[["fish.K"]]) * cur_step_size)))/fish__plusdl), 5L, avoid_zero(param[["fish.bbin"]])))
             growth_delta_w <- if (fish__growth_lastcalc == floor(cur_step_size * 12L)) 
                 fish__growth_w
-            else (fish__growth_w[] <- (g3a_grow_vec_rotate(pow_vec(fish__midlen, param[["fish.wbeta"]]), 5L + 1) - g3a_grow_vec_extrude(pow_vec(fish__midlen, param[["fish.wbeta"]]), 5L + 1)) * param[["fish.walpha"]])
+            else (fish__growth_w[] <- (g3a_grow_vec_rotate(fish__midlen^param[["fish.wbeta"]], 5L + 1) - g3a_grow_vec_extrude(fish__midlen^param[["fish.wbeta"]], 5L + 1)) * param[["fish.walpha"]])
             growthmat_w <- g3a_grow_matrix_wgt(growth_delta_w)
             growthmat_l <- g3a_grow_matrix_len(growth_delta_l)
             {

--- a/inttest/codegeneration-defaults/model.R
+++ b/inttest/codegeneration-defaults/model.R
@@ -96,8 +96,8 @@ structure(function (param = attr(get(sys.call()[[1]]), "parameter_template"))
     avoid_zero <- function(a) {
         dif_pmax(a, 0, 1000)
     }
-    logspace_add_vec <- function(a, b) {
-        pmax(a, b) + log1p(exp(pmin(a, b) - pmax(a, b)))
+    dif_pmin <- function(a, b, scale) {
+        dif_pmax(a, b, -scale)
     }
     nonconform_mult <- function(base_ar, extra_ar) {
         base_ar * as.vector(extra_ar)
@@ -381,7 +381,7 @@ structure(function (param = attr(get(sys.call()[[1]]), "parameter_template"))
             comment("Calculate fish overconsumption coefficient")
             comment("Apply overconsumption to fish")
             fish__consratio <- fish__totalpredate/avoid_zero(fish__num * fish__wgt)
-            fish__consratio <- logspace_add_vec(fish__consratio * -1000, 0.95 * -1000)/-1000
+            fish__consratio <- dif_pmin(fish__consratio, 0.95, 1000)
             fish__overconsumption <- sum(fish__totalpredate)
             fish__consconv <- 1/avoid_zero(fish__totalpredate)
             fish__totalpredate <- (fish__num * fish__wgt) * fish__consratio

--- a/inttest/codegeneration-defaults/model.cpp
+++ b/inttest/codegeneration-defaults/model.cpp
@@ -543,7 +543,7 @@ Type objective_function<Type>::operator() () {
         {
             auto growth_delta_l = (fish__growth_lastcalc == std::floor(cur_step_size*12) ? fish__growth_l : (fish__growth_l = growth_bbinom(avoid_zero(avoid_zero((fish__Linf - fish__midlen)*((double)(1) - exp(-(fish__K)*cur_step_size))) / fish__plusdl), 5, avoid_zero(fish__bbin))));
 
-            auto growth_delta_w = (fish__growth_lastcalc == std::floor(cur_step_size*12) ? fish__growth_w : (fish__growth_w = (g3a_grow_vec_rotate(pow((vector<Type>)(fish__midlen), fish__wbeta), 5 + (double)(1)) - g3a_grow_vec_extrude(pow((vector<Type>)(fish__midlen), fish__wbeta), 5 + (double)(1)))*fish__walpha));
+            auto growth_delta_w = (fish__growth_lastcalc == std::floor(cur_step_size*12) ? fish__growth_w : (fish__growth_w = (g3a_grow_vec_rotate((fish__midlen).pow(fish__wbeta), 5 + (double)(1)) - g3a_grow_vec_extrude((fish__midlen).pow(fish__wbeta), 5 + (double)(1)))*fish__walpha));
 
             auto growthmat_w = g3a_grow_matrix_wgt(growth_delta_w);
 

--- a/inttest/codegeneration-defaults/model.cpp
+++ b/inttest/codegeneration-defaults/model.cpp
@@ -75,6 +75,10 @@ template<typename X>
 auto avoid_zero(X a) {
     return dif_pmax(a, 0.0, 1e3);
 }
+template<typename X, typename Y>
+auto dif_pmin(X a, Y b, double scale) {
+    return dif_pmax(a, b, -scale);
+}
 template<typename T> std::map<int, T> intlookup_zip(vector<int> keys, vector<T> values) {
             std::map<int, T> lookup = {};
 
@@ -155,13 +159,6 @@ Type objective_function<Type>::operator() () {
     auto nonconform_add = [](array<Type> base_ar, array<Type> extra_ar) -> array<Type> {
     assert(base_ar.size() % extra_ar.size() == 0);
     return base_ar + (extra_ar.replicate(base_ar.size() / extra_ar.size(), 1));
-};
-    auto logspace_add_vec = [](vector<Type> a, Type b) -> vector<Type> {
-    vector<Type> res(a.size());
-    for(int i = 0; i < a.size(); i++) {
-        res[i] = logspace_add(a[i], b);
-    }
-    return res;
 };
     auto nonconform_mult = [](array<Type> base_ar, array<Type> extra_ar) -> array<Type> {
     assert(base_ar.size() % extra_ar.size() == 0);
@@ -515,7 +512,7 @@ Type objective_function<Type>::operator() () {
             // Calculate fish overconsumption coefficient;
             // Apply overconsumption to fish;
             fish__consratio = fish__totalpredate / avoid_zero(fish__num*fish__wgt);
-            fish__consratio = logspace_add_vec(fish__consratio*-(double)(1000), (double)(0.95)*-(double)(1000)) / -(double)(1000);
+            fish__consratio = dif_pmin(fish__consratio, (double)(0.95), (double)(1000));
             fish__overconsumption = (fish__totalpredate).sum();
             fish__consconv = (double)(1) / avoid_zero(fish__totalpredate);
             fish__totalpredate = (fish__num*fish__wgt)*fish__consratio;

--- a/inttest/codegeneration/ling.R
+++ b/inttest/codegeneration/ling.R
@@ -90,8 +90,8 @@ structure(function (param = attr(get(sys.call()[[1]]), "parameter_template"))
     avoid_zero <- function(a) {
         dif_pmax(a, 0, 1000)
     }
-    logspace_add_vec <- function(a, b) {
-        pmax(a, b) + log1p(exp(pmin(a, b) - pmax(a, b)))
+    dif_pmin <- function(a, b, scale) {
+        dif_pmax(a, b, -scale)
     }
     nonconform_mult <- function(base_ar, extra_ar) {
         base_ar * as.vector(extra_ar)
@@ -420,7 +420,7 @@ structure(function (param = attr(get(sys.call()[[1]]), "parameter_template"))
             comment("Calculate ling_imm overconsumption coefficient")
             comment("Apply overconsumption to ling_imm")
             ling_imm__consratio <- ling_imm__totalpredate/avoid_zero(ling_imm__num * ling_imm__wgt)
-            ling_imm__consratio <- logspace_add_vec(ling_imm__consratio * -1000, 0.95 * -1000)/-1000
+            ling_imm__consratio <- dif_pmin(ling_imm__consratio, 0.95, 1000)
             ling_imm__overconsumption <- sum(ling_imm__totalpredate)
             ling_imm__consconv <- 1/avoid_zero(ling_imm__totalpredate)
             ling_imm__totalpredate <- (ling_imm__num * ling_imm__wgt) * ling_imm__consratio
@@ -432,7 +432,7 @@ structure(function (param = attr(get(sys.call()[[1]]), "parameter_template"))
             comment("Calculate ling_mat overconsumption coefficient")
             comment("Apply overconsumption to ling_mat")
             ling_mat__consratio <- ling_mat__totalpredate/avoid_zero(ling_mat__num * ling_mat__wgt)
-            ling_mat__consratio <- logspace_add_vec(ling_mat__consratio * -1000, 0.95 * -1000)/-1000
+            ling_mat__consratio <- dif_pmin(ling_mat__consratio, 0.95, 1000)
             ling_mat__overconsumption <- sum(ling_mat__totalpredate)
             ling_mat__consconv <- 1/avoid_zero(ling_mat__totalpredate)
             ling_mat__totalpredate <- (ling_mat__num * ling_mat__wgt) * ling_mat__consratio

--- a/inttest/codegeneration/ling.R
+++ b/inttest/codegeneration/ling.R
@@ -112,9 +112,6 @@ structure(function (param = attr(get(sys.call()[[1]]), "parameter_template"))
         out[is.na(out)] <- vec[length(vec)]
         out
     }
-    pow_vec <- function(a, b) {
-        a^b
-    }
     g3a_grow_vec_extrude <- function(vec, a) {
         array(vec, dim = c(length(vec), a))
     }
@@ -490,7 +487,7 @@ structure(function (param = attr(get(sys.call()[[1]]), "parameter_template"))
             else (ling_imm__growth_l[] <- growth_bbinom(avoid_zero(avoid_zero((param[["ling.Linf"]] - ling_imm__midlen) * (1 - exp(-((param[["ling.K"]] * 0.001)) * cur_step_size)))/ling_imm__plusdl), 15L, avoid_zero((param[["ling.bbin"]] * 10))))
             growth_delta_w <- if (ling_imm__growth_lastcalc == floor(cur_step_size * 12L)) 
                 ling_imm__growth_w
-            else (ling_imm__growth_w[] <- (g3a_grow_vec_rotate(pow_vec(ling_imm__midlen, param[["lingimm.wbeta"]]), 15L + 1) - g3a_grow_vec_extrude(pow_vec(ling_imm__midlen, param[["lingimm.wbeta"]]), 15L + 1)) * param[["lingimm.walpha"]])
+            else (ling_imm__growth_w[] <- (g3a_grow_vec_rotate(ling_imm__midlen^param[["lingimm.wbeta"]], 15L + 1) - g3a_grow_vec_extrude(ling_imm__midlen^param[["lingimm.wbeta"]], 15L + 1)) * param[["lingimm.walpha"]])
             growthmat_w <- g3a_grow_matrix_wgt(growth_delta_w)
             growthmat_l <- g3a_grow_matrix_len(growth_delta_l)
             {
@@ -535,7 +532,7 @@ structure(function (param = attr(get(sys.call()[[1]]), "parameter_template"))
             else (ling_mat__growth_l[] <- growth_bbinom(avoid_zero(avoid_zero((param[["ling.Linf"]] - ling_mat__midlen) * (1 - exp(-((param[["ling.K"]] * 0.001)) * cur_step_size)))/ling_mat__plusdl), 15L, avoid_zero((param[["ling.bbin"]] * 10))))
             growth_delta_w <- if (ling_mat__growth_lastcalc == floor(cur_step_size * 12L)) 
                 ling_mat__growth_w
-            else (ling_mat__growth_w[] <- (g3a_grow_vec_rotate(pow_vec(ling_mat__midlen, param[["lingmat.wbeta"]]), 15L + 1) - g3a_grow_vec_extrude(pow_vec(ling_mat__midlen, param[["lingmat.wbeta"]]), 15L + 1)) * param[["lingmat.walpha"]])
+            else (ling_mat__growth_w[] <- (g3a_grow_vec_rotate(ling_mat__midlen^param[["lingmat.wbeta"]], 15L + 1) - g3a_grow_vec_extrude(ling_mat__midlen^param[["lingmat.wbeta"]], 15L + 1)) * param[["lingmat.walpha"]])
             growthmat_w <- g3a_grow_matrix_wgt(growth_delta_w)
             growthmat_l <- g3a_grow_matrix_len(growth_delta_l)
             {

--- a/inttest/codegeneration/ling.cpp
+++ b/inttest/codegeneration/ling.cpp
@@ -23,9 +23,58 @@ namespace map_extras {
     }
 }
 
+
+#ifndef TYPE_IS_SCALAR
+#ifdef TMBAD_FRAMEWORK
+#define TYPE_IS_SCALAR(TestT) typename = std::enable_if_t<std::is_same<TestT, int>::value || std::is_same<TestT, double>::value || std::is_same<TestT, TMBad::global::ad_aug>::value>
+#endif // TMBAD_FRAMEWORK
+#ifdef CPPAD_FRAMEWORK
+#define TYPE_IS_SCALAR(TestT) typename = std::enable_if_t<std::is_same<TestT, int>::value || std::is_same<TestT, double>::value || std::is_same<TestT, CppAD::AD>::value>
+#endif // CPPAD_FRAMEWORK
+#endif // TYPE_IS_SCALAR
+
 template<typename T, typename DefT> T intlookup_getdefault(std::map<int, T> lookup, int key, DefT def) {
             return lookup.count(key) > 0 ? lookup[key] : (T)def;
         }
+// Scalar templates
+template<typename T, typename LimitT, TYPE_IS_SCALAR(T), TYPE_IS_SCALAR(LimitT)>
+T dif_pmax(T a, LimitT b, double scale) {
+    return logspace_add(a * scale, (T)b * scale) / scale;
+}
+// templates for vector<Type>s & Eigen derived vectors
+template<typename LimitT, typename Derived, TYPE_IS_SCALAR(LimitT)>
+vector<typename Derived::value_type> dif_pmax(const Eigen::DenseBase<Derived>& a, LimitT b, double scale) {
+    vector<typename Derived::value_type> out(a.size());
+    for(int i = 0; i < a.size(); i++) out[i] = logspace_add(a[i] * scale, (typename Derived::value_type)b * scale) / scale;
+    return out;
+}
+template<typename LimitT, typename Derived>
+vector<typename Derived::value_type> dif_pmax(const Eigen::DenseBase<Derived>& a, const Eigen::DenseBase<LimitT>& b, double scale) {
+    assert(a.size() % b.size() == 0);
+
+    vector<typename Derived::value_type> out(a.size());
+    for(int i = 0; i < a.size(); i++) out[i] = logspace_add(a[i] * scale, (typename Derived::value_type)(b[i % b.size()]) * scale) / scale;
+    return out;
+}
+// Templates for Eigen derived arrays
+template<typename LimitT, typename Derived, TYPE_IS_SCALAR(LimitT)>
+array<typename Derived::value_type> dif_pmax(const Eigen::Map<Eigen::DenseBase<Derived>>& a, LimitT b, double scale) {
+    array<typename Derived::value_type> out(a.size());
+    for(int i = 0; i < a.size(); i++) out[i] = logspace_add(a[i] * scale, (typename Derived::value_type)b * scale) / scale;
+    return out;
+}
+template<typename LimitT, typename Derived>
+array<typename Derived::value_type> dif_pmax(const Eigen::Map<Eigen::DenseBase<Derived>>& a, const Eigen::DenseBase<LimitT>& b, double scale) {
+    assert(a.size() % b.size() == 0);
+
+    array<typename Derived::value_type> out(a.size());
+    for(int i = 0; i < a.size(); i++) out[i] = logspace_add(a[i] * scale, (typename Derived::value_type)(b[i % b.size()]) * scale) / scale;
+    return out;
+}
+template<typename X>
+auto avoid_zero(X a) {
+    return dif_pmax(a, 0.0, 1e3);
+}
 template<typename T> std::map<int, T> intlookup_zip(vector<int> keys, vector<T> values) {
             std::map<int, T> lookup = {};
 
@@ -102,13 +151,6 @@ Type objective_function<Type>::operator() () {
     assert(base_ar.size() % extra_ar.size() == 0);
     return base_ar + (extra_ar.replicate(base_ar.size() / extra_ar.size(), 1));
 };
-    auto avoid_zero_vec = [](vector<Type> a) -> vector<Type> {
-    vector<Type> res(a.size());
-    for(int i = 0; i < a.size(); i++) {
-        res[i] = logspace_add(a[i] * 1000.0, (Type)0.0) / 1000.0;
-    }
-    return res;
-};
     auto logspace_add_vec = [](vector<Type> a, Type b) -> vector<Type> {
     vector<Type> res(a.size());
     for(int i = 0; i < a.size(); i++) {
@@ -152,9 +194,6 @@ Type objective_function<Type>::operator() () {
             lgamma(alpha)).exp();
         return(val);
     };
-    auto avoid_zero = [](Type a) -> Type {
-    return logspace_add(a * 1000.0, (Type)0.0) / 1000.0;
-};
     auto g3a_grow_vec_rotate = [](vector<Type> vec, int a) -> array<Type> {
     array<Type> out(vec.size(), a);
     for (int i = 0 ; i < vec.size(); i++) {
@@ -213,14 +252,6 @@ Type objective_function<Type>::operator() () {
     auto g3a_grow_apply = [](matrix<Type> growth_matrix, matrix<Type> weight_matrix, vector<Type> input_num, vector<Type> input_wgt) -> array<Type> {
     int total_lgs = growth_matrix.cols(); // # Length groups
 
-    auto avoid_zero_vec = [](vector<Type> a) -> vector<Type> {
-        vector<Type> res(a.size());
-        for(int i = 0; i < a.size(); i++) {
-            res[i] = logspace_add(a[i] * 1000.0, (Type)0.0) / 1000.0;
-        }
-        return res;
-    };
-
     // Apply matrices to stock
     // NB: Cast to array to get elementwise multiplication
     growth_matrix = growth_matrix.array().colwise() * input_num.array();
@@ -229,11 +260,11 @@ Type objective_function<Type>::operator() () {
     // Sum together all length group brackets for both length & weight
     array<Type> combined(total_lgs,2);
     combined.col(0) = growth_matrix.colwise().sum();
-    combined.col(1) = weight_matrix.colwise().sum().array().rowwise() / avoid_zero_vec(growth_matrix.colwise().sum()).array().transpose();
+    combined.col(1) = weight_matrix.colwise().sum().array().rowwise() / avoid_zero(growth_matrix.colwise().sum()).array().transpose();
     return combined;
 };
-    auto ratio_add_vec = [&avoid_zero_vec](vector<Type> orig_vec, vector<Type> orig_amount, vector<Type> new_vec, vector<Type> new_amount) -> vector<Type> {
-    return (orig_vec * orig_amount + new_vec * new_amount) / avoid_zero_vec(orig_amount + new_amount);
+    auto ratio_add_vec = [](vector<Type> orig_vec, vector<Type> orig_amount, vector<Type> new_vec, vector<Type> new_amount) -> vector<Type> {
+    return (orig_vec * orig_amount + new_vec * new_amount) / avoid_zero(orig_amount + new_amount);
 };
     int cur_time = -1;
     int cur_year = 0;
@@ -493,10 +524,10 @@ Type objective_function<Type>::operator() () {
         {
             // Calculate ling_imm overconsumption coefficient;
             // Apply overconsumption to ling_imm;
-            ling_imm__consratio = ling_imm__totalpredate / avoid_zero_vec(ling_imm__num*ling_imm__wgt);
+            ling_imm__consratio = ling_imm__totalpredate / avoid_zero(ling_imm__num*ling_imm__wgt);
             ling_imm__consratio = logspace_add_vec(ling_imm__consratio*-(double)(1000), (double)(0.95)*-(double)(1000)) / -(double)(1000);
             ling_imm__overconsumption = (ling_imm__totalpredate).sum();
-            ling_imm__consconv = (double)(1) / avoid_zero_vec(ling_imm__totalpredate);
+            ling_imm__consconv = (double)(1) / avoid_zero(ling_imm__totalpredate);
             ling_imm__totalpredate = (ling_imm__num*ling_imm__wgt)*ling_imm__consratio;
             ling_imm__overconsumption -= (ling_imm__totalpredate).sum();
             ling_imm__consconv *= ling_imm__totalpredate;
@@ -505,10 +536,10 @@ Type objective_function<Type>::operator() () {
         {
             // Calculate ling_mat overconsumption coefficient;
             // Apply overconsumption to ling_mat;
-            ling_mat__consratio = ling_mat__totalpredate / avoid_zero_vec(ling_mat__num*ling_mat__wgt);
+            ling_mat__consratio = ling_mat__totalpredate / avoid_zero(ling_mat__num*ling_mat__wgt);
             ling_mat__consratio = logspace_add_vec(ling_mat__consratio*-(double)(1000), (double)(0.95)*-(double)(1000)) / -(double)(1000);
             ling_mat__overconsumption = (ling_mat__totalpredate).sum();
-            ling_mat__consconv = (double)(1) / avoid_zero_vec(ling_mat__totalpredate);
+            ling_mat__consconv = (double)(1) / avoid_zero(ling_mat__totalpredate);
             ling_mat__totalpredate = (ling_mat__num*ling_mat__wgt)*ling_mat__consratio;
             ling_mat__overconsumption -= (ling_mat__totalpredate).sum();
             ling_mat__consconv *= ling_mat__totalpredate;
@@ -566,7 +597,7 @@ Type objective_function<Type>::operator() () {
         {
             auto maturity_ratio = ((double)(1) / ((double)(1) + exp(((double)(0) - ((double)(0.001)*ling__mat1)*(ling_imm__midlen - ling__mat2)))));
 
-            auto growth_delta_l = (ling_imm__growth_lastcalc == std::floor(cur_step_size*12) ? ling_imm__growth_l : (ling_imm__growth_l = growth_bbinom(avoid_zero_vec(avoid_zero_vec((ling__Linf - ling_imm__midlen)*((double)(1) - exp(-((ling__K*(double)(0.001)))*cur_step_size))) / ling_imm__plusdl), 15, avoid_zero((ling__bbin*(double)(10))))));
+            auto growth_delta_l = (ling_imm__growth_lastcalc == std::floor(cur_step_size*12) ? ling_imm__growth_l : (ling_imm__growth_l = growth_bbinom(avoid_zero(avoid_zero((ling__Linf - ling_imm__midlen)*((double)(1) - exp(-((ling__K*(double)(0.001)))*cur_step_size))) / ling_imm__plusdl), 15, avoid_zero((ling__bbin*(double)(10))))));
 
             auto growth_delta_w = (ling_imm__growth_lastcalc == std::floor(cur_step_size*12) ? ling_imm__growth_w : (ling_imm__growth_w = (g3a_grow_vec_rotate(pow((vector<Type>)(ling_imm__midlen), lingimm__wbeta), 15 + (double)(1)) - g3a_grow_vec_extrude(pow((vector<Type>)(ling_imm__midlen), lingimm__wbeta), 15 + (double)(1)))*lingimm__walpha));
 
@@ -620,7 +651,7 @@ Type objective_function<Type>::operator() () {
             }
         }
         {
-            auto growth_delta_l = (ling_mat__growth_lastcalc == std::floor(cur_step_size*12) ? ling_mat__growth_l : (ling_mat__growth_l = growth_bbinom(avoid_zero_vec(avoid_zero_vec((ling__Linf - ling_mat__midlen)*((double)(1) - exp(-((ling__K*(double)(0.001)))*cur_step_size))) / ling_mat__plusdl), 15, avoid_zero((ling__bbin*(double)(10))))));
+            auto growth_delta_l = (ling_mat__growth_lastcalc == std::floor(cur_step_size*12) ? ling_mat__growth_l : (ling_mat__growth_l = growth_bbinom(avoid_zero(avoid_zero((ling__Linf - ling_mat__midlen)*((double)(1) - exp(-((ling__K*(double)(0.001)))*cur_step_size))) / ling_mat__plusdl), 15, avoid_zero((ling__bbin*(double)(10))))));
 
             auto growth_delta_w = (ling_mat__growth_lastcalc == std::floor(cur_step_size*12) ? ling_mat__growth_w : (ling_mat__growth_w = (g3a_grow_vec_rotate(pow((vector<Type>)(ling_mat__midlen), lingmat__wbeta), 15 + (double)(1)) - g3a_grow_vec_extrude(pow((vector<Type>)(ling_mat__midlen), lingmat__wbeta), 15 + (double)(1)))*lingmat__walpha));
 
@@ -677,7 +708,7 @@ Type objective_function<Type>::operator() () {
                                     ling_mat__wgt.col(ling_mat__area_idx).col(ling_mat__age_idx) = (ling_mat__wgt.col(ling_mat__area_idx).col(ling_mat__age_idx)*ling_mat__num.col(ling_mat__area_idx).col(ling_mat__age_idx)) + ling_imm__transitioning_wgt.col(ling_imm__area_idx).col(ling_imm__age_idx)*ling_imm__transitioning_num.col(ling_imm__area_idx).col(ling_imm__age_idx);
                                     ling_mat__num.col(ling_mat__area_idx).col(ling_mat__age_idx) += ling_imm__transitioning_num.col(ling_imm__area_idx).col(ling_imm__age_idx);
                                     ling_imm__transitioning_num.col(ling_imm__area_idx).col(ling_imm__age_idx) -= ling_imm__transitioning_num.col(ling_imm__area_idx).col(ling_imm__age_idx);
-                                    ling_mat__wgt.col(ling_mat__area_idx).col(ling_mat__age_idx) /= avoid_zero_vec(ling_mat__num.col(ling_mat__area_idx).col(ling_mat__age_idx));
+                                    ling_mat__wgt.col(ling_mat__area_idx).col(ling_mat__age_idx) /= avoid_zero(ling_mat__num.col(ling_mat__area_idx).col(ling_mat__age_idx));
                                 }
                             }
                         }
@@ -756,7 +787,7 @@ Type objective_function<Type>::operator() () {
 
                         {
                             // Convert ling_imm_igfs to num;
-                            cdist_sumofsquares_ldist_lln_model__num.col(cdist_sumofsquares_ldist_lln_model__area_idx) += (ling_imm_igfs__cons.col(ling_imm__area_idx).col(ling_imm__age_idx) / avoid_zero_vec(ling_imm__wgt.col(ling_imm__area_idx).col(ling_imm__age_idx)));
+                            cdist_sumofsquares_ldist_lln_model__num.col(cdist_sumofsquares_ldist_lln_model__area_idx) += (ling_imm_igfs__cons.col(ling_imm__area_idx).col(ling_imm__age_idx) / avoid_zero(ling_imm__wgt.col(ling_imm__area_idx).col(ling_imm__age_idx)));
                         }
                     }
                 }
@@ -777,7 +808,7 @@ Type objective_function<Type>::operator() () {
 
                         {
                             // Convert ling_mat_igfs to num;
-                            cdist_sumofsquares_ldist_lln_model__num.col(cdist_sumofsquares_ldist_lln_model__area_idx) += (ling_mat_igfs__cons.col(ling_mat__area_idx).col(ling_mat__age_idx) / avoid_zero_vec(ling_mat__wgt.col(ling_mat__area_idx).col(ling_mat__age_idx)));
+                            cdist_sumofsquares_ldist_lln_model__num.col(cdist_sumofsquares_ldist_lln_model__area_idx) += (ling_mat_igfs__cons.col(ling_mat__area_idx).col(ling_mat__age_idx) / avoid_zero(ling_mat__wgt.col(ling_mat__area_idx).col(ling_mat__age_idx)));
                         }
                     }
                 }
@@ -916,7 +947,7 @@ Type objective_function<Type>::operator() () {
                                 {
                                     ling_mat__wgt.col(ling_mat__area_idx).col(ling_mat__age_idx) = (ling_mat__wgt.col(ling_mat__area_idx).col(ling_mat__age_idx)*ling_mat__num.col(ling_mat__area_idx).col(ling_mat__age_idx)) + ling_imm_movement__transitioning_wgt.col(ling_imm_movement__area_idx).col(ling_imm_movement__age_idx)*ling_imm_movement__transitioning_num.col(ling_imm_movement__area_idx).col(ling_imm_movement__age_idx);
                                     ling_mat__num.col(ling_mat__area_idx).col(ling_mat__age_idx) += ling_imm_movement__transitioning_num.col(ling_imm_movement__area_idx).col(ling_imm_movement__age_idx);
-                                    ling_mat__wgt.col(ling_mat__area_idx).col(ling_mat__age_idx) /= avoid_zero_vec(ling_mat__num.col(ling_mat__area_idx).col(ling_mat__age_idx));
+                                    ling_mat__wgt.col(ling_mat__area_idx).col(ling_mat__age_idx) /= avoid_zero(ling_mat__num.col(ling_mat__area_idx).col(ling_mat__age_idx));
                                 }
                             }
                         }

--- a/inttest/codegeneration/ling.cpp
+++ b/inttest/codegeneration/ling.cpp
@@ -596,7 +596,7 @@ Type objective_function<Type>::operator() () {
 
             auto growth_delta_l = (ling_imm__growth_lastcalc == std::floor(cur_step_size*12) ? ling_imm__growth_l : (ling_imm__growth_l = growth_bbinom(avoid_zero(avoid_zero((ling__Linf - ling_imm__midlen)*((double)(1) - exp(-((ling__K*(double)(0.001)))*cur_step_size))) / ling_imm__plusdl), 15, avoid_zero((ling__bbin*(double)(10))))));
 
-            auto growth_delta_w = (ling_imm__growth_lastcalc == std::floor(cur_step_size*12) ? ling_imm__growth_w : (ling_imm__growth_w = (g3a_grow_vec_rotate(pow((vector<Type>)(ling_imm__midlen), lingimm__wbeta), 15 + (double)(1)) - g3a_grow_vec_extrude(pow((vector<Type>)(ling_imm__midlen), lingimm__wbeta), 15 + (double)(1)))*lingimm__walpha));
+            auto growth_delta_w = (ling_imm__growth_lastcalc == std::floor(cur_step_size*12) ? ling_imm__growth_w : (ling_imm__growth_w = (g3a_grow_vec_rotate((ling_imm__midlen).pow(lingimm__wbeta), 15 + (double)(1)) - g3a_grow_vec_extrude((ling_imm__midlen).pow(lingimm__wbeta), 15 + (double)(1)))*lingimm__walpha));
 
             auto growthmat_w = g3a_grow_matrix_wgt(growth_delta_w);
 
@@ -650,7 +650,7 @@ Type objective_function<Type>::operator() () {
         {
             auto growth_delta_l = (ling_mat__growth_lastcalc == std::floor(cur_step_size*12) ? ling_mat__growth_l : (ling_mat__growth_l = growth_bbinom(avoid_zero(avoid_zero((ling__Linf - ling_mat__midlen)*((double)(1) - exp(-((ling__K*(double)(0.001)))*cur_step_size))) / ling_mat__plusdl), 15, avoid_zero((ling__bbin*(double)(10))))));
 
-            auto growth_delta_w = (ling_mat__growth_lastcalc == std::floor(cur_step_size*12) ? ling_mat__growth_w : (ling_mat__growth_w = (g3a_grow_vec_rotate(pow((vector<Type>)(ling_mat__midlen), lingmat__wbeta), 15 + (double)(1)) - g3a_grow_vec_extrude(pow((vector<Type>)(ling_mat__midlen), lingmat__wbeta), 15 + (double)(1)))*lingmat__walpha));
+            auto growth_delta_w = (ling_mat__growth_lastcalc == std::floor(cur_step_size*12) ? ling_mat__growth_w : (ling_mat__growth_w = (g3a_grow_vec_rotate((ling_mat__midlen).pow(lingmat__wbeta), 15 + (double)(1)) - g3a_grow_vec_extrude((ling_mat__midlen).pow(lingmat__wbeta), 15 + (double)(1)))*lingmat__walpha));
 
             auto growthmat_w = g3a_grow_matrix_wgt(growth_delta_w);
 

--- a/inttest/codegeneration/ling.cpp
+++ b/inttest/codegeneration/ling.cpp
@@ -75,6 +75,10 @@ template<typename X>
 auto avoid_zero(X a) {
     return dif_pmax(a, 0.0, 1e3);
 }
+template<typename X, typename Y>
+auto dif_pmin(X a, Y b, double scale) {
+    return dif_pmax(a, b, -scale);
+}
 template<typename T> std::map<int, T> intlookup_zip(vector<int> keys, vector<T> values) {
             std::map<int, T> lookup = {};
 
@@ -150,13 +154,6 @@ Type objective_function<Type>::operator() () {
     auto nonconform_add = [](array<Type> base_ar, array<Type> extra_ar) -> array<Type> {
     assert(base_ar.size() % extra_ar.size() == 0);
     return base_ar + (extra_ar.replicate(base_ar.size() / extra_ar.size(), 1));
-};
-    auto logspace_add_vec = [](vector<Type> a, Type b) -> vector<Type> {
-    vector<Type> res(a.size());
-    for(int i = 0; i < a.size(); i++) {
-        res[i] = logspace_add(a[i], b);
-    }
-    return res;
 };
     auto nonconform_mult = [](array<Type> base_ar, array<Type> extra_ar) -> array<Type> {
     assert(base_ar.size() % extra_ar.size() == 0);
@@ -525,7 +522,7 @@ Type objective_function<Type>::operator() () {
             // Calculate ling_imm overconsumption coefficient;
             // Apply overconsumption to ling_imm;
             ling_imm__consratio = ling_imm__totalpredate / avoid_zero(ling_imm__num*ling_imm__wgt);
-            ling_imm__consratio = logspace_add_vec(ling_imm__consratio*-(double)(1000), (double)(0.95)*-(double)(1000)) / -(double)(1000);
+            ling_imm__consratio = dif_pmin(ling_imm__consratio, (double)(0.95), (double)(1000));
             ling_imm__overconsumption = (ling_imm__totalpredate).sum();
             ling_imm__consconv = (double)(1) / avoid_zero(ling_imm__totalpredate);
             ling_imm__totalpredate = (ling_imm__num*ling_imm__wgt)*ling_imm__consratio;
@@ -537,7 +534,7 @@ Type objective_function<Type>::operator() () {
             // Calculate ling_mat overconsumption coefficient;
             // Apply overconsumption to ling_mat;
             ling_mat__consratio = ling_mat__totalpredate / avoid_zero(ling_mat__num*ling_mat__wgt);
-            ling_mat__consratio = logspace_add_vec(ling_mat__consratio*-(double)(1000), (double)(0.95)*-(double)(1000)) / -(double)(1000);
+            ling_mat__consratio = dif_pmin(ling_mat__consratio, (double)(0.95), (double)(1000));
             ling_mat__overconsumption = (ling_mat__totalpredate).sum();
             ling_mat__consconv = (double)(1) / avoid_zero(ling_mat__totalpredate);
             ling_mat__totalpredate = (ling_mat__num*ling_mat__wgt)*ling_mat__consratio;

--- a/inttest/maturity-continuous/run.R
+++ b/inttest/maturity-continuous/run.R
@@ -11,8 +11,19 @@ actions <- local({
     eval(g2to3_mainfile('inttest/maturity-continuous'))
     c(actions, list(g3a_report_history(actions), g3a_report_history(actions, "__growth_[lw]$|stock__transitioning_(num|wgt)$", "growthinternals_")))
 })
-environment(actions[[1]][[1]])$avoid_zero <- g3_native(function (a) max(a, 1e-7), cpp = "[](Type a) -> Type { return std::max(a, (Type)1e-7); }")
-environment(actions[[1]][[1]])$avoid_zero_vec <- g3_native(function (a) pmax(a, 1e-7), cpp = "[](vector<Type> a) -> vector<Type> { return a.cwiseMax(1e-7); }")
+
+# Replace avoid_zero with a more accurate scale
+actions <- c(g3_formula({
+    avoid_zero(nll)
+}, avoid_zero = g3_native(r = function(a) {
+    dif_pmax(a, 0.0, 1e7)
+}, cpp = '
+template<typename X>
+auto __fn__(X a) {
+    return dif_pmax(a, 0.0, 1e7);
+}
+', depends = c("dif_pmax")) ), actions)
+
 model_fn <- g3_to_r(actions, strict = FALSE, trace = FALSE)
 params <- local({eval(g2to3_params_r('inttest/maturity-continuous', 'params.in')) ; params.in})
 

--- a/inttest/renewal/run.R
+++ b/inttest/renewal/run.R
@@ -11,8 +11,19 @@ actions <- local({
     eval(g2to3_mainfile('inttest/renewal'))
     c(actions, list(g3a_report_history(actions)))
 })
-environment(actions[[1]][[1]])$avoid_zero <- g3_native(function (a) max(a, 1e-7), cpp = "[](Type a) -> Type { return std::max(a, (Type)1e-7); }")
-environment(actions[[1]][[1]])$avoid_zero_vec <- g3_native(function (a) pmax(a, 1e-7), cpp = "[](vector<Type> a) -> vector<Type> { return a.cwiseMax(1e-7); }")
+
+# Replace avoid_zero with a more accurate scale
+actions <- c(g3_formula({
+    avoid_zero(nll)
+}, avoid_zero = g3_native(r = function(a) {
+    dif_pmax(a, 0.0, 1e7)
+}, cpp = '
+template<typename X>
+auto __fn__(X a) {
+    return dif_pmax(a, 0.0, 1e7);
+}
+', depends = c("dif_pmax")) ), actions)
+
 model_fn <- g3_to_r(actions, strict = FALSE, trace = FALSE)
 params <- local({eval(g2to3_params_r('inttest/renewal', 'params.in')) ; params.in})
 

--- a/inttest/spawn/run.R
+++ b/inttest/spawn/run.R
@@ -10,8 +10,19 @@ actions <- local({
     eval(g2to3_mainfile('inttest/spawn'))
     c(actions, list(g3a_report_history(actions)))
 })
-environment(actions[[1]][[1]])$avoid_zero <- g3_native(function (a) max(a, 1e-7), cpp = "[](Type a) -> Type { return std::max(a, (Type)1e-7); }")
-environment(actions[[1]][[1]])$avoid_zero_vec <- g3_native(function (a) pmax(a, 1e-7), cpp = "[](vector<Type> a) -> vector<Type> { return a.cwiseMax(1e-7); }")
+
+# Replace avoid_zero with a more accurate scale
+actions <- c(g3_formula({
+    avoid_zero(nll)
+}, avoid_zero = g3_native(r = function(a) {
+    dif_pmax(a, 0.0, 1e7)
+}, cpp = '
+template<typename X>
+auto __fn__(X a) {
+    return dif_pmax(a, 0.0, 1e7);
+}
+', depends = c("dif_pmax")) ), actions)
+
 model_fn <- g3_to_r(actions, strict = TRUE, trace = FALSE)
 params <- local({eval(g2to3_params_r('inttest/spawn', 'params.in')) ; params.in})
 

--- a/inttest/understocking/run.R
+++ b/inttest/understocking/run.R
@@ -22,8 +22,19 @@ actions <- local({
     eval(g2to3_mainfile('inttest/understocking'))
     c(actions, report_actions, list(g3a_report_history(actions, var_re = "__num$|__wgt$|__consratio$|__totalpredate$|__cons$")))
 })
-environment(actions[[1]][[1]])$avoid_zero <- g3_native(function (a) max(a, 1e-7), cpp = "[](Type a) -> Type { return std::max(a, (Type)1e-7); }")
-environment(actions[[1]][[1]])$avoid_zero_vec <- g3_native(function (a) pmax(a, 1e-7), cpp = "[](vector<Type> a) -> vector<Type> { return a.cwiseMax(1e-7); }")
+
+# Replace avoid_zero with a more accurate scale
+actions <- c(g3_formula({
+    avoid_zero(nll)
+}, avoid_zero = g3_native(r = function(a) {
+    dif_pmax(a, 0.0, 1e7)
+}, cpp = '
+template<typename X>
+auto __fn__(X a) {
+    return dif_pmax(a, 0.0, 1e7);
+}
+', depends = c("dif_pmax")) ), actions)
+
 model_fn <- g3_to_r(actions, strict = TRUE, trace = FALSE)
 params <- local({eval(g2to3_params_r('inttest/understocking', 'params.in')) ; params.in})
 

--- a/man/aaa_lang.Rd
+++ b/man/aaa_lang.Rd
@@ -55,7 +55,7 @@ eg_ratio_add_vec <- g3_native(r = function(orig_vec, orig_amount,
     ((orig_vec * orig_amount + new_vec * new_amount)
       /
     avoid_zero_vec(orig_amount + new_amount))
-}, cpp = '[&avoid_zero_vec](vector<Type> orig_vec, vector<Type> orig_amount,
+}, cpp = '[](vector<Type> orig_vec, vector<Type> orig_amount,
                             vector<Type> new_vec, vector<Type> new_amount)
                             -> vector<Type> {
     return (orig_vec * orig_amount + new_vec * new_amount)

--- a/man/aab_env.Rd
+++ b/man/aab_env.Rd
@@ -13,7 +13,6 @@
 \alias{logspace_add}
 \alias{normalize_vec}
 \alias{nvl}
-\alias{pow_vec}
 \alias{print_array}
 \alias{ratio_add_vec}
 \alias{REPORT}
@@ -81,8 +80,6 @@
   Return first non-null argument.
   NB: No C++ implementation.
 }
-
-\section{pow_vec}{Vector equivalent of \code{\link{^}}}
 
 \section{print_array}{
   Utility to pretty-print array \var{ar}

--- a/man/aab_env.Rd
+++ b/man/aab_env.Rd
@@ -12,7 +12,6 @@
 \alias{lgamma_vec}
 \alias{logspace_add}
 \alias{logspace_add_vec}
-\alias{logspace_minmax_vec}
 \alias{normalize_vec}
 \alias{nvl}
 \alias{pow_vec}
@@ -75,14 +74,6 @@
   TMB's \code{logspace_add}, essentially a differentiable version of \code{\link{pmax}}.
 }
 
-\section{logspace_minmax_vec}{
-  Differentiable equivalent of \code{pmax(pmin(vec, upper), lower)}.
-  \var{scale} influences the sharpness of inflection points at \var{lower} & \var{upper},
-  should be ~1e5, depending on ranges of input values.
-
-  \preformatted{logspace_minmax_vec(vec, lower, upper, scale)}
-}
-
 \section{normalize_vec}{
   Divide vector \var{a} by it's sum, i.e. so it now sums to 1
 }
@@ -132,9 +123,6 @@ curve(g3_eval(quote( bounded(x, 100, 200) ), x = x), -100, 100)
 
 ## logspace_add
 curve(g3_eval(quote( logspace_add(x, 10) ), x = x), 0, 40)
-
-## logspace_minmax_vec
-curve(g3_eval(quote( logspace_minmax_vec(x, 30, 60, scale = 1e5)), x = x), 0, 100)
 
 ## normalize_vec
 g3_eval(quote( normalize_vec(c( 4, 4, 8, 2 )) ))

--- a/man/aab_env.Rd
+++ b/man/aab_env.Rd
@@ -11,7 +11,6 @@
 \alias{g3_matrix_vec}
 \alias{lgamma_vec}
 \alias{logspace_add}
-\alias{logspace_add_vec}
 \alias{normalize_vec}
 \alias{nvl}
 \alias{pow_vec}
@@ -70,7 +69,7 @@
 
 \section{lgamma_vec}{Vector equivalent of \code{\link{lgamma}}}
 
-\section{logspace_add / logspace_add_vec}{
+\section{logspace_add}{
   TMB's \code{logspace_add}, essentially a differentiable version of \code{\link{pmax}}.
 }
 

--- a/man/aab_env.Rd
+++ b/man/aab_env.Rd
@@ -55,9 +55,13 @@
 }
 
 \section{bounded / bounded_vec}{
-  Ensures \var{x} is within limits \var{a} & \var{b}.
+  Ensures \var{x} is within limits \var{b} & \var{a}.
 
-  \preformatted{bounded_vec(x, 100, 1000)}
+  If \var{x} positive, return \var{a}.
+  If \var{x} negative, \var{b}.
+  If \var{x} \code{-10..10}, smoothly transition from \var{b} to \var{a}
+
+  \preformatted{bounded_vec(x, 200, 100)}
 }
 
 \section{g3_matrix_vec}{
@@ -115,7 +119,7 @@ g3_eval(quote( c( avoid_zero(0), avoid_zero(10) ) ))
 g3_eval(quote( avoid_zero(0:5) ))
 
 ## bounded / bounded_vec
-curve(g3_eval(quote( bounded(x, 100, 200) ), x = x), -100, 100)
+curve(g3_eval(quote( bounded(x, 200, 100) ), x = x), -100, 100)
 
 ## logspace_add
 curve(g3_eval(quote( logspace_add(x, 10) ), x = x), 0, 40)

--- a/man/aab_env.Rd
+++ b/man/aab_env.Rd
@@ -52,8 +52,9 @@
   \preformatted{assert_msg(x > 0, "x must be positive")}
 }
 
-\section{avoid_zero / avoid_zero_vec}{
+\section{avoid_zero}{
   Adds small value to input to ensure output is never zero
+  \code{avoid_zero_vec} is identical to \code{avoid_zero}, and is only present for backward compatibility.
 }
 
 \section{bounded / bounded_vec}{
@@ -122,9 +123,9 @@
 }
 
 \examples{
-## avoid_zero / avoid_zero_vec
+## avoid_zero
 g3_eval(quote( c( avoid_zero(0), avoid_zero(10) ) ))
-g3_eval(quote( avoid_zero_vec(0:5) ))
+g3_eval(quote( avoid_zero(0:5) ))
 
 ## bounded / bounded_vec
 curve(g3_eval(quote( bounded(x, 100, 200) ), x = x), -100, 100)

--- a/man/action_predate.Rd
+++ b/man/action_predate.Rd
@@ -56,22 +56,18 @@ g3a_predate(
         prey_stocks,
         suitabilities,
         catchability_f,
-        overconsumption_f = quote(
-            logspace_add_vec(stock__consratio * -1e3, 0.95 * -1e3) / -1e3
-        ),
+        overconsumption_f = quote( dif_pmin(stock__consratio, 0.95, 1e3) ),
         run_f = ~TRUE,
         run_at = g3_action_order$predate )
 
 # NB: Deprecated interface, use g3a_predate()
 g3a_predate_fleet(fleet_stock, prey_stocks, suitabilities, catchability_f,
-    overconsumption_f = quote(
-        logspace_add_vec(stock__consratio * -1e3, 0.95 * -1e3) / -1e3 ),
+    overconsumption_f = quote( dif_pmin(stock__consratio, 0.95, 1e3) ),
     run_f = ~TRUE, run_at = g3_action_order$predate)
 
 # NB: Deprecated interface, use g3a_predate() with g3a_predate_catchability_totalfleet
 g3a_predate_totalfleet(fleet_stock, prey_stocks, suitabilities, amount_f,
-    overconsumption_f = quote(
-        logspace_add_vec(stock__consratio * -1e3, 0.95 * -1e3) / -1e3 ),
+    overconsumption_f = quote( dif_pmin(stock__consratio, 0.95, 1e3) ),
     run_f = ~TRUE, run_at = g3_action_order$predate)
 }
 

--- a/man/env_dif.Rd
+++ b/man/env_dif.Rd
@@ -1,0 +1,58 @@
+\name{env_dif}
+\alias{dif_pmax}
+\alias{dif_pmin}
+\alias{dif_pminmax}
+\concept{G3 internals}
+
+\title{g3 env: differentiable functions}
+\description{
+  Differentiable helper functions available to any gadget3 model
+}
+
+\details{
+  These functions are part of \code{g3_env} is the top-level \link{environment} that any gadget3 model uses.
+}
+
+\section{dif_pmax}{
+  \preformatted{dif_pmax(a, b, scale)}
+
+  Returns the maximum of \var{a} & \var{b}.
+  If \var{a} is a vector/array, then all members of \var{a} are compared against \var{b}.
+  If \var{b} is also a vector, then all members of \var{a} are compared against the matching member of \var{b} (repeating \var{b} if necessary).
+
+  \var{scale} influences the sharpness of inflection points,
+  should be about 1e5, depending on ranges of input values.
+}
+
+\section{dif_pmin}{
+  \preformatted{dif_pmin(a, b, scale)}
+
+  Returns the minimum of \var{a} & \var{b}, otherwise works like \code{dif_pmax}.
+
+  \var{scale} influences the sharpness of inflection points,
+  should be about 1e5, depending on ranges of input values.
+}
+
+\section{dif_pminmax}{
+  \preformatted{dif_pminmax(a, lower, upper, scale)}
+
+  Returns values of \var{a} bounded between \var{lower} & \var{upper}.
+
+  \var{scale} influences the sharpness of inflection points at \var{lower} & \var{upper},
+  should be about 1e5, depending on ranges of input values.
+}
+
+\examples{
+## dif_pmax
+g3_eval(quote( dif_pmax(1:10, 5, 1e5) ))
+g3_eval(quote( dif_pmax(1:10, c(4, 7), 1e5) ))
+g3_eval(quote( dif_pmax(array(1:9, dim = c(3,3)), c(3,6,8), 1e5) ))
+
+## dif_pmin
+g3_eval(quote( dif_pmin(1:10, 5, 1e5) ))
+g3_eval(quote( dif_pmin(1:10, c(4, 7), 1e5) ))
+
+## dif_pminmax
+g3_eval(quote( dif_pminmax(1:10, 3, 6, 1e5) ))
+
+}

--- a/tests/test-aab_env.R
+++ b/tests/test-aab_env.R
@@ -26,20 +26,6 @@ actions <- c(actions, ~{
 expecteds$logspace_add_1 <- 1.313262
 expecteds$logspace_add_0 <- 0.6931472
 
-# logspace_add_vec()
-logspace_add_vec_inp <- c(0,0.1,0.2,0.3)
-logspace_add_vec_0 <- c(0,0,0,0)
-logspace_add_vec_1 <- c(0,0,0,0)
-actions <- c(actions, ~{
-    comment('logspace_add_vec')
-    logspace_add_vec_0 <- logspace_add_vec(logspace_add_vec_inp, 0)
-    logspace_add_vec_1 <- logspace_add_vec(logspace_add_vec_inp, 1)
-    REPORT(logspace_add_vec_0)
-    REPORT(logspace_add_vec_1)
-})
-expecteds$logspace_add_vec_0 <- c(0.6931472, 0.7443967, 0.7981389, 0.8543552)
-expecteds$logspace_add_vec_1 <- c(1.313262, 1.341154, 1.371101, 1.403186)
-
 # ratio_add_vec()
 ratio_add_vec_inp_orig_vec <- runif(10) * 100
 ratio_add_vec_inp_orig_amount <- floor(runif(10) * 10)

--- a/tests/test-aab_env.R
+++ b/tests/test-aab_env.R
@@ -40,30 +40,6 @@ actions <- c(actions, ~{
 expecteds$logspace_add_vec_0 <- c(0.6931472, 0.7443967, 0.7981389, 0.8543552)
 expecteds$logspace_add_vec_1 <- c(1.313262, 1.341154, 1.371101, 1.403186)
 
-# logspace_minmax_vec()
-logspace_minmax_vec_inp <- as.numeric(-10:10)
-logspace_minmax_vec_0 <- rep(NaN, length(logspace_minmax_vec_inp))
-logspace_minmax_vec_1 <- rep(NaN, length(logspace_minmax_vec_inp))
-actions <- c(actions, ~{
-    comment('logspace_minmax_vec')
-    logspace_minmax_vec_0 <- logspace_minmax_vec(logspace_minmax_vec_inp, 3, 6, 1e5)
-    logspace_minmax_vec_1 <- logspace_minmax_vec(logspace_minmax_vec_inp, -4, 7.7, 1e5)
-    REPORT(logspace_minmax_vec_0)
-    REPORT(logspace_minmax_vec_1)
-})
-expecteds$logspace_minmax_vec_0 <- c(
-    3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
-    3,
-    3, 3, 3, 4, 5, 6, 6, 6, 6, 6,
-    NULL)
-tolerances$logspace_minmax_vec_0 <- 1e-5
-expecteds$logspace_minmax_vec_1 <- c(
-    -4, -4, -4, -4, -4, -4, -4, -3, -2, -1,
-    0,
-    1, 2, 3, 4, 5, 6, 7, 7.7, 7.7, 7.7,
-    NULL)
-tolerances$logspace_minmax_vec_1 <- 1e-5
-
 # ratio_add_vec()
 ratio_add_vec_inp_orig_vec <- runif(10) * 100
 ratio_add_vec_inp_orig_amount <- floor(runif(10) * 10)

--- a/tests/test-aab_env.R
+++ b/tests/test-aab_env.R
@@ -8,6 +8,8 @@ actions <- list()
 expecteds <- new.env(parent = emptyenv())
 tolerances <- new.env(parent = emptyenv())
 
+native_avz <- function (a) ( pmax(a * 1000, 0) + log1p(exp(pmin(a * 1000, 0) - pmax(a * 1000, 0))) ) / 1000
+
 # logspace_add()
 logspace_add_1 <- 0.0
 logspace_add_0 <- 0.0
@@ -76,8 +78,8 @@ actions <- c(actions, ~{
     REPORT(ratio_add_vec_output)
 })
 ratio_add_vec_total <- ratio_add_vec_inp_orig_amount + ratio_add_vec_inp_new_amount
-expecteds$ratio_add_vec_output <- ratio_add_vec_inp_orig_vec * (ratio_add_vec_inp_orig_amount / g3_env$avoid_zero_vec(ratio_add_vec_total)) +
-    ratio_add_vec_inp_new_vec * (ratio_add_vec_inp_new_amount / g3_env$avoid_zero_vec(ratio_add_vec_total))
+expecteds$ratio_add_vec_output <- ratio_add_vec_inp_orig_vec * (ratio_add_vec_inp_orig_amount / native_avz(ratio_add_vec_total)) +
+    ratio_add_vec_inp_new_vec * (ratio_add_vec_inp_new_amount / native_avz(ratio_add_vec_total))
 
 # nonconform_mult
 nonconform_inp1 <- array(runif(4*3*2), dim = c(4,3,2))
@@ -147,9 +149,9 @@ actions <- c(actions, ~{
     REPORT(nonconform_outdiv_avz2)
     REPORT(nonconform_outdiv_avz2a)
 })
-expecteds$nonconform_outdiv_avz1 <- nonconform_inp1 / g3_env$avoid_zero_vec(as.vector(nonconform_div_avz_extra[,1]))
-expecteds$nonconform_outdiv_avz2 <- nonconform_inp2 / g3_env$avoid_zero_vec(as.vector(nonconform_div_avz_extra[,2]))
-expecteds$nonconform_outdiv_avz2a <- nonconform_inp2[,,1] / g3_env$avoid_zero_vec(as.vector(nonconform_div_avz_extra[,2]))
+expecteds$nonconform_outdiv_avz1 <- nonconform_inp1 / native_avz(as.vector(nonconform_div_avz_extra[,1]))
+expecteds$nonconform_outdiv_avz2 <- nonconform_inp2 / native_avz(as.vector(nonconform_div_avz_extra[,2]))
+expecteds$nonconform_outdiv_avz2a <- nonconform_inp2[,,1] / native_avz(as.vector(nonconform_div_avz_extra[,2]))
 
 ###############################################################################
 

--- a/tests/test-action_predate.R
+++ b/tests/test-action_predate.R
@@ -389,7 +389,7 @@ ok_group("Overconsumption", {
     ok(ut_cmp_equal(
         as.vector(r$prey_a__num),
         c(15, 25, 35, 45 - (45 * 0.95), 55 - (55 * 0.95), 65 - (65 * 0.95), 75, 85, 95, 105),
-        # NB: Low tolerance due to using logspace_add_vec
+        # NB: Low tolerance due to using dif_pmin
         tolerance = 1e-2), "prey_a__num: Still some left thanks to overconsumption being triggered")
 
     # prey_b
@@ -403,7 +403,7 @@ ok_group("Overconsumption", {
     ok(ut_cmp_equal(
         as.vector(r$prey_b__num),
         c(15, 25, 35, 45, 55, 65 - (65 * 0.95), 75 - (75 * 0.95), 85 - (85 * 0.95), 94.96735, 105),
-        # NB: Low tolerance due to using logspace_add_vec
+        # NB: Low tolerance due to using dif_pmin
         tolerance = 1e-2), "prey_b__num: Hit overconsumption limit")
 
     # prey_c

--- a/tests/test-action_weightloss.R
+++ b/tests/test-action_weightloss.R
@@ -30,7 +30,14 @@ actions <- list(
         st,
         rel_loss = g3_parameterized("ut_rel_loss_len_mw", value = 0),
         min_weight = g3_formula(mw * st__midlen, mw = g3_parameterized("ut_min_weight_len_mw", value = 0)),
-        run_step = 2 ),
+        run_step = 2,
+        run_f = g3_formula(x > 0, x = g3_parameterized("ut_rel_loss_len_mw", value = 0)) ),
+
+    g3a_weightloss(st,
+        # Remove "10" from body weight, with a minimum based on length
+        abs_loss = g3_parameterized("ut_abs_loss_len_mw", value = 0),
+        min_weight = g3_formula(mw * st__midlen, mw = g3_parameterized("ut_min_weight_len_mw", value = 0)),
+        run_f = g3_formula(x > 0, x = g3_parameterized("ut_abs_loss_len_mw", value = 0)) ),
 
     g3l_abundancedistribution(
         'test_results',
@@ -138,7 +145,7 @@ age5    5000    5000    4500    4050    4050    3645    3240    3240    2916  25
 gadget3:::ut_tmb_r_compare2(model_fn, model_cpp, params)
 ######## rel_loss:0.1,abs_loss:100,min_weight:500
 
-ok_group("min_weight by length") ########
+ok_group("rel_loss min_weight by length") ########
 params <- attr(model_fn, 'parameter_template') |>
     g3_init_val("ut_rel_loss_len_mw", 0.75) |>
     g3_init_val("ut_min_weight_len_mw", 50) |>
@@ -155,4 +162,23 @@ ok(gadget3:::ut_cmp_df(r$detail_st__wgt[,1,], '
 ', tolerance = 1e-6), "detail_st__wgt[1,,]: Limit hit depends on length")
 
 gadget3:::ut_tmb_r_compare2(model_fn, model_cpp, params)
-######## rel_loss:0.1,abs_loss:100,min_weight:500
+######## rel_loss min_weight by length
+
+ok_group("abs_loss min_weight by length") ########
+params <- attr(model_fn, 'parameter_template') |>
+    g3_init_val("ut_abs_loss_len_mw", 18) |>
+    g3_init_val("ut_min_weight_len_mw", 50) |>
+    identity() -> params
+r <- lapply(attributes(model_fn(params)), drop)
+
+ok(gadget3:::ut_cmp_df(r$detail_st__wgt[,1,], '
+         2000-01 2000-02 2000-03 2001-01 2001-02 2001-03 2002-01 2002-02 2002-03 2003-01 2003-02 2003-03 2004-01 2004-02 2004-03 2005-01 2005-02 2005-03
+  10:20     1000     982     964     946     928     910     892     874     856     838     820     802     784     766     750     750     750     750
+  20:30     1000    1250    1250    1250    1250    1250    1250    1250    1250    1250    1250    1250    1250    1250    1250    1250    1250    1250
+  30:40     1000    1750    1750    1750    1750    1750    1750    1750    1750    1750    1750    1750    1750    1750    1750    1750    1750    1750
+  40:50     1000    2250    2250    2250    2250    2250    2250    2250    2250    2250    2250    2250    2250    2250    2250    2250    2250    2250
+  50:Inf    1000    2750    2750    2750    2750    2750    2750    2750    2750    2750    2750    2750    2750    2750    2750    2750    2750    2750
+', tolerance = 1e-6), "detail_st__wgt[1,,]: Limit hit depends on length")
+
+gadget3:::ut_tmb_r_compare2(model_fn, model_cpp, params)
+######## abs_loss min_weight by length

--- a/tests/test-env_dif.R
+++ b/tests/test-env_dif.R
@@ -1,0 +1,167 @@
+library(unittest)
+
+library(gadget3)
+
+params <- list()
+actions <- list()
+
+# NB: Should test under both CppAD and TMBAD
+# options(gadget3.tmb.framework = "CppAD")
+
+###############################################################################
+
+dif_pmax_scl_dbl_in <- runif(1, 0, 100)
+dif_pmax_vec_in <- runif(10, 0, 100)
+dif_pmax_vec_vec_max <- runif(10, 0, 10) * 10
+actions[['dif_pmax_vec']] <- g3_formula(
+    {
+        expect_dif_pmax_scl_dbl <- dif_pmax(dif_pmax_scl_dbl_in, 40.0, 1e5)
+        expect_dif_pmax_vec_typ <- dif_pmax(dif_pmax_vec_in, dif_pmax_vec_typ_max, 1e5)
+        expect_dif_pmax_dervec_typ <- dif_pmax(dif_pmax_vec_in * 2, dif_pmax_vec_typ_max, 1e5)
+        expect_dif_pmax_vec_dbl <- dif_pmax(dif_pmax_vec_in, 30.0, 1e5)
+        expect_dif_pmax_vec_int <- dif_pmax(dif_pmax_vec_in, dif_pmax_vec_int_max, 1e5)
+        expect_dif_pmax_vec_vec <- dif_pmax(dif_pmax_vec_in, dif_pmax_vec_vec_max, 1e5)
+    },
+    dif_pmax_scl_dbl_in = dif_pmax_scl_dbl_in,
+    dif_pmax_vec_in = dif_pmax_vec_in,
+    dif_pmax_vec_typ_max = 40.0,
+    dif_pmax_vec_int_max = 60L,
+    dif_pmax_vec_vec_max = dif_pmax_vec_vec_max,
+    expect_dif_pmax_scl_dbl = pmax(dif_pmax_scl_dbl_in, 40),
+    expect_dif_pmax_vec_typ = pmax(dif_pmax_vec_in, 40.0),
+    expect_dif_pmax_dervec_typ = pmax(dif_pmax_vec_in * 2, 40.0),
+    expect_dif_pmax_vec_dbl = pmax(dif_pmax_vec_in, 30.0),
+    expect_dif_pmax_vec_int = pmax(dif_pmax_vec_in, 60L),
+    expect_dif_pmax_vec_vec = pmax(dif_pmax_vec_in, dif_pmax_vec_vec_max),
+    end = NULL )
+
+dif_pmax_arr_in <- array(runif(10, 0, 9), dim = c(3, 3))
+dif_pmax_arr_vec_max <- runif(3, 0, 10) * 10
+actions[['dif_pmax_arr']] <- g3_formula(
+    {
+        expect_dif_pmax_arr_typ <- dif_pmax(dif_pmax_arr_in, dif_pmax_arr_typ_max, 1e5)
+        expect_dif_pmax_dearr_typ <- dif_pmax(dif_pmax_arr_in * 2, dif_pmax_arr_typ_max, 1e5)
+        expect_dif_pmax_arr_dbl <- dif_pmax(dif_pmax_arr_in, 30.0, 1e5)
+        expect_dif_pmax_arr_int <- dif_pmax(dif_pmax_arr_in, dif_pmax_arr_int_max, 1e5)
+        expect_dif_pmax_arr_vec <- dif_pmax(dif_pmax_arr_in, dif_pmax_arr_vec_max, 1e5)
+    },
+    dif_pmax_arr_in = dif_pmax_arr_in,
+    dif_pmax_arr_typ_max = 40.0,
+    dif_pmax_arr_int_max = 60L,
+    dif_pmax_arr_vec_max = dif_pmax_arr_vec_max,
+    expect_dif_pmax_arr_typ = pmax(dif_pmax_arr_in, 40.0),
+    expect_dif_pmax_dearr_typ = pmax(dif_pmax_arr_in * 2, 40.0),
+    expect_dif_pmax_arr_dbl = pmax(dif_pmax_arr_in, 30.0),
+    expect_dif_pmax_arr_int = pmax(dif_pmax_arr_in, 60L),
+    expect_dif_pmax_arr_vec = pmax(dif_pmax_arr_in, dif_pmax_arr_vec_max),
+    end = NULL )
+
+dif_pmin_vec_in <- runif(10, 0, 100)
+dif_pmin_vec_vec_max <- runif(10, 0, 10) * 10
+actions[['dif_pmin_vec']] <- g3_formula(
+    {
+        expect_dif_pmin_vec_typ <- dif_pmin(dif_pmin_vec_in, dif_pmin_vec_typ_max, 1e5)
+        expect_dif_pmin_vec_dbl <- dif_pmin(dif_pmin_vec_in, 30.0, 1e5)
+        expect_dif_pmin_vec_int <- dif_pmin(dif_pmin_vec_in, dif_pmin_vec_int_max, 1e5)
+        expect_dif_pmin_vec_vec <- dif_pmin(dif_pmin_vec_in, dif_pmin_vec_vec_max, 1e5)
+    },
+    dif_pmin_vec_in = dif_pmin_vec_in,
+    dif_pmin_vec_typ_max = 40.0,
+    dif_pmin_vec_int_max = 60L,
+    dif_pmin_vec_vec_max = dif_pmin_vec_vec_max,
+    expect_dif_pmin_vec_typ = pmin(dif_pmin_vec_in, 40.0),
+    expect_dif_pmin_vec_dbl = pmin(dif_pmin_vec_in, 30.0),
+    expect_dif_pmin_vec_int = pmin(dif_pmin_vec_in, 60L),
+    expect_dif_pmin_vec_vec = pmin(dif_pmin_vec_in, dif_pmin_vec_vec_max),
+    end = NULL )
+
+dif_pmin_arr_in <- array(runif(10, 0, 9), dim = c(3, 3))
+dif_pmin_arr_vec_max <- runif(3, 0, 10) * 10
+actions[['dif_pmin_arr']] <- g3_formula(
+    {
+        expect_dif_pmin_arr_typ <- dif_pmin(dif_pmin_arr_in, dif_pmin_arr_typ_max, 1e5)
+        expect_dif_pmin_arr_dbl <- dif_pmin(dif_pmin_arr_in, 30.0, 1e5)
+        expect_dif_pmin_arr_int <- dif_pmin(dif_pmin_arr_in, dif_pmin_arr_int_max, 1e5)
+        expect_dif_pmin_arr_vec <- dif_pmin(dif_pmin_arr_in, dif_pmin_arr_vec_max, 1e5)
+    },
+    dif_pmin_arr_in = dif_pmin_arr_in,
+    dif_pmin_arr_typ_max = 40.0,
+    dif_pmin_arr_int_max = 60L,
+    dif_pmin_arr_vec_max = dif_pmin_arr_vec_max,
+    expect_dif_pmin_arr_typ = pmin(dif_pmin_arr_in, 40.0),
+    expect_dif_pmin_arr_dbl = pmin(dif_pmin_arr_in, 30.0),
+    expect_dif_pmin_arr_int = pmin(dif_pmin_arr_in, 60L),
+    expect_dif_pmin_arr_vec = pmin(dif_pmin_arr_in, dif_pmin_arr_vec_max),
+    end = NULL )
+
+dif_pminmax_vec_in <- runif(10, 0, 100)
+dif_pminmax_vec_vec_l <- runif(10, 0, 50)
+dif_pminmax_vec_vec_u <- 50 + runif(10, 0, 50)
+actions[['dif_pminmax_vec']] <- g3_formula(
+    {
+        expect_dif_pminmax_vec_dbl <- dif_pminmax(dif_pminmax_vec_in, 30.0, 60.0, 1e5)
+        expect_dif_pminmax_vec_vec <- dif_pminmax(dif_pminmax_vec_in, dif_pminmax_vec_vec_l, dif_pminmax_vec_vec_u, 1e5)
+    },
+    dif_pminmax_vec_in = dif_pminmax_vec_in,
+    dif_pminmax_vec_vec_l = dif_pminmax_vec_vec_l,
+    dif_pminmax_vec_vec_u = dif_pminmax_vec_vec_u,
+    expect_dif_pminmax_vec_dbl = pmin(pmax(dif_pminmax_vec_in, 30.0), 60.0),
+    expect_dif_pminmax_vec_vec = pmin(pmax(dif_pminmax_vec_in, dif_pminmax_vec_vec_l), dif_pminmax_vec_vec_u),
+    end = NULL )
+
+###############################################################################
+
+expecteds <- new.env(parent = emptyenv())
+
+for (i in seq_along(actions)) {
+    exp_names <- grep("^expect_", names(environment(actions[[i]])), value = TRUE)
+
+    # For each expect_ variable, move to expecteds
+    for (exp_name in exp_names) {
+        expecteds[[exp_name]] <- environment(actions[[i]])[[exp_name]]
+        environment(actions[[i]])[[exp_name]][] <- 0
+    }
+
+    # REPORT every expect_
+    reports <- lapply(exp_names, function (exp_name) {
+        substitute(REPORT(sym), list(sym = as.symbol(exp_name)))
+    })
+    # Convert list to { REPORT(x) ; REPORT(y); ... }
+    reports <- as.call(c(as.symbol("{"), reports))
+
+    # Top/tail actions with a comment of their name & reports
+    actions[[i]] <- gadget3:::f_substitute(quote({
+        comment(act_name)
+        act_f
+        reports
+    }), list(
+        act_name = names(actions)[[i]],
+        act_f = actions[[i]],
+        reports = reports))
+}
+
+actions[['z']] <- g3_formula({
+    comment('done')
+    nll <- nll + g3_param('rv')
+    return(nll)
+}, nll = 0.0)
+params$rv <- 0.0
+
+model_fn <- g3_to_r(actions)
+model_cpp <- g3_to_tmb(actions)
+result <- model_fn(params)
+
+# Compare everything we've been told to compare
+for (n in ls(expecteds)) {
+    tol <- sqrt(.Machine$double.eps)
+    if (!is.null(attr(expecteds[[n]], "tol"))) {
+        tol <- attr(expecteds[[n]], "tol")
+        attr(expecteds[[n]], "tol") <- NULL
+    }
+    ok(ut_cmp_equal(
+        attr(result, n),
+        expecteds[[n]],
+        tolerance = tol ), n)
+}
+
+gadget3:::ut_tmb_r_compare2(model_fn, model_cpp, params)

--- a/tests/test-likelihood_distribution.R
+++ b/tests/test-likelihood_distribution.R
@@ -20,7 +20,6 @@ cmp_grep <- function (a, ...) {
 # NB: Name has to be different, or it gets sucked into the model
 g3_avoid_zero <- g3_env$avoid_zero
 g3_logspace_add <- g3_env$logspace_add
-g3_logspace_add_vec <- g3_env$logspace_add_vec
 g3_lgamma_vec <- lgamma
 
 ok_group("g3_distribution_preview", {
@@ -616,7 +615,7 @@ ok_group("Likelihood per step", {
         (r$step0_cdist_sumofsquares_utcd_weight_model__wgt[,2] / g3_avoid_zero(sum(r$step0_cdist_sumofsquares_utcd_weight_model__wgt[,2])) -
             r$cdist_sumofsquares_utcd_weight_obs__wgt[,1,2] / g3_avoid_zero(sum(r$cdist_sumofsquares_utcd_weight_obs__wgt[,1,2]))) ** 2,
         # multinom:
-        (2 * (-sum(r$cdist_multinomial_multinom_obs__num[,1] * log(g3_logspace_add_vec(r$step0_cdist_multinomial_multinom_model__num/g3_avoid_zero(sum(r$step0_cdist_multinomial_multinom_model__num)) *
+        (2 * (-sum(r$cdist_multinomial_multinom_obs__num[,1] * log(g3_logspace_add(r$step0_cdist_multinomial_multinom_model__num/g3_avoid_zero(sum(r$step0_cdist_multinomial_multinom_model__num)) *
             10000, (1/(length(r$cdist_multinomial_multinom_obs__num[,1]) * 10)) * 10000)/10000)) +
                 (sum(g3_lgamma_vec(1 + r$cdist_multinomial_multinom_obs__num[,1])) - lgamma(1 +
                         sum(r$cdist_multinomial_multinom_obs__num[,1]))))),
@@ -650,7 +649,7 @@ ok_group("Likelihood per step", {
         (r$step1_cdist_sumofsquares_utcd_weight_model__wgt[,2] / g3_avoid_zero(sum(r$step1_cdist_sumofsquares_utcd_weight_model__wgt[,2])) -
             r$cdist_sumofsquares_utcd_weight_obs__wgt[,2,2] / g3_avoid_zero(sum(r$cdist_sumofsquares_utcd_weight_obs__wgt[,2,2]))) ** 2,
         # multinom:
-        (2 * (-sum(r$cdist_multinomial_multinom_obs__num[,2] * log(g3_logspace_add_vec(r$step1_cdist_multinomial_multinom_model__num/g3_avoid_zero(sum(r$step1_cdist_multinomial_multinom_model__num)) *
+        (2 * (-sum(r$cdist_multinomial_multinom_obs__num[,2] * log(g3_logspace_add(r$step1_cdist_multinomial_multinom_model__num/g3_avoid_zero(sum(r$step1_cdist_multinomial_multinom_model__num)) *
             10000, (1/(length(r$cdist_multinomial_multinom_obs__num[,2]) * 10)) * 10000)/10000)) +
                 (sum(g3_lgamma_vec(1 + r$cdist_multinomial_multinom_obs__num[,2])) - lgamma(1 +
                         sum(r$cdist_multinomial_multinom_obs__num[,2]))))),
@@ -684,7 +683,7 @@ ok_group("Likelihood per step", {
         (r$step2_cdist_sumofsquares_utcd_weight_model__wgt[,2] / g3_avoid_zero(sum(r$step2_cdist_sumofsquares_utcd_weight_model__wgt[,2])) -
             r$cdist_sumofsquares_utcd_weight_obs__wgt[,3,2] / g3_avoid_zero(sum(r$cdist_sumofsquares_utcd_weight_obs__wgt[,3,2]))) ** 2,
         # multinom:
-        (2 * (-sum(r$cdist_multinomial_multinom_obs__num[,3] * log(g3_logspace_add_vec(r$step2_cdist_multinomial_multinom_model__num/g3_avoid_zero(sum(r$step2_cdist_multinomial_multinom_model__num)) *
+        (2 * (-sum(r$cdist_multinomial_multinom_obs__num[,3] * log(g3_logspace_add(r$step2_cdist_multinomial_multinom_model__num/g3_avoid_zero(sum(r$step2_cdist_multinomial_multinom_model__num)) *
             10000, (1/(length(r$cdist_multinomial_multinom_obs__num[,3]) * 10)) * 10000)/10000)) +
                 (sum(g3_lgamma_vec(1 + r$cdist_multinomial_multinom_obs__num[,3])) - lgamma(1 +
                         sum(r$cdist_multinomial_multinom_obs__num[,3]))))),
@@ -718,7 +717,7 @@ ok_group("Likelihood per step", {
         (r$step3_cdist_sumofsquares_utcd_weight_model__wgt[,2] / g3_avoid_zero(sum(r$step3_cdist_sumofsquares_utcd_weight_model__wgt[,2])) -
             r$cdist_sumofsquares_utcd_weight_obs__wgt[,4,2] / g3_avoid_zero(sum(r$cdist_sumofsquares_utcd_weight_obs__wgt[,4,2]))) ** 2,
         # multinom:
-        (2 * (-sum(r$cdist_multinomial_multinom_obs__num[,4] * log(g3_logspace_add_vec(r$step3_cdist_multinomial_multinom_model__num/g3_avoid_zero(sum(r$step3_cdist_multinomial_multinom_model__num)) *
+        (2 * (-sum(r$cdist_multinomial_multinom_obs__num[,4] * log(g3_logspace_add(r$step3_cdist_multinomial_multinom_model__num/g3_avoid_zero(sum(r$step3_cdist_multinomial_multinom_model__num)) *
             10000, (1/(length(r$cdist_multinomial_multinom_obs__num[,4]) * 10)) * 10000)/10000)) +
                 (sum(g3_lgamma_vec(1 + r$cdist_multinomial_multinom_obs__num[,4])) - lgamma(1 +
                         sum(r$cdist_multinomial_multinom_obs__num[,4]))))),
@@ -957,7 +956,7 @@ ok_group("Likelihood per year", {
         (r$step1_cdist_sumofsquares_utcd_weight_model__wgt[,2] / sum(r$step1_cdist_sumofsquares_utcd_weight_model__wgt[,2]) -
             r$cdist_sumofsquares_utcd_weight_obs__wgt[,1,2] / sum(r$cdist_sumofsquares_utcd_weight_obs__wgt[,1,2])) ** 2,
         # multinom:
-        (2 * (-sum(r$cdist_multinomial_multinom_obs__num[,1] * log(g3_logspace_add_vec(r$step1_cdist_multinomial_multinom_model__num/g3_avoid_zero(sum(r$step1_cdist_multinomial_multinom_model__num)) *
+        (2 * (-sum(r$cdist_multinomial_multinom_obs__num[,1] * log(g3_logspace_add(r$step1_cdist_multinomial_multinom_model__num/g3_avoid_zero(sum(r$step1_cdist_multinomial_multinom_model__num)) *
             10000, (1/(length(r$cdist_multinomial_multinom_obs__num[,1]) * 10)) * 10000)/10000)) +
                 (sum(g3_lgamma_vec(1 + r$cdist_multinomial_multinom_obs__num[,1])) - lgamma(1 +
                         sum(r$cdist_multinomial_multinom_obs__num[,1]))))),
@@ -992,7 +991,7 @@ ok_group("Likelihood per year", {
         (r$step3_cdist_sumofsquares_utcd_weight_model__wgt[,2] / g3_avoid_zero(sum(r$step3_cdist_sumofsquares_utcd_weight_model__wgt[,2])) -
             r$cdist_sumofsquares_utcd_weight_obs__wgt[,2,2] / g3_avoid_zero(sum(r$cdist_sumofsquares_utcd_weight_obs__wgt[,2,2]))) ** 2,
         # multinom:
-        (2 * (-sum(r$cdist_multinomial_multinom_obs__num[,2] * log(g3_logspace_add_vec(r$step3_cdist_multinomial_multinom_model__num/g3_avoid_zero(sum(r$step3_cdist_multinomial_multinom_model__num)) *
+        (2 * (-sum(r$cdist_multinomial_multinom_obs__num[,2] * log(g3_logspace_add(r$step3_cdist_multinomial_multinom_model__num/g3_avoid_zero(sum(r$step3_cdist_multinomial_multinom_model__num)) *
             10000, (1/(length(r$cdist_multinomial_multinom_obs__num[,2]) * 10)) * 10000)/10000)) +
                 (sum(g3_lgamma_vec(1 + r$cdist_multinomial_multinom_obs__num[,2])) - lgamma(1 +
                         sum(r$cdist_multinomial_multinom_obs__num[,2]))))),

--- a/vignettes/writing_actions.Rmd
+++ b/vignettes/writing_actions.Rmd
@@ -33,20 +33,14 @@ See ``R/aab_env.R`` for more information, and other existing helpers.
 ## Global & native functions
 
 Some things aren't easy to do with code translation. ``g3_native`` allows you to
-define a function with separate R and C++ definitions, for example ``logspace_add_vec``,
-used in many actions to avoid div/0, has the following definition:
+define a function with separate R and C++ definitions, for example ``normalize_vec``,
+which ensures a vector sums to 1, has the following definition:
 
 ```
-# vector<Type> form of logspace_add
-g3_env$logspace_add_vec <- g3_native(r = function(a,b) {
-    # https://github.com/kaskr/adcomp/issues/7#issuecomment-642559660
-    pmax(a, b) + log1p(exp(pmin(a,b) - pmax(a, b)))
-}, cpp = '[](vector<Type> a, Type b) -> vector<Type> {
-    vector<Type> res(a.size());
-    for(int i = 0; i < a.size(); i++) {
-        res[i] = logspace_add(a[i], b);
-    }
-    return res;
+g3_env$normalize_vec <- g3_native(r = function (a) {
+    a / sum(a)
+}, cpp = '[](vector<Type> a) -> vector<Type> {
+    return a / a.sum();
 }')
 ```
 
@@ -153,28 +147,3 @@ g3_to_r(list(g3a_naturalmortality(ling_imm, nmort())))
 As well as making values available to other steps, ``g3_global_formula``()
 can also be used to ensure that the value ends up in the model report, which will
 happen automatically for any non-constant global in the model.
-
-## g3_native
-
-There are limits to what the Gadget3 transpilation can manage, particularly
-once you need to operate on matrices. To get around this, you can define
-functions using ``g3_native``, which annotates functions with a C++ definition.
-For example, it is used to define ``logspace_add_vec``:
-
-```
-# vector<Type> form of logspace_add
-g3_env$logspace_add_vec <- g3_native(r = function(a,b) {
-    pmax(a, b) + log1p(exp(pmin(a,b) - pmax(a, b)))
-}, cpp = '[](vector<Type> a, Type b) -> vector<Type> {
-    vector<Type> res(a.size());
-
-    for(int i = 0; i < a.size(); i++) {
-        res[i] = logspace_add(a[i], b);
-    }
-
-    // NB: This is a string within R code, so we have to escape slashes.
-    //     For example, "\\n"
-
-    return res;
-}')
-```


### PR DESCRIPTION
This adds ``dif_pmax()``, which simplifies our standard ``logspace_add()`` shenanigans with C++ templates. So we don't need a combinatorial explosion of functions, depending if the inputs are scalar/vector/array.

This means ``min_weight`` in ``g3a_weightloss()`` can be vector or scalar, and the templates work out what the right thing to do is.

We also shouldn't copy arrays where possible, which should lessen memory requirements.

Now these are available, we can do a bunch of housekeeping in ``g3_env``:

* ``avoid_zero()`` becomes an alias to ``dif_pmax(x, 0, 1e3)``.
* ``logspace_minmax_vec()`` is replaced with with ``dif_pminmax()`` (we only used it once)
* Uses of ``logspace_add_vec()`` are reworked, and the function also removed
* Unrelated, ``pow_vec()`` removed, we don't need it now
* Better documentation for ``bounded()``

It's tempting to outright remove ``bounded()``, since it's a bit confusing---it made sense for bounding parameters, but in general I don't think it doesn't do what you expect.