### PR TITLE
quota: Replace init_val with interim_value

### DIFF
--- a/R/quota.R
+++ b/R/quota.R
@@ -99,11 +99,10 @@ g3_quota <- function (
         quota_name = attr(function_f, 'quota_name'),
         year_length = 1L,
         start_step = 1L,
-        init_val = 0.0,
+        interim_value = NULL,
         run_revstep = -1,
         run_f = TRUE,
         run_at = g3_action_order$quota ) {
-    stopifnot(is.numeric(init_val))
 
     if (!is.null(run_revstep)) run_f <- f_substitute(quote(quotastock__fishingyear_revstep == x && run_f), list(
         run_f = run_f,
@@ -111,7 +110,7 @@ g3_quota <- function (
 
     quotastock <- g3_storage(c('quota', quota_name))
     quotastock <- g3s_modeltime_fishingyear(quotastock, year_length = year_length, start_step = start_step)
-    quotastock__var <- g3_stock_instance(quotastock, init_val, desc = paste0("Quota values for ", quotastock$name))
+    quotastock__var <- g3_stock_instance(quotastock, 0.0, desc = paste0("Quota values for ", quotastock$name))
 
     # Formula to select current quota value, for use in catchability
     out <- g3_step(f_substitute(~(
@@ -119,6 +118,12 @@ g3_quota <- function (
     ), list(
         end = NULL )), recursing = TRUE)
     attr(out, "catchability_unit") <- attr(function_f, "catchability_unit")
+
+    if (!is.null(interim_value)) {
+        function_f <- f_substitute(quote(
+            if (cur_year_projection) f else i
+        ), list(f = function_f, i = interim_value))
+    }
 
     # Ancillary step to calculate quota at assessent step
     environment(out)[[step_id(run_at, "g3a_quota", quotastock)]] <- g3_step(f_substitute(~{

--- a/man/quota.Rd
+++ b/man/quota.Rd
@@ -30,7 +30,7 @@ g3_quota(
         quota_name = attr(function_f, 'quota_name'),
         year_length = 1L,
         start_step = 1L,
-        init_val = 0.0,
+        interim_value = NULL,
         run_revstep = -1,
         run_f = TRUE,
         run_at = g3_action_order$quota )
@@ -82,9 +82,8 @@ g3_quota(
   \item{run_f}{
     When the quota should be recalculated, in addition to any condition defined by \var{run_revstep}.
   }
-  \item{init_val}{
-    Numeric scalar that the quota array is initalised to.
-    Will be used if the quota used before it is calculated, e.g. at model start.
+  \item{interim_value}{
+    A formula that provides the interim value to bridge the gap between historical landings & projected quota values, see examples.
   }
   \item{run_at}{
     Integer order that actions will be run within model, see \code{\link{g3_action_order}}.
@@ -208,5 +207,27 @@ par(mar = c(6, 5, 1, 0)) ; barplot(r$quota_hockeyfleet_fl__var, las = 2) ; ablin
 ##   (b) inflection of hitting btrigger
 ##   (c) Uneven spread of fishing effort throughout year (fl.quota.step.#)
 barplot(g3_array_agg(r$detail_st_fl__cons, "time"), las = 2)
+
+## Timing of calculations for fishing year
+fl_quota <- g3_quota(
+    # Our quota values are year/step at the assessment time step
+    quote( cur_year * 10 + cur_step ),
+    year_length = 1L,
+    start_step = 4L,
+    interim_value = g3_parameterized("interim_value", value = 99, optimize = FALSE),
+    run_revstep = -3L )
+yr <- as.integer(format(Sys.Date(), "\%Y"))
+actions <- list(
+    g3a_time(yr - 6, yr - 1, project_years = 10, step_lengths = rep(3L, 4)),
+    fl_quota,
+    # At each step in the model, print the current year/step, and the quota value that will get used
+    # NB: before projection, g3a_predate_catchability_project() will use landings data not the quota
+    g3_step(g3_formula(
+        writeLines(paste(cur_year, cur_step, if (cur_year_projection) q else "landings")),
+        q = fl_quota )),
+    NULL)
+model_fn <- g3_to_r(c(actions,
+    g3a_report_history(actions, "quota_", out_prefix = NULL) ))
+attr(model_fn(), "quota__var")
 
 }

--- a/tests/test-quota.R
+++ b/tests/test-quota.R
@@ -1,0 +1,77 @@
+if (!interactive()) options(warn=2, error = function() { sink(stderr()) ; traceback(3) ; q(status = 1) })
+library(unittest)
+
+library(gadget3)
+
+do_fishing_calendar <- function(wall_calendar, fishing_calendar) {
+    fl_quota <- do.call(g3_quota, c(
+        # Our quota values are year/step at the assessment time step
+        list( quote( cur_year * 10 + cur_step ) ),
+        fishing_calendar), quote = TRUE)
+    actions <- list(
+        do.call(g3a_time, wall_calendar, quote = TRUE),
+        fl_quota,
+        # NB: before projection, g3a_predate_catchability_project() will use landings data not the quota
+        g3_step(g3_formula(
+            writeLines(paste(cur_year, cur_step, if (cur_year_projection) q else "landings")),
+            q = fl_quota )),
+        NULL)
+    model_fn <- g3_to_r(c(actions,
+        g3a_report_history(actions, "quota_", out_prefix = NULL) ))
+    capture.output({ r <- model_fn() })
+}
+
+ok_group("interim_value", {
+    out <- do_fishing_calendar(wall_calendar = list(
+        start_year = 2019,
+        end_year = 2024,
+        project_years = 10,
+        step_lengths = rep(3L, 4)
+    ), fishing_calendar = list(
+        year_length = 1L,
+        start_step = 4L,
+        interim_value = "interim",
+        run_revstep = -3L ))
+    ok(ut_cmp_identical(out, c(
+        "2019 1 landings", "2019 2 landings", "2019 3 landings", "2019 4 landings",
+        "2020 1 landings", "2020 2 landings", "2020 3 landings", "2020 4 landings",
+        "2021 1 landings", "2021 2 landings", "2021 3 landings", "2021 4 landings",
+        "2022 1 landings", "2022 2 landings", "2022 3 landings", "2022 4 landings",
+        "2023 1 landings", "2023 2 landings", "2023 3 landings", "2023 4 landings",
+        "2024 1 landings", "2024 2 landings", "2024 3 landings", "2024 4 landings",
+        "2025 1 interim", "2025 2 interim", "2025 3 interim",
+        "2025 4 20251", "2026 1 20251", "2026 2 20251", "2026 3 20251",
+        "2026 4 20261", "2027 1 20261", "2027 2 20261", "2027 3 20261",
+        "2027 4 20271", "2028 1 20271", "2028 2 20271", "2028 3 20271",
+        "2028 4 20281", "2029 1 20281", "2029 2 20281", "2029 3 20281",
+        "2029 4 20291", "2030 1 20291", "2030 2 20291", "2030 3 20291",
+        "2030 4 20301", "2031 1 20301", "2031 2 20301", "2031 3 20301",
+        "2031 4 20311", "2032 1 20311", "2032 2 20311", "2032 3 20311",
+        "2032 4 20321", "2033 1 20321", "2033 2 20321", "2033 3 20321",
+        "2033 4 20331", "2034 1 20331", "2034 2 20331", "2034 3 20331",
+        "2034 4 20341")), "Fishing calendar with interim value")
+
+    out <- do_fishing_calendar(wall_calendar = list(
+        start_year = 2019,
+        end_year = 2024,
+        retro_years = 6L,
+        project_years = 10,
+        step_lengths = rep(3L, 4)
+    ), fishing_calendar = list(
+        year_length = 1L,
+        start_step = 4L,
+        interim_value = "interim",
+        run_revstep = -3L ))
+    ok(ut_cmp_identical(out, c(
+        "2019 1 0", "2019 2 0", "2019 3 0",
+        "2019 4 20191", "2020 1 20191", "2020 2 20191", "2020 3 20191",
+        "2020 4 20201", "2021 1 20201", "2021 2 20201", "2021 3 20201",
+        "2021 4 20211", "2022 1 20211", "2022 2 20211", "2022 3 20211",
+        "2022 4 20221", "2023 1 20221", "2023 2 20221", "2023 3 20221",
+        "2023 4 20231", "2024 1 20231", "2024 2 20231", "2024 3 20231",
+        "2024 4 20241", "2025 1 20241", "2025 2 20241", "2025 3 20241",
+        "2025 4 20251", "2026 1 20251", "2026 2 20251", "2026 3 20251",
+        "2026 4 20261", "2027 1 20261", "2027 2 20261", "2027 3 20261",
+        "2027 4 20271", "2028 1 20271", "2028 2 20271", "2028 3 20271",
+        "2028 4 20281")), "interim_value doesn't apply when model is all-projection (we have to wait for first quota-run, possibly a bug)")
+})


### PR DESCRIPTION
@willbutler42 What do you make of this? I think the example I e-mailed you wasn't particularly clear about when the interim value would get used, which hopefully this test makes a bit clearer:

https://github.com/gadget-framework/gadget3/blob/8345b51743fa9934d31b46830584c1b916d8611e/tests/test-quota.R#L25-L52

The interim_value, whilst technically used for every quota pre-projection, is ignored because we use landings data then.

This pull also removes ``init_val``, since it's pretty useless. Ideally we should be calculating a quota as part of an initial conditions step, but that's another can of worms entirely.

It'd be good to get this sorted before releasing to CRAN.