### PR TITLE
Add our own head / tail definitions

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,5 +1,5 @@
 importFrom("stats", "as.formula", "formula", "dnorm", "rnorm", "lag")
-importFrom("utils", "capture.output", "head", "str", "tail")
+importFrom("utils", "capture.output", "str")
 
 # R/aaa_lang.R
 export(g3_native)

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,5 +1,4 @@
 importFrom("stats", "as.formula", "formula", "dnorm", "rnorm", "lag")
-importFrom("utils", "capture.output", "str")
 
 # R/aaa_lang.R
 export(g3_native)

--- a/R/debug_utils.R
+++ b/R/debug_utils.R
@@ -3,7 +3,7 @@
 # Display the parse tree of a formulae / language object
 parse_tree <- function (o, prefix = "") {
     short_str <- function (x) {
-        trimws(capture.output(str(x))[[1]])
+        trimws(utils::capture.output(utils::str(x))[[1]])
     }
 
     if (missing(o)) {

--- a/R/eval.R
+++ b/R/eval.R
@@ -46,9 +46,9 @@ g3_eval <- function (f, ...) {
         stop(paste(c(
             e,
             "Whilst evaluating expression:",
-            capture.output(print( rlang::f_rhs(f) )),
+            utils::capture.output(print( rlang::f_rhs(f) )),
             "With environment:",
-            capture.output(print( as.list(environment(f)) )),
+            utils::capture.output(print( as.list(environment(f)) )),
             NULL), collapse = "\n"))
     })
 }

--- a/R/headtail.R
+++ b/R/headtail.R
@@ -1,0 +1,23 @@
+# NB: We copy the definitions of head / tail to avoid picking up
+# S3 methods provided by other packages (read: reformulas)
+# utils:::head.default isn't exported, so can't call it directly.
+
+# Common case of utils:::head.default
+head <- function (x, n = 6L) {
+    stopifnot(length(n) == 1L)
+    n <- if (n < 0L)
+        max(length(x) + n, 0L)
+    else min(n, length(x))
+    x[seq_len(n)]
+}
+
+# Common case of utils:::tail.default
+tail <- function (x, n = 6L)
+{
+    stopifnot(length(n) == 1L)
+    xlen <- length(x)
+    n <- if (n < 0L)
+        max(xlen + n, 0L)
+    else min(n, xlen)
+    x[seq.int(to = xlen, length.out = n)]
+}

--- a/R/run_r.R
+++ b/R/run_r.R
@@ -303,10 +303,10 @@ print.g3_r <- function(x, ..., with_environment = FALSE, with_template = FALSE) 
         env_names <- setdiff(names(environment(x)), "parameter_template")
 
         writeLines("Environment:")
-        str(as.list(environment(x))[env_names], no.list = TRUE)
+        utils::str(as.list(environment(x))[env_names], no.list = TRUE)
     }
     if (with_template) {
         writeLines("Parameter template:")
-        str(a$parameter_template, no.list = TRUE)
+        utils::str(a$parameter_template, no.list = TRUE)
     }
 }

--- a/R/run_tmb.R
+++ b/R/run_tmb.R
@@ -912,7 +912,7 @@ g3_to_tmb <- function(actions, trace = FALSE, strict = FALSE) {
                     # NB: bool -> int, as array<bool> doesn't REPORT() (tests/test-action_time.R, R/test_utils.R)
                     cpp_type <- 'int'
                 } else {
-                    stop("Don't know how to define ", var_name, " = ", paste(capture.output(str(var_val)), collapse = "\n    "))
+                    stop("Don't know how to define ", var_name, " = ", paste(utils::capture.output(utils::str(var_val)), collapse = "\n    "))
                 }
                 if (is.array(var_val)) {
                     cpp_type <- paste0('array<', cpp_type, '>')

--- a/R/test_utils.R
+++ b/R/test_utils.R
@@ -180,7 +180,7 @@ vignette_test_output <- function (vign_name, model_code, params.out, tolerance =
         param_df <- as.data.frame(unlist(params.out$value))
         colnames(param_df) <- "value"
         param_df <- param_df[order(rownames(param_df)),,drop = F]
-        capture.output(print.data.frame(param_df, digits = 20), file = paste0(out_base, '.params'))
+        utils::capture.output(print.data.frame(param_df, digits = 20), file = paste0(out_base, '.params'))
     }
 
     model_fn <- g3_to_r(attr(model_code, "actions"))
@@ -198,7 +198,7 @@ vignette_test_output <- function (vign_name, model_code, params.out, tolerance =
     for (n in grep('^detail_.*__(num|wgt)$', names(r), value = TRUE)) {
         unittest::ok(all(!is.na(r[[n]])), paste0(n, ": No NaN values"))
 
-        capture.output(
+        utils::capture.output(
             print(signif(drop(r[[n]]), 4), width = 1e4),
             file = paste0(out_base, '.', n))
     }


### PR DESCRIPTION
@MikkoVihtakari It was actually fairly easy to add our own internal definitions for head/tail, without changing any of the code and/or retraining my fingers to use a different function name.

With the following, usage of reformulas (or any other package that tries similar) is no longer a problem.