### PR TITLE
Add g3_param_project() for both random devates & projections

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,4 +1,4 @@
-importFrom("stats", "as.formula", "formula", "dnorm", "lag")
+importFrom("stats", "as.formula", "formula", "dnorm", "rnorm", "lag")
 importFrom("utils", "capture.output", "head", "str", "tail")
 
 # R/aaa_lang.R
@@ -128,6 +128,11 @@ export(g3l_understocking)
 
 # R/params.R
 export(g3_parameterized)
+
+# R/param_project.R
+export(g3_param_project_dnorm)
+export(g3_param_project_rwalk)
+export(g3_param_project)
 
 # R/run_desc.R
 export(g3_to_desc)

--- a/R/formula_utils.R
+++ b/R/formula_utils.R
@@ -84,8 +84,11 @@ f_substitute <- function (f, env) {
                 assign(n, o[[2]], envir = env)
             }
 
-            # Only copy things the formulae mentions
-            vars_to_copy <- all.names(rlang::f_rhs(o), unique = TRUE)
+            vars_to_copy <- c(
+                # Copy anything the formula explicitly mentions
+                all.names(rlang::f_rhs(o), unique = TRUE),
+                # Anything starting with "001:" (e.g.) is assumed to be an ancillary step, which should be copied regardless
+                grep("^(?:\\d|-)\\d{2}:", names(environment(o)), value = TRUE, perl = TRUE) )
             environment_merge(combined_env, rlang::f_env(o), var_names = vars_to_copy)
         }
     }

--- a/R/param_project.R
+++ b/R/param_project.R
@@ -1,0 +1,117 @@
+g3_param_project_dnorm <- function (
+        mean_f = 0,
+        stddev_f = 1 ) {
+    # https://eigen.tuxfamily.org/dox/group__TutorialSlicingIndexing.html
+
+    # NB: Only real purpose is to cast the var to .vec()
+    g3_param_project_nll_dnorm <- g3_native(r = function (var, mean, stddev) {
+        return(dnorm(var, mean = mean, sd = stddev))
+    }, cpp = '[](array<Type> var, Type mean, Type stddev) -> vector<Type> {
+        return(dnorm(var.vec(), mean, stddev, 0));
+    }')
+    g3_param_project_dnorm <- g3_native(r = function (var, mean, stddev) {
+        var[!is.finite(var)] <- rnorm(length(var[!is.finite(var)]), mean = mean, sd = stddev)
+        return(var)
+    }, cpp = '[](array<Type> var, Type mean, Type stddev) {
+        int count = var.size() - var.isFinite().count();
+
+        vector<Type> rn = rnorm(count, mean, stddev);
+        var.tail(count) = rn;
+
+        return var;
+    }')
+
+    list(
+        name = "dnorm",
+        # NB: We don't define projstock__nll, so g3_param_project will define a g3_stock_instance()
+        nll = f_substitute(
+            ~sum(projstock__nll[] <- g3_param_project_nll_dnorm(projstock__var, mean_f, stddev_f)),
+            list(mean_f = mean_f, stddev_f = stddev_f) ),
+        project = f_substitute(
+            ~g3_param_project_dnorm(projstock__var, mean_f, stddev_f),
+            list(mean_f = mean_f, stddev_f = stddev_f) ))
+}
+
+g3_param_project_rwalk <- function (
+        mean_f = 0,
+        stddev_f = 1 ) {
+    g3_param_project_nll_rwalk <- g3_native(r = function (var, mean, stddev) {
+        d <- c(0, diff(var))
+        return(dnorm(d, mean = mean, sd = stddev))
+    }, cpp = '[](array<Type> var, Type mean, Type stddev) -> vector<Type> {
+        array<Type> d(var.size());
+        std::adjacent_difference(var.begin(), var.end(), d.begin());
+        d(0) = 0;  // NB: Starting difference should be 0, not first value
+        return(dnorm(d.vec(), mean, stddev, 0));
+    }')
+    g3_param_project_rwalk <- g3_native(r = function (var, mean, stddev) {
+        var[!is.finite(var)] <- as.vector(tail(var[is.finite(var)], 1)) +
+            cumsum(rnorm(length(var[!is.finite(var)]), mean = mean, sd = stddev))
+        return(var)
+    }, cpp = '[](array<Type> var, Type mean, Type stddev) -> array<Type> {
+        int count = var.size() - var.isFinite().count();
+
+        vector<Type> rn = rnorm(count, mean, stddev);
+        std::partial_sum(rn.begin(), rn.end(), rn.begin());
+        var.tail(count) = rn;
+
+        return var;
+    }')
+
+    list(
+        name = "rwalk",
+        # NB: We don't define projstock__nll, so g3_param_project will define a g3_stock_instance()
+        nll = f_substitute(
+            ~sum(projstock__nll[] <- g3_param_project_nll_rwalk(projstock__var, mean_f, stddev_f)),
+            list(mean_f = mean_f, stddev_f = stddev_f) ),
+        project = f_substitute(
+            ~g3_param_project_rwalk(projstock__var, mean_f, stddev_f),
+            list(mean_f = mean_f, stddev_f = stddev_f) ))
+}
+
+g3_param_project <- function (
+        param_name,
+        project_fs = g3_param_project_rwalk(),
+        # TODO: Support by_stock
+        # * Support stock_prepend(stock, stock_ss(proj__woo))
+        # * Recycle the prepending logic in g3_parameterized() to do the above
+        # * Make the g3_step() happen implicitly in the overall g3_step(), thus having stock about
+        by_step = TRUE,
+        weight = g3_parameterized(paste0(param_name, "_weight"),
+            optimise = FALSE, value = 1),
+        random = TRUE ) {
+    projstock <- g3_storage(c('proj', project_fs$name, param_name))
+    projstock <- g3s_modeltime(projstock, by_year = isFALSE(by_step))
+
+    param_tbl <- g3_parameterized(param_name, by_year = TRUE, by_step = isTRUE(by_step), random = random, ifmissing = NaN)
+    projstock__var <- g3_stock_instance(projstock, NaN, desc = paste0("Projected values for ", param_name))
+
+    out <- g3_step(f_substitute(~(
+        stock_with(projstock, stock_ss(projstock__var, vec = single))
+    ), list(
+        end = NULL )), recursing = TRUE)
+
+    # If nll formula doesn't define projstock__nll, generate a stock instance for it to use
+    if (!exists("projstock__nll", envir = environment(project_fs$nll))) {
+        environment(project_fs$nll)$projstock__nll <- g3_stock_instance(projstock, NaN, desc = paste0("nll for ", param_name, " deviants"))
+    }
+
+    environment(out)[[step_id(g3_action_order$initial, "g3a_project_param", param_name)]] <- g3_step(f_substitute(~stock_with(projstock, {
+        if (cur_time > total_steps) {
+            nll <- nll + weight * nll_f
+        } else if (cur_year_projection) {
+            if (is.nan(stock_ss(projstock__var, vec = single))) {
+                projstock__var <- project_f
+            }
+        } else {
+            stock_ss(projstock__var, vec = single) <- param_tbl
+        }
+    }), list(
+        # Add projstock_var_sym into the projection method
+        project_f = project_fs$project,
+        nll_f = project_fs$nll,
+        param_tbl = param_tbl,
+        weight = weight,
+        end = NULL )))
+    return(out)
+}

--- a/R/run_tmb.R
+++ b/R/run_tmb.R
@@ -999,7 +999,10 @@ Type objective_function<Type>::operator() () {
     }
 
     # Make sure we include TMB
-    out <- c("#include <TMB.hpp>", "", out)
+    out <- c(
+        "#include <TMB.hpp>",
+        "#include <numeric>",  # Required for std::partial_sum, std::adjacent_difference
+        "", out)
 
     class(out) <- c("g3_cpp", class(out))
 

--- a/baseline/introduction-single-stock.cpp
+++ b/baseline/introduction-single-stock.cpp
@@ -1,4 +1,5 @@
 #include <TMB.hpp>
+#include <numeric>
 
 namespace map_extras {
     // at(), but throw (err) if item isn't available

--- a/baseline/multiple-substocks.cpp
+++ b/baseline/multiple-substocks.cpp
@@ -1,4 +1,5 @@
 #include <TMB.hpp>
+#include <numeric>
 
 namespace map_extras {
     // at(), but throw (err) if item isn't available

--- a/inttest/codegeneration-defaults/model.cpp
+++ b/inttest/codegeneration-defaults/model.cpp
@@ -1,4 +1,5 @@
 #include <TMB.hpp>
+#include <numeric>
 
 namespace map_extras {
     // at(), but throw (err) if item isn't available

--- a/inttest/codegeneration/ling.cpp
+++ b/inttest/codegeneration/ling.cpp
@@ -1,4 +1,5 @@
 #include <TMB.hpp>
+#include <numeric>
 
 namespace map_extras {
     // at(), but throw (err) if item isn't available

--- a/man/param_project.Rd
+++ b/man/param_project.Rd
@@ -1,0 +1,165 @@
+\name{param_project}
+\alias{g3_param_project_dnorm}
+\alias{g3_param_project_rwalk}
+\alias{g3_param_project}
+\concept{G3 utilities}
+
+\title{Gadget3 projected parameters}
+\description{
+  Add time-based random deviates / projections
+}
+
+\usage{
+g3_param_project_dnorm(
+        # TODO: Parameterized defaults?
+        mean_f = 0,
+        stddev_f = 1 )
+
+g3_param_project_rwalk(
+        mean_f = 0,
+        stddev_f = 1 )
+
+g3_param_project(
+        param_name,
+        project_fs = g3_param_project_rwalk(),
+        by_step = TRUE,
+        weight = g3_parameterized(paste0(param_name, "_weight"),
+            optimise = FALSE, value = 1),
+        random = TRUE )
+}
+
+\arguments{
+  \item{mean_f, stddev_f}{
+    mean / stddev used for both the likelihood of deviates & to project future values.
+  }
+  \item{param_name}{
+    Character string used to name the parameters.
+  }
+  \item{project_fs}{
+    Results of either \code{\link{g3_param_project_dnorm}}, \code{\link{g3_param_project_rwalk}}.
+  }
+  \item{by_step}{
+    Boolean, generate per-step or per-year values.
+  }
+  \item{weight}{
+    A weighting to give to the likelhood when generating total nll.
+  }
+  \item{random}{
+    Boolean, tell TMB to treat the deviates as random variables by default. Can be changed in the parameter template.
+  }
+}
+
+\details{
+  The actions will define the following variables in your model, which could be reported with \code{\link{g3a_report_history}}:
+  \describe{
+    \item{proj_(dnorm|rwalk)_(param_name)__var}{Vector of all values, both parameters & projected, by time}
+    \item{proj_(dnorm|rwalk)_(param_name)__nll}{Likelihood of each value}
+  }
+}
+
+\seealso{
+  \code{\link{g3a_time}}
+  \code{\link{g3_parameterized}}
+}
+
+\value{
+  \subsection{g3_param_project_dnorm}{
+    Returns a "nll" & "project" \link{formula} objects for use as \var{project_fs}.
+
+    The parameter will describe deviates around a mean.
+
+    \describe{
+      \item{nll}{Compare values against \code{dnorm(x, mean_f, stddev_f)}}
+      \item{proj}{Generate new values with \code{rnorm(mean_f, stddev_f)}}
+    }
+  }
+
+  \subsection{g3_param_project_rwalk}{
+    Returns a "nll" & "project" \link{formula} objects for use as \var{project_fs}.
+
+    The parameter will describe a random walk.
+
+    \describe{
+      \item{nll}{Compare difference between values \code{dnorm(x, mean_f, stddev_f)}}
+      \item{proj}{Generate new values with a delta of \code{rnorm(mean_f, stddev_f)}}
+    }
+  }
+  
+  \subsection{g3_param_project}{
+    Returns a \link{formula} to choose the current value from the \code{__var} vector.
+
+    An extra G3 action will:
+    \enumerate{
+      \item{Populate the array with random deviates from parameters (see examples)}
+      \item{Project for any projection years (see \code{\link{g3a_time}})}
+      \item{Add likelihood comparing random deviates to expected values}
+    }
+  }
+
+  \subsection{g3l_sparsesample_sumsquares}{
+    Returns a \link{formula} for use as \var{function_f}:
+
+    \deqn{
+      \sum_{\it i}^{rows} w (\frac{\nu_{i}}{P_{i}} - N_{i})^2
+    }
+    \describe{
+      \item{\eqn{N_{i}}}{"mean" column from \var{obs_df}}
+      \item{\eqn{\nu_{i}}}{Total predicted values, i.e. \var{nll_spabund_name__model_sum}}
+      \item{\eqn{P_{i}}}{Number of data points, i.e. \var{nll_spabund_name__model_n}}
+      \item{\eqn{w}}{\var{weighting} parameter, either:\enumerate{
+        \item{\eqn{1 / \sigma^2}, using stddev of model predicted values if \code{weighting = "model_stddev"}}
+        \item{\eqn{1 / \sigma^2}, using stddev column from \var{obs_df} if \code{weighting = "obs_stddev"}}
+        \item{A custom forumla provided for \var{weighting}}
+      }}
+    }
+  }
+}
+
+\examples{
+st <- g3_stock("fish", c(10, 20, 30))
+
+actions <- list(
+    g3a_time(1990, 1994, c(6,6)),
+    g3a_initialconditions(st,
+        quote( 100 + stock__minlen ),
+        quote( 1e4 + 0 * stock__minlen ) ),
+
+    # Natural mortality with per-year random walk
+    g3a_naturalmortality(st, g3a_naturalmortality_exp(
+        g3_param_project("Mrw", g3_param_project_rwalk(
+          mean_f = 0,
+          stddev_f = 0.001 ), by_step = FALSE ))),
+
+    # Natural mortality with per-step deviates
+    g3a_naturalmortality(st, g3a_naturalmortality_exp(
+        g3_param_project("Mdn", g3_param_project_dnorm(
+          mean_f = g3_parameterized("Mdn_mean", value = 0.1, optimise = FALSE),
+          stddev_f = g3_parameterized("Mdn_sd", value = 0.001, optimise = FALSE) )))),
+    NULL )
+
+model_fn <- g3_to_r(c(actions, list(
+    g3a_report_history(actions, 'proj_.*', out_prefix = NULL),
+    NULL )))
+
+# Mdn has a parameter for each year/step, as well as mean/sd (added above) & likelihood weighting
+grep("^Mdn", names(attr(model_fn, 'parameter_template')), value = TRUE)
+
+# Mrw has parameters for each year
+grep("^Mrw", names(attr(model_fn, 'parameter_template')), value = TRUE)
+
+attr(model_fn, 'parameter_template') |>
+    # Fill in initial values for each
+    g3_init_val("Mdn.#.#", 0.5, lower = 0.1, upper = 0.9, random = TRUE) |>
+    g3_init_val("Mrw.#", 0.5, lower = 0.1, upper = 0.9, random = TRUE) |>
+    # Project forwards 20 years
+    g3_init_val("project_years", 20) |>
+    identity() -> params
+r <- attributes(model_fn(params))
+
+# Values used for dnorm
+plot(r$proj_dnorm_Mdn__var)
+
+# Values used for random walk
+plot(r$proj_rwalk_Mrw__var)
+
+}

--- a/tests/test-param_project.R
+++ b/tests/test-param_project.R
@@ -1,0 +1,97 @@
+if (!interactive()) options(warn=2, error = function() { sink(stderr()) ; traceback(3) ; q(status = 1) })
+library(unittest)
+
+library(gadget3)
+
+st <- g3_stock(c("stst"), c(10, 20, 30))
+fl <- g3_fleet(c("fl", "surv"))
+
+actions <- list(
+    g3a_time(1990, 1994, c(6,6)),
+    g3a_initialconditions(st,
+        quote( 100 + stock__minlen ),
+        quote( 1e4 + 0 * stock__minlen ) ),
+    g3a_naturalmortality(st, g3a_naturalmortality_exp(g3_param_project(
+        "Mrw",
+        g3_param_project_rwalk(mean_f = g3_parameterized("Mrw_mean", value = 0.001), stddev_f = 0.001) ))),
+    g3a_naturalmortality(st, g3a_naturalmortality_exp(g3_param_project(
+        "Mdn",
+        g3_param_project_dnorm(mean_f = g3_parameterized("Mdn_mean", value = 0.1), stddev_f = 0.001) ))),
+    # NB: Dummy parameter so model will compile in TMB
+    quote( nll <- nll + g3_param("x", value = 0) ) )
+full_actions <- c(actions, list(
+    g3a_report_detail(actions),
+    g3a_report_history(actions, 'proj_.*', out_prefix = NULL),
+    NULL))
+model_fn <- g3_to_r(full_actions)
+model_cpp <- g3_to_tmb(full_actions)
+
+ok_group("project_years=0") ###################################################
+
+attr(model_fn, 'parameter_template') |>
+    g3_init_val("Mrw_mean", runif(1, 0.001, 0.1)) |>
+    g3_init_val("Mdn_mean", runif(1, 0.001, 0.1)) |>
+    g3_init_val("Mrw.#.#", rnorm(5 * 2, 0.2, 0.001)) |>
+    g3_init_val("Mdn.#.#", rnorm(5 * 2, 0.5, 0.001)) |>
+    g3_init_val("project_years", 0) |>
+    identity() -> params
+nll <- model_fn(params) ; r <- attributes(nll) ; nll <- as.vector(nll)
+
+ok(ut_cmp_equal(signif(mean(r$proj_rwalk_Mrw__var), 1), 0.2), "mean(r$proj_dnorm_Mrw__var): Same as param input")
+ok(ut_cmp_equal(signif(mean(r$proj_dnorm_Mdn__var), 1), 0.5), "mean(r$proj_dnorm_Mdn__var): Same as param input")
+
+ok(ut_cmp_equal(
+    as.vector(r$proj_rwalk_Mrw__nll),
+    as.vector(dnorm(c("1990-01" = 0, diff(r$proj_dnorm_Mdn__var)), mean = params$Mrw_mean, sd = 0.1)),
+    tolerance = 1e8 ), "r$proj_rwalk_Mrw__nll: dnorm of __var")
+ok(ut_cmp_equal(
+    as.vector(r$proj_dnorm_Mdn__nll),
+    as.vector(dnorm(r$proj_dnorm_Mdn__var, mean = params$Mdn_mean, sd = 0.1)),
+    tolerance = 1e7 ), "r$proj_dnorm_Mdn__nll: dnorm of __var")
+
+gadget3:::ut_tmb_r_compare2(model_fn, model_cpp, params)
+
+ok_group("project_years=20") ##################################################
+
+attr(model_fn, 'parameter_template') |>
+    g3_init_val("Mrw_mean", runif(1, 0.001, 0.1)) |>
+    g3_init_val("Mdn_mean", runif(1, 0.001, 0.1)) |>
+    g3_init_val("Mrw.#.#", rnorm(5 * 2, 0.2, 0.001)) |>
+    g3_init_val("Mdn.#.#", rnorm(5 * 2, 0.5, 0.001)) |>
+    g3_init_val("project_years", 20) |>
+    identity() -> params
+
+# NB: Projections mean values between runs shouldn't match, so build list of values & compare all
+rs <- list(
+    attributes(model_fn(params)),
+    attributes(model_fn(params)),
+    attributes(model_fn(params)) )
+if (nzchar(Sys.getenv("G3_TEST_TMB"))) {
+    param_template <- attr(model_cpp, "parameter_template")
+    param_template$value[names(params)] <- params
+    model_tmb <- g3_tmb_adfun(model_cpp, param_template, compile_flags = c("-O0", "-g"))
+    rs <- c(rs, list(
+        model_tmb$report(),
+        model_tmb$report(),
+        model_tmb$report() ))
+}
+
+for (r in rs) {
+    ok(ut_cmp_equal(
+        length(r$proj_rwalk_Mrw__var),
+        5 * 2 + params$project_years * 2 ), "length(r$proj_rwalk_Mrw__var): 5 normal years, 20 projection years, 2 steps for each")
+
+    ok(ut_cmp_equal(signif(mean(head(r$proj_rwalk_Mrw__var, 5*2)), 1), 0.2), "mean(r$proj_rwalk_Mrw__var): Same as param input, for first 10")
+    ok(ut_cmp_equal(signif(mean(head(r$proj_dnorm_Mdn__var, 5*2)), 1), 0.5), "mean(r$proj_dnorm_Mdn__var): Same as param input, for first 10")
+
+    ok(ut_cmp_equal(
+        mean(tail(r$proj_dnorm_Mdn__var, -5*2)),
+        params$Mdn_mean,
+        tolerance = 1e4), "mean(r$proj_dnorm_Mdn__var): Projected values have a mean ~matching Mdn_mean")
+    ok(sd(tail(r$proj_dnorm_Mdn__var, -5*2)) > 0, "sd(r$proj_dnorm_Mdn__var): sd greater than 0 (values not equal)")
+    ok(ut_cmp_equal(
+        mean(diff(c(0, tail(r$proj_rwalk_Mrw__var, -5*2)))),
+        params$Mrw_mean,
+        tolerance = 1e4), "mean(r$proj_rwalk_Mrw__var): Projected values have a mean delta ~matching Mrw_mean")
+    ok(sd(tail(r$proj_rwalk_Mrw__var, -5*2)) > 0, "sd(r$proj_rwalk_Mrw__var): sd greater than 0 (values not equal)")
+}

--- a/tests/test-run.R
+++ b/tests/test-run.R
@@ -62,4 +62,21 @@ ok(gadget3:::ut_cmp_code(out, quote({
         "fu2"
 }), model_body = TRUE), "g3_to_r: unnamed at end, later beat former, NULLs removed, code included")
 
+st_imm <- g3_stock(c("st", "imm"), 1:10)
+out <- g3_to_r(list(
+    g3a_naturalmortality(
+        st_imm,
+        g3_formula(
+            parrot,
+            parrot = 0,
+            "-01:ut:parrot" = g3_formula(parrot <- runif(1)),
+            "999:ut:parrot" = g3_formula(parrot <- parrot + 1) )),
+    NULL ))
+ok(gadget3:::ut_cmp_code(out, quote({
+    parrot <- runif(1)
+    comment("Natural mortality for st_imm")
+    st_imm__num[] <- st_imm__num[] * parrot
+    parrot <- parrot + 1
+}), optimize = TRUE, model_body = TRUE), "Ancillary steps passed through action, in model in appropriate order")
+
 ########## g3_collate

--- a/vignettes/writing_actions.Rmd
+++ b/vignettes/writing_actions.Rmd
@@ -147,3 +147,25 @@ g3_to_r(list(g3a_naturalmortality(ling_imm, nmort())))
 As well as making values available to other steps, ``g3_global_formula``()
 can also be used to ensure that the value ends up in the model report, which will
 happen automatically for any non-constant global in the model.
+
+## Ancillary steps
+
+Additional steps can be attached to a formula, allowing setup for a variable at the beginning of a model,
+or implicit likelihood components. For example:
+
+```{r}
+st_imm <- g3_stock(c("st", "imm"), 1:10)
+g3_to_r(list(
+    g3a_naturalmortality(
+        st_imm,
+        g3_formula(
+            parrot**2,
+            parrot = 0,
+            "-01:ut:parrot" = g3_formula({
+                parrot <- runif(1)
+            }))),
+    NULL ))
+```
+
+The attached step gets inserted at the beginning of the model,
+and a new random number is chosen for ``parrot`` at each model timestep.


### PR DESCRIPTION
Right, I think this is ready now. [The final commit](https://github.com/gadget-framework/gadget3/commit/ab02cac51ed9767a3e71f6f9460dfa10ae78c903) is the interesting one.

The most interesting bit to look at is [the documentation, which shows how to use it](https://github.com/gadget-framework/gadget3/commit/ab02cac51ed9767a3e71f6f9460dfa10ae78c903#diff-c1a82b3d069914aaf9b3a26a145b0ed3a74a6cf4d4509909206bb4ee52671695)

But essentially you fill a gap for a formula with ``g3_param_project()`` and you get per-step/per-year parameters, a likelihood component & projections based around the same parameters the likelhood component uses:

```r
    g3a_naturalmortality(st, g3a_naturalmortality_exp(
        g3_param_project("Mdn", g3_param_project_dnorm(
          mean_f = g3_parameterized("Mdn_mean", value = 0.1, optimise = FALSE),
          stddev_f = g3_parameterized("Mdn_sd", value = 0.001, optimise = FALSE) )))),
    NULL )
```

The main thing that's irritating me is there's no ``by_stock`` option. I've not thought of a non-painful way of doing it, so not added it for now, but it's an obvious thing to want.

We should probably have parametrised defaults for mean/stddev as above. Naming these is also marginally tricky, but not the end of the world.

@bthe any thoughts?

Fixes #181