### PR TITLE
Add configuratble units to g3_quota_hockeyfleet

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -151,6 +151,7 @@ export(g3_param_project_logar1)
 export(g3_param_project)
 
 # R/quota.R
+export(g3_quota_hockeystick)
 export(g3_quota_hockeyfleet)
 export(g3_quota_assess)
 export(g3_quota)

--- a/R/params.R
+++ b/R/params.R
@@ -1,4 +1,4 @@
-stock_common_part <- function (stocks, collapse = ".") {
+stock_common_part <- function (stocks, collapse = "_") {
     # Find common name_part, add that to our name
     for (i in seq_along(stocks)) {
         if (i == 1) {

--- a/man/quota.Rd
+++ b/man/quota.Rd
@@ -1,4 +1,5 @@
 \name{quota}
+\alias{g3_quota_hockeystick}
 \alias{g3_quota_hockeyfleet}
 \alias{g3_quota_assess}
 \alias{g3_quota}
@@ -10,10 +11,19 @@
 }
 
 \usage{
+g3_quota_hockeystick(
+        predstocks,  # Predator / fleet stocks forming a name for quota
+        preystocks,  # Mature spawning-stocks
+        preyprop_fs = 1,  # NB: Doesn't have to sum to 1
+        trigger = g3_parameterized("hs.trigger", by_stock = predstocks),
+        target = g3_parameterized("hs.target", by_stock = predstocks),
+        stddev = g3_parameterized("hs.stddev", by_stock = predstocks, value = 0),
+        unit = c("harvest-rate-year", "biomass-year", "individuals-year") )
+
 g3_quota_hockeyfleet(
-        predstocks,
-        preystocks,
-        preyprop_fs = 1,
+        predstocks,  # Predator / fleet stocks forming a name for quota
+        preystocks,  # Mature spawning-stocks
+        preyprop_fs = 1,  # NB: Doesn't have to sum to 1
         btrigger = g3_parameterized("hf.btrigger", by_stock = predstocks),
         harvest_rate = g3_parameterized("hf.harvest_rate", by_stock = predstocks),
         stddev = g3_parameterized("hf.stddev", by_stock = predstocks, value = 0) )
@@ -53,11 +63,11 @@ g3_quota(
 
     Using a suitability function is also supported, e.g. \code{\link{g3_suitability_exponentiall50}}.
   }
-  \item{btrigger}{
-    Trigger biomass, see formula
+  \item{trigger, btrigger}{
+    Trigger biomass (or number of individuals, if \var{unit} is "individuals-year"), see formula
   }
-  \item{harvest_rate}{
-    Harvest rate, see formula
+  \item{target, harvest_rate}{
+    The maximum quota value to be returned, assuming the stock is healthy, and above \var{trigger}, see formula
   }
   \item{stddev}{
     If > 0, then apply log-normal noise to the output quota.
@@ -66,7 +76,9 @@ g3_quota(
     A formula that runs an assessment model & returns a quota. See vignette TODO:
   }
   \item{unit}{
-    A single string representing the unit of the value that \var{assess_f} returns.
+    A single string representing the returned quota's unit, as used by \code{\link{g3a_predate_catchability_project}}.
+    In \code{\link{g3_quota_hockeyfleet}}, the unit of both \var{harvest_rate} and \var{btrigger}
+    In \code{\link{g3_quota_assess}}, the value returned by \var{assess_f} will be assumed to have this unit.
   }
   \item{function_f}{
     Output of one of the \code{g3_quota_*} functions, responsible for choosing the next quota
@@ -140,19 +152,23 @@ g3_quota(
 }
 
 \value{
-  \subsection{g3_quota_hockeyfleet}{
+  \subsection{g3_quota_hockeystick}{
     A formula for use in \code{\link{g3_quota}}
 
-    \deqn{SSB = \sum^{preys}_{p}{S_p N_p W_p}}
-    \deqn{H {min}(\frac{SSB}{B_{trig}}, 1)}
+    \deqn{SS = \sum^{preys}_{p}{S_p N_p}} ... if unit = \code{"individuals-year"}
+    \deqn{SS = \sum^{preys}_{p}{S_p N_p W_p}} ... otherwise
+    \deqn{Tg {min}(\frac{SS}{Tr}, 1)}
     \describe{
-      \item{\eqn{H}}{Harvest rate, provided by \var{harvest_rate} argument, by default the \code{hf.harvest_rate} parameter}
-      \item{\eqn{B_{trig}}}{Trigger biomass, provided by \var{btrigger} argument, by default the \code{hf.btrigger} parameter}
-      \item{\eqn{SSB}}{Spawning Stock Biomass (SSB)}
+      \item{\eqn{Tg}}{Target consumption, provided by \var{target} argument, by default the \code{hs.target} parameter}
+      \item{\eqn{Tr}}{Trigger biomass / harvest-rate / individuals, provided by \var{trigger} argument, by default the \code{hs.trigger} parameter}
+      \item{\eqn{SS}}{Spawning Stock (SS) in biomass / individuals}
       \item{\eqn{S_{p}}}{Suitable proportion of prey \eqn{p}, as decided by \var{preyprop_fs}}
       \item{\eqn{N_p}}{Total abundance of prey \eqn{p}}
       \item{\eqn{N_p}}{Mean weight of prey \eqn{p}}
     }
+  }
+  \subsection{g3_quota_hockeyfleet}{
+    For backward-compatibility, essentially the same as \code{g3_quota_hockeystick(..., unit = "harvest-rate-year")}
   }
   \subsection{g3_quota_assess}{A formula for use in \code{\link{g3_quota}} }
   \subsection{g3_quota}{
@@ -165,14 +181,14 @@ g3_quota(
 \examples{
 st <- g3_stock("st", c(10))
 fleets <- list(
-    # NB: We break down our fleet names into parts, g3_quota_hockeyfleet() will
+    # NB: We break down our fleet names into parts, g3_quota_hockeystick() will
     # use the common name part (read: trawl) when naming parameters.
     nor = g3_fleet(c(type = "trawl", country = "nor")),
     oth = g3_fleet(c(type = "trawl", country = "oth")) )
 
 # Define quota for both fleets, with an assessment in spring, application in autumn
 fl_quota <- g3_quota(
-    g3_quota_hockeyfleet(fleets, list(st), preyprop_fs = 1),
+    g3_quota_hockeystick(fleets, list(st), preyprop_fs = 1, unit="harvest-rate"),
     start_step = 4L,
     run_revstep = -2L )
 
@@ -221,13 +237,16 @@ attr(model_fn, "parameter_template") |>
     g3_init_val("trawl_nor.quota.prop", 0.75) |>
     g3_init_val("trawl_oth.quota.prop", 0.25) |>
     # Hockefleet: harvest rate & trigger biomass (shared across trawl_nor & trawl_oth)
-    g3_init_val("trawl.hf.harvest_rate", 0.2) |>
-    g3_init_val("trawl.hf.btrigger", 7.2e6) |>
+    g3_init_val("trawl.hs.target", 0.2) |>
+    g3_init_val("trawl.hs.trigger", 7.2e6) |>
     identity() -> params.in
 r <- attributes(model_fn(params.in))
 
+## Total biomass at assessment point
+g3_array_agg(r$dend_st__num * r$dend_st__wgt, "year", step = 2)
+
 ## Quota values, inflection once total biomass falls below btrigger
-par(mar = c(6, 5, 1, 0)) ; barplot(r$quota_hockeyfleet_trawl__var, las = 2) ; abline(v=27.7)
+par(mar = c(6, 5, 1, 0)) ; barplot(r$quota_hockeystick_trawl__var, las = 2) ; abline(v=27.7)
 
 ## Consumption by fleet, demonstrating
 ##   (a) fixed landings before projections (landings_trawl_nor)

--- a/tests/test-params.R
+++ b/tests/test-params.R
@@ -185,12 +185,12 @@ ok(cmp_code(
         # No common parts, so concatenate everything after sorting
         g3_parameterized('nocommon', by_stock = list(g3_stock(c("zz", "b"), 1), g3_stock(c("c", "d"), 1))),
     NULL), quote({
-        stock_prepend("st.m", g3_param("parp"))
+        stock_prepend("st_m", g3_param("parp"))
         stock_prepend("st", g3_param("parp"))
-        stock_prepend("st.f", g3_param_table("parp", expand.grid(
+        stock_prepend("st_f", g3_param_table("parp", expand.grid(
             age = seq(min(st_f_imm__minage, st_f_mat__minage), max(st_f_imm__maxage, st_f_mat__maxage))), select = list(age)))
         stock_prepend("comm", g3_param("mismatch"))
-        stock_prepend("c_d.zz_b", g3_param("nocommon"))
+        stock_prepend("c_d_zz_b", g3_param("nocommon"))
     NULL})), "Can give a list of stocks, in which case it works out name parts for you")
 
 ok(cmp_code(
@@ -265,3 +265,12 @@ ok(ut_cmp_identical(param_tmpl(
         NULL )), "prepend_extra: Used code / string / list of strings")
 
 ########## prepend_extra
+
+ok_group("stock_common_part", local({
+    scp <- function(...) gadget3:::stock_common_part(lapply(list(...), function (x) g3_stock(x, 1:10)))
+    ok(ut_cmp_identical(scp(c("a", "b")), g3_stock(c("a", "b"), 1)$name), "Common part of single item should match name")
+    ok(ut_cmp_identical(scp(c("a", "b"), c("a", "c")), "a"), "Single common part")
+    ok(ut_cmp_identical(scp(c("a", "b", "d"), c("a", "b")), "a_b"), "Multiple common parts")
+    ok(ut_cmp_identical(scp(c("a", "b"), c("a", "b")), "a_b"), "All common parts")
+    ok(ut_cmp_identical(scp(c("a", "b"), c("c", "d")), "a_b_c_d"), "No common parts")
+}))

--- a/tests/test-quota-hockeyfleet.R
+++ b/tests/test-quota-hockeyfleet.R
@@ -8,12 +8,25 @@ stocks_fl <- list(
     a = g3_fleet(c(type = 'fl', 'a')),
     # NB: We don't use this one, just added to ensure we alter names accordingly
     b = g3_fleet(c(type = 'fl', 'b')) )
+stocks_ind <- list(
+    x = g3_fleet(c(type = 'ind', 'x')) )
 
 # Define quota for the fleet, with an assessment in spring, application in autumn
 fl_quota <- g3_quota(
     g3_quota_hockeyfleet(stocks_fl, list(st), preyprop_fs = 1),
     start_step = 4L,
     run_revstep = -2L )
+
+# Define quota based on individuals caught
+fl_quota_ind <- g3_quota(
+    g3_quota_hockeystick(stocks_ind, list(st), unit = "individuals-year"),
+    start_step = 2L,
+    run_revstep = -1L )
+
+landings_ind <- expand.grid(
+    year = 1990:1995,
+    step = 2:3 )
+landings_ind$number <- 5
 
 actions <- list(
     g3a_time(1990, 1995, c(3,3,3,3)),
@@ -31,6 +44,16 @@ actions <- list(
             # Use the quota when projecting, otherwise use landings parameters
             fl_quota,
             g3_parameterized("landings", value = 0, by_year = TRUE, by_predator = TRUE) )),
+    # Predation based on number of indivduals
+    g3a_predate(
+        stocks_ind$x,
+        list(st),
+        suitabilities = 0.8,
+        catchability_f = g3a_predate_catchability_project(
+            quota_f = fl_quota_ind,
+            landings_f = g3_timeareadata("landings_ind", landings_ind, "number"),
+            # Set the unit for the landings (fl_quota_ind has it's own unit)
+            unit = "individuals" )),
      # NB: Only required for testing
      gadget3:::g3l_test_dummy_likelihood() )
 full_actions <- c(actions, list(
@@ -41,7 +64,8 @@ full_actions <- c(actions, list(
 model_fn <- g3_to_r(full_actions)
 model_cpp <- g3_to_tmb(full_actions)
 
-attr(model_fn, "parameter_template") |>
+ok_group("Population above trigger") ########
+attr(model_cpp, "parameter_template") |>
     # Project for 30 years
     g3_init_val("project_years", 30) |>
     # Fishing generally occurs in spring/summer, none in winter
@@ -51,6 +75,10 @@ attr(model_fn, "parameter_template") |>
     # Hockefleet: harvest rate & trigger biomass
     g3_init_val("fl.hf.harvest_rate", 0.2) |>
     g3_init_val("fl.hf.btrigger", 7.8e6) |>
+    #
+    g3_init_val("ind_x.hs.target", 20) |>
+    g3_init_val("ind_x.hs.trigger", 100) |>
+    g3_init_val("ind_x.cons.step.#", c(0.1, 0.2, 0.3, 0.4)) |>
     identity() -> params.in
 nll <- model_fn(params.in) ; r <- attributes(nll) ; nll <- as.vector(nll)
 
@@ -118,7 +146,59 @@ ok(ut_cmp_equal(
         r$dstart_st__num * r$dstart_st__wgt * 0.8, "year", step = 4) * tail(r$quota_hockeyfleet_fl__var * 0.1, -1)), -6)),
     tolerance = 1e-7), "detail_st_fl_a__cons[step = 4]: consumption based on quota")
 
+ok(all(tail(head(r$quota_hockeystick_ind_x__var, -1), -1) == params.in$value$ind_x.hs.target), "quota_hockeystick_ind_x__var: All equal to quota target (population not constrained)")
+ok(ut_cmp_equal(
+    as.vector(tail(g3_array_agg(r$detail_st_ind_x__cons / r$dstart_st__wgt, "year", step = 1), -6)),
+    as.vector(tail(to_vect(head(r$quota_hockeystick_ind_x__var * params.in$value$ind_x.cons.step.1, -2)), -6)),
+    tolerance = 1e-7), "detail_st_ind_x__cons[step = 1]: consumption based on quota, individuals-wise")
+ok(ut_cmp_equal(
+    as.vector(tail(g3_array_agg(r$detail_st_ind_x__cons / r$dstart_st__wgt, "year", step = 2), -6)),
+    as.vector(tail(to_vect(head(r$quota_hockeystick_ind_x__var * params.in$value$ind_x.cons.step.2, -2)), -6)),
+    tolerance = 1e-7), "detail_st_ind_x__cons[step = 2]: consumption based on quota, individuals-wise")
+ok(ut_cmp_equal(
+    as.vector(tail(g3_array_agg(r$detail_st_ind_x__cons / r$dstart_st__wgt, "year", step = 3), -6)),
+    as.vector(tail(to_vect(head(r$quota_hockeystick_ind_x__var * params.in$value$ind_x.cons.step.3, -2)), -6)),
+    tolerance = 1e-7), "detail_st_ind_x__cons[step = 3]: consumption based on quota, individuals-wise")
+ok(ut_cmp_equal(
+    as.vector(tail(g3_array_agg(r$detail_st_ind_x__cons / r$dstart_st__wgt, "year", step = 4), -6)),
+    as.vector(tail(to_vect(head(tail(r$quota_hockeystick_ind_x__var * params.in$value$ind_x.cons.step.4, -1), -1)), -6)),
+    tolerance = 1e-7), "detail_st_ind_x__cons[step = 4]: consumption based on quota, individuals-wise")
+
 gadget3:::ut_tmb_r_compare2(model_fn, model_cpp, params.in)
+######## Population above trigger
+
+ok_group("Population falls below trigger (ind)") ########
+attr(model_cpp, "parameter_template") |>
+    # Project for 30 years
+    g3_init_val("project_years", 30) |>
+    # Disable fl_a
+    g3_init_val("fl_a.cons.step.#", 0) |>
+    # Population will fall below btrigger during model
+    g3_init_val("ind_x.hs.target", 100) |>
+    g3_init_val("ind_x.hs.trigger", 8e5) |>
+    g3_init_val("ind_x.cons.step.#", c(0.25, 0.25, 0.5, 0)) |>
+    identity() -> params.in
+nll <- model_fn(params.in) ; r <- attributes(nll) ; nll <- as.vector(nll)
+
+# Individuals are assessed at step 1 each year
+assess_pop <- as.vector(g3_array_agg(r$dstart_st__num, "year", step = 1))
+
+# Remove interim top/tail of quota
+quota_var <- as.vector(head(tail(r$quota_hockeystick_ind_x__var, -1), -1))
+
+full_pop <- as.vector(g3_array_agg(r$dstart_st__num, "year", step = 1) > params.in$value$ind_x.hs.trigger)
+
+ok(any(assess_pop > params.in$value$ind_x.hs.trigger), "quota_hockeystick_ind_x__var: Contains some entries above trigger point")
+ok(any(assess_pop < params.in$value$ind_x.hs.trigger), "quota_hockeystick_ind_x__var: Contains some entries below trigger point")
+ok(ut_cmp_equal(
+    quota_var,
+    pmin(
+        assess_pop / params.in$value$ind_x.hs.trigger * params.in$value$ind_x.hs.target,
+        params.in$value$ind_x.hs.target ),
+    tolerance = 1e-3), "quota_hockeystick_ind_x__var: Matches recalculated version")
+
+gadget3:::ut_tmb_r_compare2(model_fn, model_cpp, params.in)
+######## Population falls below trigger (ind)
 
 ok_group("g3_quota_hockeyfleet: selectivity function preyprop_fs", local({
     g3_suitability_blueling <- function(){


### PR DESCRIPTION
@MikkoVihtakari @vbartolino What do you make of this? The main change is adding a "unit" parameter to ``g3_quota_hockeyfleet``, so you can do things like:

```r
g3_quota_hockeyfleet(fleets, stocks, unit = "biomass-year")
```

What this essentially means is the harvest_rate parameter is in biomass-per-year, rather than a proportion of the whole stock. 

If we do:

```r
g3_quota_hockeyfleet(fleets, stocks, unit = "individuals-year")
```

...then as well as harvest_rate being in individuals-per-year, then we also consider "btrigger" to be in individuals not biomass.

I think these both cover what you're after doing from what I understand? But...

* Is there a case that you'd want "harvest_rate" to be in indivduals-per-year but "btrigger" to still be in biomass (seems pretty unlikely to me)?
* The naming is atrocious. "harvest_rate" may not be a harvest rate, depending on the unit you've set, and "btrigger" may not be a biomass. But OTOH renaming these parameters will create upheaval for existing models.