### PR TITLE
params: Include selection tuple in g3_param_table() call

### DIFF
--- a/R/params.R
+++ b/R/params.R
@@ -155,7 +155,12 @@ g3_parameterized <- function(
     # Generate core call
     if (length(table_defn) > 0) {
         table_defn <- as.call(c(as.symbol('expand.grid'), table_defn))
-        out <- substitute(g3_param_table(x, table_defn), list(x = name, table_defn = table_defn))
+        # NB: select isn't used (yet), but give something for code-analysis to find
+        select_c <- as.call(c(
+            list(as.symbol("list")),
+            lapply(tail(names(table_defn), -1), as.symbol) ))
+        out <- substitute(
+            g3_param_table(x, table_defn, select = select_c), list(x = name, table_defn = table_defn, select_c = select_c))
     } else {
         out <- substitute(g3_param(x), list(x = name))
     }
@@ -195,7 +200,5 @@ g3_parameterized <- function(
     if (avoid_zero != 0) out <- substitute(avoid_zero(x), list(x = out))
     if (offset != 0) out <- substitute(x + offset, list(x = out, offset = offset))
 
-    # TODO: Big hack to make sure by_age stays in relevant loop
-    if (isTRUE(by_age)) out <- substitute(x + 0 * age, list(x = out))
     return(out)
 }

--- a/tests/test-params.R
+++ b/tests/test-params.R
@@ -4,7 +4,7 @@ if (!interactive()) options(warn=2, error = function() { sink(stderr()) ; traceb
 
 library(gadget3)
 
-cmp_code <- function (a, b) ut_cmp_identical(deparse(a), deparse(b))
+cmp_code <- function (a, b) ut_cmp_identical(deparse1(a), deparse1(b))
 
 # Generate parameter template for all given parameters (beginning with "ut.")
 param_model <- function (...) {
@@ -109,7 +109,7 @@ ok(cmp_code(
             ifmissing = stock_prepend(stock, g3_param("def.byst"), name_part = NULL)
         ), name_part = NULL)
         g3_param("nby", ifmissing = g3_param("def.nby"))
-        g3_param_table("parp", expand.grid(cur_year = seq(start_year, end_year)), ifmissing = g3_param("peep"))
+        g3_param_table("parp", expand.grid(cur_year = seq(start_year, end_year)), select = list(cur_year), ifmissing = g3_param("peep"))
     NULL})), "ifmissing can be character (and gets assigned a parameter)")
 
 ok(cmp_code(
@@ -137,10 +137,10 @@ ok(cmp_code(
         g3_parameterized('parp', by_stock = TRUE, by_year = TRUE, by_age = TRUE),
     NULL)), quote({
         g3_param_table("st_m_imm.parp", expand.grid(
-            cur_year = seq(start_year, end_year)))
+            cur_year = seq(start_year, end_year)), select = list(cur_year) )
         g3_param_table("st_m_imm.parp", expand.grid(
             cur_year = seq(start_year, end_year),
-            age = seq(st_m_imm__minage, st_m_imm__maxage))) + 0 * age
+            age = seq(st_m_imm__minage, st_m_imm__maxage)), select = list(cur_year, age))
     NULL})), "Adding by_year or by_age turns it into a table")
 
 ok(cmp_code(
@@ -150,12 +150,12 @@ ok(cmp_code(
         g3_parameterized('yrst', by_year = TRUE, by_step = TRUE),
     NULL)), quote({
     g3_param_table("yr", expand.grid(
-        cur_year = seq(start_year, end_year)))
+        cur_year = seq(start_year, end_year)), select = list(cur_year))
     g3_param_table("st", expand.grid(
-        cur_step = seq_along(step_lengths)))
+        cur_step = seq_along(step_lengths)), select = list(cur_step))
     g3_param_table("yrst", expand.grid(
         cur_year = seq(start_year, end_year),
-        cur_step = seq_along(step_lengths)))
+        cur_step = seq_along(step_lengths)), select = list(cur_year, cur_step))
     NULL})), "by_year & by_step can be combined")
 
 ok(cmp_code(
@@ -166,7 +166,7 @@ ok(cmp_code(
     NULL)), quote({
         g3_param("st.parp", lower = 3)
         g3_param("st_m.parp", lower = 3)
-        g3_param_table("m.parp", expand.grid(cur_year = seq(start_year, end_year)))
+        g3_param_table("m.parp", expand.grid(cur_year = seq(start_year, end_year)), select = list(cur_year))
     NULL})), "Can specify which name_part should be used in the name")
 
 ok(cmp_code(
@@ -180,7 +180,7 @@ ok(cmp_code(
         stock_prepend("st.m", g3_param("parp"))
         stock_prepend("st", g3_param("parp"))
         stock_prepend("st.f", g3_param_table("parp", expand.grid(
-            age = seq(min(st_f_imm__minage, st_f_mat__minage), max(st_f_imm__maxage, st_f_mat__maxage))))) + 0 * age
+            age = seq(min(st_f_imm__minage, st_f_mat__minage), max(st_f_imm__maxage, st_f_mat__maxage))), select = list(age)))
         stock_prepend("c_d.zz_b", g3_param("nocommon"))
     NULL})), "Can give a list of stocks, in which case it works out name parts for you")
 
@@ -192,7 +192,7 @@ ok(cmp_code(
     NULL), quote({
         stock_prepend(stock, g3_param("rec"), name_part = "species") * stock_prepend(stock, g3_param("rec.scalar"), name_part = "species")
         stock_prepend(stock, g3_param("rec"), name_part = "species") * stock_prepend(stock, g3_param("rec.scalar"), name_part = "species") + stock_prepend(stock, g3_param("rec.offset"), name_part = "species")
-        stock_prepend(stock, g3_param_table("rec", expand.grid(age = seq(stock__minage, stock__maxage))), name_part = "species") * stock_prepend(stock, g3_param("rec.scalar"), name_part = "species") + 0 * age
+        stock_prepend(stock, g3_param_table("rec", expand.grid(age = seq(stock__minage, stock__maxage)), select = list(age)), name_part = "species") * stock_prepend(stock, g3_param("rec.scalar"), name_part = "species")
     NULL})), "scale / offset can be character, in which case they are also a param. Only by_stock is honoured though")
 
 year_range <- 1982:1986

--- a/tests/test-step.R
+++ b/tests/test-step.R
@@ -316,7 +316,7 @@ ok_group("g3_step:dependent_formulas", (function () {
             const := g3_param("ling_imm.const"),
             for (age in seq(ling_imm__minage, ling_imm__maxage, by = 1)) g3_with(
                 ling_imm__age_idx := g3_idx(age - ling_imm__minage + 1L),
-                by_age := (g3_param_table("ling_imm.byage", expand.grid(age = seq(ling_imm__minage, ling_imm__maxage))) + 0 * age),
+                by_age := g3_param_table("ling_imm.byage", expand.grid(age = seq(ling_imm__minage, ling_imm__maxage)), select = list(age)),
                 (ling_imm__num[, ling_imm__age_idx] + const + by_age)))
     ))), "add_dependent_formula: stock substituted both inside and outside loop")
 


### PR DESCRIPTION
@bthe This should mean that you don't have to do ``0 * cur_year`` any more for time-based selectivity parameters.

It's still an ugly bodge, but less ugly at least :)