### PR TITLE
Add surplus production models

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -75,6 +75,10 @@ export(g3a_spawn_recruitment_bevertonholt_ss3)
 export(g3a_spawn_recruitment_hockeystick)
 export(g3a_spawn)
 
+# R/action_spmodel.R
+export(g3a_spmodel_logistic)
+export(g3a_spmodel)
+
 # R/action_tagging.R
 export(g3a_predate_tagrelease)
 export(g3a_tag_shedding)

--- a/R/action_spmodel.R
+++ b/R/action_spmodel.R
@@ -1,0 +1,49 @@
+g3a_spmodel_logistic <- function(
+        r = g3_parameterized("spm_r", lower = 0.01, upper = 1, value = 0.5,
+            by_stock = by_stock),
+        p = g3_parameterized("spm_p", lower = 0.01, upper = 10, value = 1,
+            by_stock = by_stock),
+        K = g3_parameterized("spm_K", lower = 100, upper = 1e6, value = 1000,
+            by_stock = by_stock),
+        by_stock = TRUE) {
+
+    s <- ~sum(stock_ss(stock__num))
+    ~r *  s * (1-(s/K)^p)
+}
+
+g3a_spmodel <- function (
+        stock,
+        spm_num = g3a_spmodel_logistic(),
+        spm_num_init = g3_parameterized("spm_n0", by_stock = TRUE),
+        spm_wgt = 1,
+        run_f = TRUE,
+        run_at = g3_action_order$initial) {
+
+    out <- new.env(parent = emptyenv())
+    action_name <- unique_action_name()
+
+    stock__renewalnum <- g3_stock_instance(stock, 0)
+    stock__num <- g3_stock_instance(stock, 0)
+    stock__wgt <- g3_stock_instance(stock, 1)
+
+    out[[step_id(run_at, "g3a_spmodel", stock, action_name)]] <- g3_step(f_substitute(~{
+        debug_label("Surplus production model for ", stock)
+        stock_iterate(stock, {
+            if (cur_time == 0) {
+                stock_ss(stock__num) <- 0 * stock__midlen + spm_num_init
+                stock_ss(stock__wgt) <- 0 * stock__midlen + spm_wgt
+            } else if (run_f) {
+                stock_ss(stock__renewalnum) <- 0 * stock__midlen + spm_num
+                stock_ss(stock__num) <- stock_ss(stock__num) + stock_ss(stock__renewalnum)
+                stock_ss(stock__wgt) <- 0 * stock__midlen + spm_wgt
+            } else {
+                stock_ss(stock__renewalnum) <- 0 * stock__midlen
+            }
+        })
+    }, list(
+        spm_num = spm_num,
+        spm_wgt = spm_wgt,
+        run_f = run_f )))
+
+    return(as.list(out))
+}

--- a/man/action_spmodel.Rd
+++ b/man/action_spmodel.Rd
@@ -1,0 +1,129 @@
+\name{action_spmodel}
+\alias{g3a_spmodel_logistic}
+\alias{g3a_spmodel}
+\concept{G3 action}
+
+\title{Gadget3 surplus production model}
+\description{
+  A simple production model can be used in place of a set of gadget stock dynamics actions.
+}
+
+\usage{
+g3a_spmodel_logistic(
+        r = g3_parameterized("spm_r", lower = 0.01, upper = 1, value = 0.5,
+            by_stock = by_stock),
+        p = g3_parameterized("spm_p", lower = 0.01, upper = 10, value = 1,
+            by_stock = by_stock),
+        K = g3_parameterized("spm_K", lower = 100, upper = 1e6, value = 1000,
+            by_stock = by_stock),
+        by_stock = TRUE)
+
+g3a_spmodel(
+        stock,
+        spm_num = g3a_spmodel_logistic(),
+        spm_num_init = g3_parameterized("spm_n0", by_stock = TRUE),
+        spm_wgt = 1,
+        run_f = TRUE,
+        run_at = g3_action_order$initial)
+}
+
+\arguments{
+  \item{r, p, K}{
+    Parameters for the logistic model, see value section.
+  }
+  \item{by_stock}{
+    Change the default parameterisation (e.g. to be by 'species'), see \code{\link{g3_parameterized}}.
+  }
+  \item{stock}{
+    \code{\link{g3_stock}} object to apply the simple production model to.
+  }
+  \item{spm_num}{
+    \link{formula} to calculate the relative change in abundance, one of the \code{g3a_spmodel_*} functions.
+  }
+  \item{spm_num_init}{
+    Starting point for stock abundance.
+  }
+  \item{spm_wgt}{
+    \link{formula} to calculate the mean weight, if "1", then abundance in numbers == total biomass.
+  }
+  \item{run_f}{
+    \link{formula} specifying a condition for running this action, default always runs.
+  }
+  \item{run_at}{
+    Integer order that actions will be run within model, see \code{\link{g3_action_order}}.
+  }
+}
+
+\details{
+  The actions will define the following variables in your model, which could be reported with \code{\link{g3a_report_history}}:
+  \describe{
+    \item{(stock)__renewalnum}{Numbers added to the abundance of \var{stock}}
+  }
+
+  Note that the input stock should not have \code{\link{g3s_age}},
+  if the stock was broken up by age the model would quickly not make sense.
+}
+
+\seealso{
+  \code{\link{g3_stock}}
+}
+
+\value{
+  \subsection{g3a_spmodel_logistic}{
+    Returns a \link{formula} for use as \var{spm_num}:
+
+    \deqn{
+      r s (1 - (\frac{s}{K})^p)
+    }
+
+    \describe{
+      \item{\eqn{s}}{}
+      \item{\eqn{r}}{\var{r} argument, by default the \code{(stock)_spm_r} model parameter}
+      \item{\eqn{p}}{\var{p} argument, by default the \code{(stock)_spm_p} model parameter}
+      \item{\eqn{K}}{\var{K} argument, by default the \code{(stock)_spm_K} model parameter}
+    }
+  }
+  \subsection{g3a_spmodel}{
+    G3 action that maintains stock abundance / mean weight according to simple production model
+  }
+}
+
+\examples{
+# NB: Stock only has one length group, 30:40. So the stocks midlen is 35
+stock_a <- g3_stock(c("stock", "a"), c(30, 40), open_ended = FALSE)
+stocks <- list(stock_a)
+fleet_a <- g3_fleet(c('fleet', "a"))
+
+actions <- list(
+    g3a_time(2000, 2010, step_lengths = c(6,6), project_years = 0),
+
+    g3a_spmodel(
+        stock_a ),
+    g3a_predate(
+        fleet_a,
+        stocks,
+        suitabilities = 1,
+        catchability_f = g3a_predate_catchability_linearfleet(
+            g3_parameterized("effort", value = 1e-1, by_predator = TRUE) )),
+
+    # NB: Dummy parameter so model will compile in TMB
+    ~{nll <- nll + g3_param("x", value = 0, optimise = TRUE)} )
+actions <- c(actions, list(
+    # NB: Late reporting for abundance
+    g3a_report_history(actions, "__num$|__wgt$", out_prefix="dend_"),
+    g3a_report_detail(actions) ))
+model_fn <- g3_to_r(actions)
+
+attr(model_fn, 'parameter_template') |>
+    # Surplus production model parameters
+    g3_init_val("*.spm_n0", 1e4) |>
+    g3_init_val("*.spm_r", 0.1) |>
+    g3_init_val("*.spm_p", 0.01) |>
+    g3_init_val("*.spm_K", 1e8, lower = 0, upper = 1e20) |>
+
+    identity() -> params.in
+r <- attributes(model_fn(params.in))
+
+barplot(r$dend_stock_a__num, las = 2)
+barplot(r$detail_stock_a__renewalnum, las = 2)
+}

--- a/tests/test-action_spmodel.R
+++ b/tests/test-action_spmodel.R
@@ -1,0 +1,67 @@
+if (!interactive()) options(warn=2, error = function() { sink(stderr()) ; traceback(3) ; q(status = 1) })
+library(unittest)
+
+library(gadget3)
+
+stock_a <- g3_stock(c("stock", "a"), seq(10, 50, by = 10))
+stocks <- list(stock_a)
+fleet_a <- g3_fleet(c('fleet', "a"))
+
+actions <- list(
+    g3a_time(2000, 2010, step_lengths = c(6,6), project_years = 0),
+
+    g3a_spmodel(
+        stock_a,
+        # Only run on first step
+        run_f = quote( cur_step == 1 )),
+    g3a_predate(
+        fleet_a,
+        stocks,
+        suitabilities = g3_suitability_exponentiall50(),
+        catchability_f = g3a_predate_catchability_linearfleet(
+            g3_parameterized("effort", value = 1e-2, by_predator = TRUE) )),
+
+    # NB: Dummy parameter so model will compile in TMB
+    ~{nll <- nll + g3_param("x", value = 0, optimise = TRUE)} )
+actions <- c(actions, list(
+    g3a_report_history(actions, "__num$|__wgt$", out_prefix="dend_"),  # NB: Late reporting
+    g3a_report_detail(actions) ))
+model_fn <- g3_to_r(actions)
+model_cpp <- g3_to_tmb(actions)
+
+ok_group("Default params") ########
+attr(model_cpp, 'parameter_template') |>
+    # Surplus production model parameters
+    g3_init_val("*.spm_n0", 1e6) |>
+    g3_init_val("*.spm_r", 0.1) |>
+    g3_init_val("*.spm_p", 0.01) |>
+    g3_init_val("*.spm_K", 1e8, lower = 0, upper = 1e20) |>
+
+    # Predation parameters
+    g3_init_val("stock_a.fleet_a.alpha", 0.2) |>
+    g3_init_val("stock_a.fleet_a.l50", 30) |>
+
+    identity() -> params.in
+nll <- model_fn(params.in) ; r <- attributes(nll) ; nll <- as.vector(nll)
+# barplot(r$suit_stock_a_fleet_a__report)
+# barplot(r$dend_stock_a__num, las = 2)
+
+ok(gadget3:::ut_cmp_df(r$dend_stock_a__num, '
+         2000-01 2000-02 2001-01 2001-02 2002-01 2002-02 2003-01 2003-02 2004-01 2004-02 2005-01 2005-02 2006-01 2006-02 2007-01 2007-02 2008-01 2008-02 2009-01 2009-02 2010-01 2010-02
+  10:20   999763  999526 1013983 1013742 1028282 1028038 1042660 1042413 1057118 1056867 1071655 1071401 1086272 1086015 1100969 1100708 1115745 1115480 1130601 1130333 1145536 1145265
+  20:30   998655  997312 1010649 1009290 1022696 1021321 1034797 1033406 1046952 1045544 1059160 1057736 1071422 1069981 1083737 1082280 1096105 1094632 1108528 1107037 1121003 1119495
+  30:40   996345  992703 1003718 1000049 1011123 1007427 1018559 1014836 1026028 1022278 1033528 1029750 1041060 1037254 1048622 1044789 1056216 1052356 1063841 1059953 1071497 1067580
+  40:50   995237  990497 1000407  995642 1005613 1000823 1010855 1006040 1016133 1011294 1021448 1016583 1026797 1021907 1032182 1027266 1037603 1032661 1043057 1038090 1048547 1043553
+  50:Inf  995033  990092  999799  994833 1004602  999613 1009444 1004430 1014323 1009286 1019241 1014178 1024195 1019108 1029187 1024075 1034215 1029078 1039280 1034118 1044381 1039194
+', tolerance = 1e-6), "r$dend_stock_a__num: spm & fishing effort roughly balanced")
+
+ok(gadget3:::ut_cmp_df(r$detail_stock_a__renewalnum, '
+         2000-01 2000-02 2001-01 2001-02 2002-01 2002-02 2003-01 2003-02 2004-01 2004-02 2005-01 2005-02 2006-01 2006-02 2007-01 2007-02 2008-01 2008-02 2009-01 2009-02 2010-01 2010-02
+  10:20        0       0   14697       0   14783       0   14870       0   14956       0   15042       0   15129       0   15215       0   15302       0   15389       0   15475       0
+  20:30        0       0   14697       0   14783       0   14870       0   14956       0   15042       0   15129       0   15215       0   15302       0   15389       0   15475       0
+  30:40        0       0   14697       0   14783       0   14870       0   14956       0   15042       0   15129       0   15215       0   15302       0   15389       0   15475       0
+  40:50        0       0   14697       0   14783       0   14870       0   14956       0   15042       0   15129       0   15215       0   15302       0   15389       0   15475       0
+  50:Inf       0       0   14697       0   14783       0   14870       0   14956       0   15042       0   15129       0   15215       0   15302       0   15389       0   15475       0
+', tolerance = 5e-5), "r$detail_stock_a__renewalnum: Only happens every other year, even over all length groups")
+
+gadget3:::ut_tmb_r_compare2(model_fn, model_cpp, params.in)


### PR DESCRIPTION
By popular request, add ``g3a_spmodel()``.

The main difference from the example code floating about is fixing a bug with the initial conditions. It also makes an attempt at dealing with multiple length groups, the attempt is to apply the logistic function evenly, which is better than crashing, but not by much.

We could apply selectivity / vonB curves atop the initial conditions / logistic function to improve this, but it's probably not really worth it. For this to make sense you'd have a single length group anyway.

Fixes #169