### PR TITLE
R models should support data.frames

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,10 +42,10 @@ serve-docs:
 	Rscript -e "options(pkgdown.internet = FALSE) ; pkgdown::build_site(override=list(url='http://localhost:8000/')) ; servr::httd(dir='docs', host='0.0.0.0', port='8000')"
 
 test: install
-	for f in tests/test*.R; do echo "=== $$f ============="; Rscript $$f || exit 1; done
+	parallel -j 8 --halt now,fail=1 Rscript ::: tests/test*.R
 
 inttest: install
-	for f in inttest/*/run.R; do echo "=== $$f ============="; Rscript $$f || exit 1; done
+	parallel -j 8 --halt now,fail=1 Rscript ::: inttest/*/run.R
 	make vignettes G3_TEST_TMB=1
 
 coverage:

--- a/R/action_predate.R
+++ b/R/action_predate.R
@@ -84,7 +84,7 @@ g3a_predate_catchability_quotafleet <- function (quota_table, E, sum_stocks = li
     }
 
     out <- list(
-        suit_unit = "energy content",
+        suit_unit = "total biomass",
         suit = quote( suit_f * stock_ss(stock__num) * stock_ss(stock__wgt) ),
         cons = f_substitute(
             ~quota_f * E * cur_step_size * stock_ss(predprey__suit),

--- a/R/formula_utils.R
+++ b/R/formula_utils.R
@@ -217,6 +217,21 @@ f_chain_conditional <- function (fs, default_f = NaN, ...) {
     f_substitute(out, fs)
 }
 
+# Combine list of formulas with an operator, e.g. f_chain_op(list(~a, ~b, ~c), "+") ---> ~a + b + c
+f_chain_op <- function (fs, op) {
+    # Assign names to list we can use as symbols
+    names(fs) <- paste0("f", seq_along(fs))
+
+    # Build code to do sum, based list names
+    sum_c <- NULL
+    for (i in seq_along(fs)) {
+        sym <- as.symbol(names(fs)[[i]])
+        sum_c <- if (i == 1) sym else call(op, sum_c, sym)
+    }
+
+    return(f_substitute(sum_c, fs))
+}
+
 # Perform optimizations on code within formulae, mostly for readability
 f_optimize <- function (f) {
     # Simplify Basic arithmetic

--- a/R/params.R
+++ b/R/params.R
@@ -132,7 +132,12 @@ g3_parameterized <- function(
         for (i in seq_along(by_stock)) if (i > 1) {
             common_part <- common_part & (by_stock[[1]]$name_parts == by_stock[[i]]$name_parts)
         }
-        stock_extra <- paste(by_stock[[1]]$name_parts[common_part], collapse = ".")
+        if (any(common_part)) {
+            stock_extra <- paste(by_stock[[1]]$name_parts[common_part], collapse = ".")
+        } else {
+            # No common parts, concatenate full names of both
+            stock_extra <- paste(sort(vapply(by_stock, function (s) s$name, character(1))), collapse = ".")
+        }
     } else stop('Unknown by_stock parameter, should be FALSE, TRUE, a name_part or list of stocks')
 
     if (isTRUE(by_area) && (isTRUE(by_stock) || is.character(by_stock))) {

--- a/R/params.R
+++ b/R/params.R
@@ -32,6 +32,7 @@ g3_parameterized <- function(
         avoid_zero = FALSE,
         scale = 1,
         offset = 0,
+        ifmissing = NULL,
         ...) {
     stopifnot(is.character(name))
     stopifnot(is.logical(by_age))
@@ -39,6 +40,7 @@ g3_parameterized <- function(
     stopifnot(is.logical(by_step))
     stopifnot(is.logical(by_area))
     stopifnot(is.logical(avoid_zero))
+    extra_params <- list(...)
 
     find_public_call <- function (calls) {
         for (in_c in rev(calls)) {
@@ -158,8 +160,14 @@ g3_parameterized <- function(
         out <- substitute(g3_param(x), list(x = name))
     }
 
+    # Add ifmissing to output, turning strings into parameters
+    if (!is.null(ifmissing)) {
+        if (is.character(ifmissing)) ifmissing <- g3_parameterized(ifmissing, by_stock = by_stock)
+        out$ifmissing <- ifmissing
+    }
+
     # Pass through standard g3_param arguments
-    out <- as.call(c(as.list(out), list(...)))
+    out <- as.call(c(as.list(out), extra_params))
 
     # Add source if we found one
     source <- find_public_call(sys.calls())

--- a/R/run_r.R
+++ b/R/run_r.R
@@ -202,6 +202,8 @@ g3_to_r <- function(
     # Wrap all steps in a function call
     out <- call("function", pairlist(param = quote( attr(get(sys.call()[[1]]), "parameter_template") )), as.call(c(
         list(as.symbol(open_curly_bracket)),
+        # Prefix with df -> list converstion, if needed
+        list(quote( if (is.data.frame(param)) param <- structure(param$value, names = param$switch) )),
         scope,
         all_actions_code )))
 

--- a/R/step.R
+++ b/R/step.R
@@ -502,10 +502,14 @@ list_to_stock_switch <- function(l, stock_var = "stock") {
         l <- l[[1]]
     }
     if (!is.list(l)) {
+        if (!is.call(l)) {
+            # Input isn't code, so no point wrapping with stock_with()
+            return(f_substitute(quote(x), list(x = l)))
+        }
         # Choosing one item is just stock_with()
         return(f_substitute(quote(
-            stock_with(stock_var, l)
-        ), list(stock_var = stock_var, l = l)))
+            stock_with(stock_var_sym, l)
+        ), list(stock_var_sym = as.symbol(stock_var), l = l)))
     }
 
     # NB: Substituting "" doesn't work, so we turn the non-named

--- a/R/test_utils.R
+++ b/R/test_utils.R
@@ -54,15 +54,20 @@ ut_tmb_r_compare2 <- function (
         return()
     }
 
-    # Splice R parameters into parameter_template
-    param_template <- attr(model_cpp, 'parameter_template')
-    param_template$value[names(params)] <- params
+    if (is.data.frame(params)) {
+        # Input params is already a parameter template
+        param_template <- params
+    } else {
+        # Splice R parameters into parameter_template
+        param_template <- attr(model_cpp, 'parameter_template')
+        param_template$value[names(params)] <- params
+    }
 
     # writeLines(TMB::gdbsource(g3_tmb_adfun(model_cpp, compile_flags = c("-O0", "-g"), output_script = TRUE)))
     model_tmb <- g3_tmb_adfun(model_cpp, param_template, compile_flags = c("-O0", "-g"))
 
     model_tmb_report <- model_tmb$report()
-    r_result <- model_fn(params)
+    r_result <- model_fn(param_template)
 
     for (n in names(attributes(r_result))) {
         unittest::ok(unittest::ut_cmp_equal(

--- a/inttest/codegeneration-defaults/model.R
+++ b/inttest/codegeneration-defaults/model.R
@@ -1,5 +1,14 @@
 structure(function (param = attr(get(sys.call()[[1]]), "parameter_template")) 
 {
+    if (is.data.frame(param)) {
+        param_lower <- structure(param$lower, names = param$switch)
+        param_upper <- structure(param$upper, names = param$switch)
+        param <- structure(param$value, names = param$switch)
+    }
+    else {
+        param_lower <- lapply(param, function(x) NA)
+        param_upper <- lapply(param, function(x) NA)
+    }
     stopifnot("retro_years" %in% names(param))
     stopifnot("fish.Linf" %in% names(param))
     stopifnot("fish.K" %in% names(param))

--- a/inttest/codegeneration/ling.R
+++ b/inttest/codegeneration/ling.R
@@ -1,5 +1,14 @@
 structure(function (param = attr(get(sys.call()[[1]]), "parameter_template")) 
 {
+    if (is.data.frame(param)) {
+        param_lower <- structure(param$lower, names = param$switch)
+        param_upper <- structure(param$upper, names = param$switch)
+        param <- structure(param$value, names = param$switch)
+    }
+    else {
+        param_lower <- lapply(param, function(x) NA)
+        param_upper <- lapply(param, function(x) NA)
+    }
     stopifnot("retro_years" %in% names(param))
     stopifnot("ling.Linf" %in% names(param))
     stopifnot("ling.K" %in% names(param))

--- a/man/params.Rd
+++ b/man/params.Rd
@@ -20,6 +20,7 @@ g3_parameterized(
         avoid_zero = FALSE,
         scale = 1,
         offset = 0,
+        ifmissing = NULL,
         ...)
 }
 
@@ -73,6 +74,11 @@ g3_parameterized(
       \item{FALSE}{No}
       \item{TRUE}{Produce a \code{"name.area"} parameter for each area of the stock(s) in \var{by_stock}}
     }
+  }
+  \item{ifmissing}{
+    Value to use for when there is no valid parameter (read: year when by_year = TRUE)
+    Either a numeric constant or character.
+    If character, add another parameter for ifmissing, using the same \var{by_stock} value.
   }
   \item{exponentiate}{Use \code{exp(value)} instead of the raw parameter value. Will add "_exp" to the parameter name.}
   \item{avoid_zero}{If TRUE, wrap parameter with \code{avoid_zero}}

--- a/man/params.Rd
+++ b/man/params.Rd
@@ -144,6 +144,11 @@ param_template_for( g3_parameterized('K', by_stock = 'species', by_year = TRUE) 
 param_template_for( g3_parameterized('K', by_stock = list(stock_imm, stock_mat)) )
 param_template_for( g3_parameterized('K', by_stock = list(stock_imm, stock_mat), by_age = TRUE) )
 
+# If there are no shared name parts, then all names will be added
+param_template_for( g3_parameterized(
+    'btrigger',
+    by_stock = list(g3_fleet("surv"), g3_fleet("comm"))) )
+
 # You can set fixed scale/offset for the parameter
 g3_parameterized('K', scale = 5, offset = 9)
 

--- a/man/run_r.Rd
+++ b/man/run_r.Rd
@@ -51,8 +51,15 @@ g3_to_r(
 }
 
 \value{
-  A function that takes a \var{params} variable, that defines all \var{g3_param}s required by the model.
-  The following attributes will be set:
+  A function that takes a \var{params} variable, which can be:
+
+  \enumerate{
+    \item{A list of parameters as defined by \code{attr(fn, 'parameter_template')}}
+    \item{A data.frame of parameters defined by \code{\link{g3_to_tmb}}'s parameter template}
+    \item{Not provided, in which case the parameter defaults are used}
+  }
+
+  The function will have the following attributes:
   \describe{
     \item{actions}{The original \var{actions} list given to the function}
     \item{parameter_template}{A list of all parameters expected by the model, to fill in}

--- a/tests/test-formula_utils.R
+++ b/tests/test-formula_utils.R
@@ -192,6 +192,17 @@ ok(gadget3:::ut_cmp_code(out_f, quote({
 ok(ut_cmp_identical(as.list(environment(out_f)), list(
     y = 9 )), "f_concatenate: code has no effect on environment")
 
+out_f <- gadget3:::f_chain_op(list(
+    quote(2),
+    3,
+    g3_formula(x**2, x = 99),
+    g3_formula(1 + a + 3, a = 2, z = 123),
+    101 ), "+")
+ok(gadget3:::ut_cmp_code(out_f, quote(2 + 3 + (x^2) + (1 + a + 3) + 101)), "f_chain_op: Can use calls, formulas, constants. Precedence correct")
+ok(ut_cmp_identical(as.list(environment(out_f), sorted = TRUE), list(
+    a = 2,
+    x = 99)), "f_chain_op: Relevant parts of environment copied")
+
 ok(gadget3:::ut_cmp_code(
     gadget3:::f_optimize(~{woo; oink; baa}),
     ~{woo; oink; baa}), "f_optimize: Passed through 3 terms")

--- a/tests/test-formula_utils.R
+++ b/tests/test-formula_utils.R
@@ -24,6 +24,12 @@ cmp_environment <- function (a, b) {
     ut_cmp_identical(ordered_list(a), ordered_list(b))
 }
 
+model_body <- function(...) {
+    out_c <- body(suppressWarnings(g3_to_r(list(...))))
+    out_c[[2]] <- NULL  # Remove data.frame -> list munging
+    return(out_c)
+}
+
 deep_ls <- function (env) {
     if (environmentName(env) == "R_EmptyEnv") {
         c()
@@ -353,7 +359,7 @@ out <- adf(g3_formula(
         mean = g3_formula(block1 + offset, offset = g3_formula(block1)),
         stddev = g3_formula(block2 + offset, offset = g3_formula(block1)) )))
 ok(gadget3:::ut_cmp_code(
-    body(g3_to_r(list(g3_formula(quote(9), block1 = 1, block2 = 2), out))), quote({
+    model_body(g3_formula(quote(9), block1 = 1, block2 = 2), out), quote({
         block1 <- 1
         block2 <- 2
         while (TRUE) {
@@ -374,7 +380,7 @@ out <- adf(g3_formula(
     glob1 = g3_global_formula(g3_formula(block1 + glob2)),
     end = NULL))
 ok(gadget3:::ut_cmp_code(
-    body(g3_to_r(list(g3_formula(quote(9), block1 = 1, block2 = 2), out))), quote({
+    model_body(g3_formula(quote(9), block1 = 1, block2 = 2), out), quote({
          block2 <- 2
          block1 <- 1
          while (TRUE) {
@@ -390,7 +396,7 @@ out <- adf(g3_formula(
     f1 = g3_formula(f2 + f3, f2 = quote(block1 + 2), f3 = 4),
     end = NULL))
 ok(gadget3:::ut_cmp_code(
-    body(g3_to_r(list(g3_formula(quote(9), block1 = 1, block2 = 2), out))), quote({
+    model_body(g3_formula(quote(9), block1 = 1, block2 = 2), out), quote({
         block1 <- 1
         f3 <- 4
         while (TRUE) {
@@ -405,7 +411,7 @@ out <- adf(g3_formula(
     10 + f1,
     f1 = g3_formula(f2 + f3, f2 = quote(secret_block + 2), f3 = 4),
     end = NULL) )
-ok(gadget3:::ut_cmp_code(body(suppressWarnings(g3_to_r(list(g3_formula(quote(9), block1 = 1, block2 = 2), out)))), quote({
+ok(gadget3:::ut_cmp_code(model_body(g3_formula(quote(9), block1 = 1, block2 = 2), out), quote({
     secret_block <- stop("Incomplete model: No definition for ",
         "secret_block")
     f2 <- secret_block + 2
@@ -420,7 +426,7 @@ out <- adf(g3_formula(
     10 + f1,
     f1 = g3_formula(f2 + f3, f2 = quote(secret_block + 2), f3 = 4),
     end = NULL), filter_fn = function (f) gadget3:::call_replace(f, secret_block = function (y) quote(block1)) )
-ok(gadget3:::ut_cmp_code(body(g3_to_r(list(g3_formula(quote(9), block1 = 1, block2 = 2), out))), quote({
+ok(gadget3:::ut_cmp_code(model_body(g3_formula(quote(9), block1 = 1, block2 = 2), out), quote({
     block1 <- 1
     f3 <- 4
     while (TRUE) {
@@ -437,7 +443,7 @@ out <- adf(g3_formula(
     10 + f1,
     f1 = g3_formula(f2 + 1, f2 = g3_formula(f3 + 2, f3 = g3_formula(secret_block))),
     end = NULL) )
-ok(gadget3:::ut_cmp_code(body(suppressWarnings(g3_to_r(list(g3_formula(quote(9), block1 = 1, block2 = 2), out)))), quote({
+ok(gadget3:::ut_cmp_code(model_body(g3_formula(quote(9), block1 = 1, block2 = 2), out), quote({
     secret_block <- stop("Incomplete model: No definition for ",
         "secret_block")
     f3 <- secret_block
@@ -452,7 +458,7 @@ out <- adf(g3_formula(
     10 + f1,
     f1 = g3_formula(f2 + 1, f2 = g3_formula(f3 + 2, f3 = g3_formula(secret_block))),
     end = NULL), filter_fn = function (f) gadget3:::call_replace(f, secret_block = function (y) quote(block1)) )
-ok(gadget3:::ut_cmp_code(body(g3_to_r(list(g3_formula(quote(9), block1 = 1, block2 = 2), out))), quote({
+ok(gadget3:::ut_cmp_code(model_body(g3_formula(quote(9), block1 = 1, block2 = 2), out), quote({
     block1 <- 1
     while (TRUE) {
         9

--- a/tests/test-params.R
+++ b/tests/test-params.R
@@ -100,15 +100,27 @@ ok(cmp_code(
 
 ok(cmp_code(
     call("{",  # }
+        g3_parameterized('byst', by_stock = TRUE, ifmissing = "def.byst"),
+        g3_parameterized('nby', by_stock = FALSE, ifmissing = "def.nby"),
+        g3_parameterized('parp', by_year = TRUE, ifmissing = g3_parameterized('peep')),
+    NULL), quote({
+        stock_prepend(stock, g3_param(
+            "byst",
+            ifmissing = stock_prepend(stock, g3_param("def.byst"), name_part = NULL)
+        ), name_part = NULL)
+        g3_param("nby", ifmissing = g3_param("def.nby"))
+        g3_param_table("parp", expand.grid(cur_year = seq(start_year, end_year)), ifmissing = g3_param("peep"))
+    NULL})), "ifmissing can be character (and gets assigned a parameter)")
+
+ok(cmp_code(
+    call("{",  # }
         g3_parameterized('parp', by_stock = FALSE, value = 4, lower = 2, upper = 9),
         g3_parameterized('parp', by_stock = FALSE, optimise = FALSE),
         g3_parameterized('parp', by_stock = FALSE, random = TRUE),
-        g3_parameterized('parp', by_year = TRUE, ifmissing = g3_parameterized('peep')),
     NULL), quote({
         g3_param("parp", value = 4, lower = 2, upper = 9)
         g3_param("parp", optimise = FALSE)
         g3_param("parp", random = TRUE)
-        g3_param_table("parp", expand.grid(cur_year = seq(start_year, end_year)), ifmissing = g3_param("peep"))
     NULL})), "Extra parameters passed through")
 
 ok(cmp_code(

--- a/tests/test-params.R
+++ b/tests/test-params.R
@@ -162,11 +162,14 @@ ok(cmp_code(
         g3_parameterized('parp', by_stock = list(stock_mimm, stock_mmat)),
         g3_parameterized('parp', by_stock = list(stock_mimm, stock_fmat)),  # M vs F, so only species matches
         g3_parameterized('parp', by_stock = list(stock_fimm, stock_fmat), by_age = TRUE),
+        # No common parts, so concatenate everything after sorting
+        g3_parameterized('nocommon', by_stock = list(g3_stock(c("zz", "b"), 1), g3_stock(c("c", "d"), 1))),
     NULL), quote({
         stock_prepend("st.m", g3_param("parp"))
         stock_prepend("st", g3_param("parp"))
         stock_prepend("st.f", g3_param_table("parp", expand.grid(
             age = seq(min(st_f_imm__minage, st_f_mat__minage), max(st_f_imm__maxage, st_f_mat__maxage))))) + 0 * age
+        stock_prepend("c_d.zz_b", g3_param("nocommon"))
     NULL})), "Can give a list of stocks, in which case it works out name parts for you")
 
 ok(cmp_code(

--- a/tests/test-run_r.R
+++ b/tests/test-run_r.R
@@ -35,8 +35,15 @@ ok_group('print.g3_r', {
     ok(ut_cmp_identical(cap(print(model_fn)), c(
         "function (param = attr(get(sys.call()[[1]]), \"parameter_template\")) ",
         "{",
-        "    if (is.data.frame(param)) ",
+        "    if (is.data.frame(param)) {",
+        "        param_lower <- structure(param$lower, names = param$switch)",
+        "        param_upper <- structure(param$upper, names = param$switch)",
         "        param <- structure(param$value, names = param$switch)",
+        "    }",
+        "    else {",
+        "        param_lower <- lapply(param, function(x) NA)",
+        "        param_upper <- lapply(param, function(x) NA)",
+        "    }",
         "    stopifnot(\"parp\" %in% names(param))",
         "    x <- param[[\"parp\"]]",
         "    while (TRUE) {",
@@ -49,8 +56,15 @@ ok_group('print.g3_r', {
     ok(ut_cmp_identical(cap(print(model_fn, with_environment = TRUE, with_template = TRUE)), c(
         "function (param = attr(get(sys.call()[[1]]), \"parameter_template\")) ",
         "{",
-        "    if (is.data.frame(param)) ",
+        "    if (is.data.frame(param)) {",
+        "        param_lower <- structure(param$lower, names = param$switch)",
+        "        param_upper <- structure(param$upper, names = param$switch)",
         "        param <- structure(param$value, names = param$switch)",
+        "    }",
+        "    else {",
+        "        param_lower <- lapply(param, function(x) NA)",
+        "        param_upper <- lapply(param, function(x) NA)",
+        "    }",
         "    stopifnot(\"parp\" %in% names(param))",
         "    x <- param[[\"parp\"]]",
         "    while (TRUE) {",
@@ -147,6 +161,6 @@ ok_group('parameter data.frame', {
     # We can also hand model_fn a data.frame, in which case the value column is used
     model_fn <- g3_to_r(~return(g3_param("archibald", value = 45)))
 
-    df <- data.frame(switch = c("archibald"), value = I(list(floor(runif(1, 100, 200)))))
+    df <- data.frame(switch = c("archibald"), lower = 0, upper = 100, value = I(list(floor(runif(1, 100, 200)))))
     ok(ut_cmp_equal(as.numeric(model_fn(df)), as.numeric(df$value)), "data.frame accepted as input")
 })

--- a/tests/test-run_r.R
+++ b/tests/test-run_r.R
@@ -35,6 +35,8 @@ ok_group('print.g3_r', {
     ok(ut_cmp_identical(cap(print(model_fn)), c(
         "function (param = attr(get(sys.call()[[1]]), \"parameter_template\")) ",
         "{",
+        "    if (is.data.frame(param)) ",
+        "        param <- structure(param$value, names = param$switch)",
         "    stopifnot(\"parp\" %in% names(param))",
         "    x <- param[[\"parp\"]]",
         "    while (TRUE) {",
@@ -47,6 +49,8 @@ ok_group('print.g3_r', {
     ok(ut_cmp_identical(cap(print(model_fn, with_environment = TRUE, with_template = TRUE)), c(
         "function (param = attr(get(sys.call()[[1]]), \"parameter_template\")) ",
         "{",
+        "    if (is.data.frame(param)) ",
+        "        param <- structure(param$value, names = param$switch)",
         "    stopifnot(\"parp\" %in% names(param))",
         "    x <- param[[\"parp\"]]",
         "    while (TRUE) {",
@@ -137,4 +141,12 @@ ok_group('parameter_template default', {
     model_fn <- g3_to_r(~return(g3_param("archibald", value = 45)))
     ok(ut_cmp_equal(model_fn(), 45), "Used default from parameter_template")
     ok(ut_cmp_equal(model_fn(list(archibald = 99)), 99), "Override default")
+})
+
+ok_group('parameter data.frame', {
+    # We can also hand model_fn a data.frame, in which case the value column is used
+    model_fn <- g3_to_r(~return(g3_param("archibald", value = 45)))
+
+    df <- data.frame(switch = c("archibald"), value = I(list(floor(runif(1, 100, 200)))))
+    ok(ut_cmp_equal(as.numeric(model_fn(df)), as.numeric(df$value)), "data.frame accepted as input")
 })

--- a/tests/test-step.R
+++ b/tests/test-step.R
@@ -449,6 +449,10 @@ ok_group("list_to_stock_switch", {
         gadget3:::g3_step(f)
     }
 
+    ok(gadget3:::ut_cmp_code(
+        gadget3:::list_to_stock_switch(34),
+        quote( 34 ) ), "Non-code items aren't wrapped with stock_with()")
+
     ok(ut_cmp_error(
         gadget3:::list_to_stock_switch(list(1,2)),
         "one default"), "Only one default option allowed")


### PR DESCRIPTION
As well as a bunch of small bugfixes, here's something that should have been done a while ago.

The R model now supports the TMB data.frame parameter template, and thus can now do parameter bounds properly. So things like this now work:

```r
model_cpp <- g3_to_tmb(c(actions, list( g3l_bounds_penalty(actions) )))
model_fn <- g3_to_r(c(actions, list( g3l_bounds_penalty(actions) )))

attr(model_cpp, 'parameter_template') |>
    g3_init_val('pa', 100.45) |>
    g3_init_val('pb', 200) |>
    g3_init_val('pc', 300.5342) |>
    identity() -> params.in

nll <- model_fn(params.in)
```

The format of the R parameter_template is still a list, fixing that will be trickier, but at least you can forget about having to do ``params.in$value``.