### PR TITLE
Functions in models

### DIFF
--- a/R/run_r.R
+++ b/R/run_r.R
@@ -130,9 +130,19 @@ g3_to_r <- function(
                     environment(fn_defn) <- env  # TODO: This should be the output function scope, not env.
                     scope[[var_name]] <<- call("<-", as.symbol(var_name), fn_defn)
                 } else if (is.character(all_defns[[var_name]]) && all_defns[[var_name]] != var_name) {
-                    # Native function with a different name
+                    # R function, not part of baseenv
                     scope[[var_name]] <<- call("<-", as.symbol(var_name), as.symbol(all_defns[[var_name]]))
                 }
+                next
+            }
+            if (is.function(all_defns[[var_name]])) {
+                # Ignore baseenv functions
+                if (identical(all_defns[[var_name]], get0(var_name, envir = baseenv()))) next
+
+                # Include function in model environment
+                # We don't modify it's environment, so closures will be intact
+                # NB: Package functions won't be visible here, since that's a "::" call.
+                assign(var_name, all_defns[[var_name]], envir = model_env)
             }
         }
 

--- a/vignettes/writing_actions.Rmd
+++ b/vignettes/writing_actions.Rmd
@@ -32,16 +32,47 @@ See ``R/aab_env.R`` for more information, and other existing helpers.
 
 ## Global & native functions
 
-Some things aren't easy to do with code translation. ``g3_native`` allows you to
-define a function with separate R and C++ definitions, for example ``normalize_vec``,
-which ensures a vector sums to 1, has the following definition:
+### Under R
 
+R functions can be included in a formula as anything else, *provided you use this through R*.
+For example:
+
+```r
+model_fn <- g3_to_r(list(g3a_time(1990, 1990), g3_formula(
+    nll <- nll + fn(9),
+    fn = function (x) x * 10 )))
+model_fn()
 ```
-g3_env$normalize_vec <- g3_native(r = function (a) {
+
+Your function is now part of the model environment
+
+```r
+environment(model_fn)$fn
+```
+
+### Under TMB: g3_native
+
+We do not yet translate functions from TMB to R,however ``g3_native`` allows you to
+Some things aren't easy to do with code translation. ``g3_native`` allows you to
+define a function with separate R and C++ definitions, for example:
+
+```r
+normalize_vec <- g3_native(r = function (a) {
     a / sum(a)
 }, cpp = '[](vector<Type> a) -> vector<Type> {
     return a / a.sum();
 }')
+model_fn <- g3_to_r(list(g3a_time(1990, 1990), g3_formula(
+    nll <- nll + normalize_vec(g3_param("a")),
+    normalize_vec = normalize_vec )))
+model_fn(c(list(a = 10:20), attr(model_fn, "parameter_template")))
+```
+
+```r
+model_code <- g3_to_tmb(list(g3a_time(1990, 1990), g3_formula(
+    nll <- nll + normalize_vec(g3_param("a")),
+    normalize_vec = normalize_vec )))
+model_code
 ```
 
 ## Stock steps


### PR DESCRIPTION
Allow functions to be included in R models, so things like the following work:

```r
model_fn <- g3_to_r(list(g3a_time(1990, 1990), g3_formula(
    nll <- nll + fn(9),
    fn = function (x) x * 10 )))
model_fn()
```

Also, make sure we can use namespace references, and that we *can't* refer to things in globalenv (which has a high probability of doing the wrong thing).

Obvious reason for doing this is to simplify the setup of MSE scenarios. Write a wrapper that calls r4ss or whatever, and give that to the quota-defining methods.