### PR TITLE
Add g3a_trace_var, revamp debugging vignette

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -83,6 +83,9 @@ export(g3a_spmodel)
 export(g3a_predate_tagrelease)
 export(g3a_tag_shedding)
 
+# R/action_trace.R
+export(g3a_trace_var)
+
 # R/action_order.R
 export(g3_action_order)
 

--- a/R/action_trace.R
+++ b/R/action_trace.R
@@ -1,0 +1,93 @@
+g3a_trace_var <- function (
+        actions,
+        check_finite = TRUE,
+        check_positive = FALSE,
+        check_strictly_positive = FALSE,
+        on_error = c("continue", "browser", "stop"),
+        print_var = FALSE,
+        var_re = c("__num$", "__wgt$")) {
+    out <- new.env(parent = emptyenv())
+    var_re <- paste(var_re, collapse = "|")
+
+    # Convert on_error shortcuts
+    if (is.character(on_error)) on_error <- list(
+        "continue" = quote({}),
+        "browser" = quote(browser()),
+        "stop" = quote(stop()),
+        "end" = NULL )[[match.arg(on_error)]]
+    stopifnot(is.call(on_error))
+
+    # Generate condition to see if var_name fails any checks
+    to_test_code <- function (var_name, var_val) {
+        common <- function (test_c) {
+            test_c <- do.call(substitute, list(test_c, list(var = as.symbol(var_name))))
+            if (is.array(var_val)) test_c <- call("any", test_c)
+            return(test_c)
+        }
+
+        tests <- list()
+        if (isTRUE(check_finite)) tests$check_finite <- common(quote( !is.finite(var) ))
+        if (isTRUE(check_positive)) tests$check_positive <- common(quote( var < 0 ))
+        if (isTRUE(check_strictly_positive)) tests$check_strictly_positive <- common(quote( var <= 0 ))
+
+        return(rlang::f_rhs(f_chain_op(tests, "||")))
+    }
+
+    # Form list of definitions as we would do when compiling
+    collated_actions <- g3_collate(actions)
+    all_actions <- f_concatenate(collated_actions, parent = g3_env, wrap_call = call("while", TRUE))
+    code <- rlang::f_rhs(all_actions)
+    env <- environment(all_actions)
+    all_defns <- mget(all.names(code, unique = TRUE), envir = env, inherits = TRUE, ifnotfound = list(NULL))
+    all_defns <- all_defns[!is.null(all_defns)]
+
+    # Get variables we're interested in
+    target_vars <- all_defns[grep(var_re, names(all_defns))]
+
+    # Make map of var_name to nan_(var_name)
+    nan_var_names <- structure(
+        paste0('nan_', names(target_vars)),
+        names = names(target_vars))
+
+    # Environment for all trace steps, defining nan_vars
+    trace_env <- as.environment(structure(
+        rep(list(g3_global_formula(init_val = FALSE)), length(nan_var_names)),
+        names = nan_var_names ))
+
+    for (action_name in names(collated_actions)) {
+        desc <- step_find_desc(collated_actions[[action_name]], minor_steps = TRUE)
+
+        # Find variables this step alters (no point checking anything else)
+        altered_vars <- intersect(names(target_vars), vapply(
+            f_find(collated_actions[[action_name]], "<-"),
+            function (x) as.character(if (is.call(x[[2]])) x[[2]][[2]] else x[[2]]),
+            character(1) ))
+        if (length(altered_vars) == 0) next  # Nothing to trace, don't add empty step
+
+        # Step to add after current step, checking NaN status for all vars
+        trace_step <- as.call(c(
+            as.symbol("{"),  # }
+            substitute(
+                debug_label(lbl), list(lbl = paste0("g3a_trace_nan: ", desc))),
+            lapply(altered_vars, function (var_name) substitute(
+                if (!nan_var && test_c) {
+                    nan_var <- TRUE
+                    Rprintf(warn_msg, cur_year, cur_step)
+                    if (print_var) print(drop(var_sym))
+                    on_error
+                }, list(
+                    warn_msg = paste0(var_name, " failed test at %d-%d, after '", desc, "'\n"),
+                    test_c = to_test_code(var_name, target_vars[[var_name]]),
+                    nan_var = as.symbol(nan_var_names[[var_name]]),
+                    var_sym = as.symbol(var_name),
+                    print_var = print_var,
+                    on_error = on_error)))))
+
+        # Remove disabled print_var, e.g.
+        trace_step <- f_optimize(trace_step)
+
+        out[[paste0(action_name, ":trace_nan")]] <- call_to_formula(trace_step, env = trace_env)
+    }
+
+    return(as.list(out))
+}

--- a/inttest/codegeneration-defaults/run.R
+++ b/inttest/codegeneration-defaults/run.R
@@ -96,7 +96,7 @@ actions <- c(actions, actions_acoustic, actions_likelihood_acoustic)
 actions_reporting <- list(
   g3a_report_detail(actions),
   # g3a_report_history(actions),
-  # g3experiments:::g3a_trace_nan(actions,  var_re = c("fish__num$", "fish__wgt$")),
+  # g3a_trace_var(actions,  var_re = c("fish__num$", "fish__wgt$")),
   NULL)
 
 actions <- c(actions, actions_reporting)

--- a/man/action_trace.Rd
+++ b/man/action_trace.Rd
@@ -1,0 +1,103 @@
+\name{action_trace}
+\alias{g3a_trace_var}
+\concept{G3 utilities}
+
+\title{Trace value of variables in a G3 model}
+\description{
+  Trace value of variables in a G3 model, warning if conditions are met
+}
+
+\usage{
+g3a_trace_var(
+        actions,
+        check_finite = TRUE,
+        check_positive = FALSE,
+        check_strictly_positive = FALSE,
+        on_error = c("continue", "browser", "stop"),
+        print_var = FALSE,
+        var_re = c("__num$", "__wgt$"))
+}
+
+\arguments{
+  \item{actions}{
+    A list of model actions to add tracing to
+  }
+  \item{check_finite}{Boolean, notify if variable is not finite (i.e. Inf, NA, NaN)}
+  \item{check_positive}{Boolean, notify if variable is < 0}
+  \item{check_strictly_positive}{Boolean, notify if variable is <= 0}
+  \item{on_error}{
+    What to do when a variable fails one of the checks?
+    NB: "browser" will not work in a TMB-compiled model.
+  }
+  \item{print_var}{
+    Boolean, if true print the value of the variable at the point the test fails.
+    NB: This will not work in a TMB-compiled model.
+  }
+  \item{var_re}{
+    Regular expression(s), variable whose name matches will be traced.
+  }
+}
+
+\details{
+  The main reason to use \code{g3a_trace_var} is to find out why a model is producing NaN in reports / likelihood.
+  Adding this to your model will help pinpoint the action this originally occurs in, so you can inspect closer for incorrect settings and/or bugs.
+  
+  \subsection{Suggested \var{var_re} settings}{
+    The \var{var_re} parameter chooses which variables are traced, and should be tweaked to further pinpoint the problem.
+    Generally, once an error has been found, dig into the code (e.g. by doing \code{edit(g3_to_r(actions))}),
+    and see what other variables are available for tracing.
+    Some pre-canned suggestions follow:
+
+    \describe{
+      \item{\code{c("__num$", "__wgt$") (i.e. default)}}{
+        This will trace abundance/weight for all stocks, and a good starting point.
+      }
+      \item{\code{^[stock_name]__(num|wgt|cons|suit|totalpredate|consratio|feedinglevel)$}}{
+        This will, once \code{[stock_name]} is replaced with the name of your stock,
+        dig deeper into the predation mechanisms.
+      }
+    }
+  }
+}
+
+\seealso{
+  \code{\link{g3a_predate_catchability_project}}
+}
+
+\value{
+  \subsection{g3_trace_var}{
+    A list of actions that will report when variables stop being finite (e.g.)
+  }
+}
+
+\examples{
+stocks <- list(
+    st = g3_stock("st", 1:10 * 10) |> g3s_age(1, 5) )
+
+actions <- list(
+    g3a_time(1990, 1995, c(3,3,3,3)),
+    g3a_initialconditions_normalcv(stocks$st),
+    g3a_growmature(stocks$st, impl_f = gadget3::g3a_grow_impl_bbinom(
+        maxlengthgroupgrowth = 2L) ),
+
+    NULL )
+model_fn <- g3_to_r(c(actions,
+    list(g3a_trace_var(actions)),
+    g3a_report_detail(actions) ))
+
+# Configure set of working parameters
+attr(model_fn, "parameter_template") |>
+    g3_init_val("*.K", 0.3) |>
+    g3_init_val("*.t0", 0.2) |>
+    g3_init_val("*.Linf", 80) |>
+    g3_init_val("*.lencv", 0.1) |>
+    g3_init_val("*.walpha", 0.01) |>
+    g3_init_val("*.wbeta", 3) |>
+    g3_init_val("*.M.#", 0.01) |>
+    identity() -> params.in
+nll <- model_fn(params.in) ; r <- attributes(nll) ; nll <- as.vector(nll)
+
+# Try setting parameters to NaN and see what fails:
+r <- model_fn(params.in |> g3_init_val("*.t0", NaN))
+r <- model_fn(params.in |> g3_init_val("*.bbin", NaN))
+}

--- a/tests/test-action_grow-weightjones.R
+++ b/tests/test-action_grow-weightjones.R
@@ -36,7 +36,7 @@ full_actions <- c(actions, list(
     g3a_report_detail(actions),
     g3a_report_history(actions, "__num$|__wgt$", out_prefix="dend_"),  # NB: Late reporting
     g3a_report_history(actions, "quota_", out_prefix = NULL),
-    # g3experiments::g3a_trace_nan(actions, check_positive = TRUE, var_re = c("__wgt$"), on_error = "stop"),
+    # g3a_trace_var(actions, check_positive = TRUE, var_re = c("__wgt$"), on_error = "stop"),
     NULL))
 model_fn <- g3_to_r(full_actions)
 model_cpp <- g3_to_tmb(full_actions)

--- a/vignettes/model-debugging.Rmd
+++ b/vignettes/model-debugging.Rmd
@@ -16,37 +16,63 @@ library(magrittr)
 if (nzchar(Sys.getenv('G3_TEST_TMB'))) options(gadget3.tmb.work_dir = gadget3:::vignette_base_dir('work_dir'))
 ```
 
-## Debugging the R model
+There are several techniques available to help debug problems in gadget3 models.
+The following lists common errors and ways you can investigate further.
 
-In theory, the TMB and R output of gadget3 should be identically-behaving
-functions, so instead of trying to decipher what the TMB model is doing wrong,
-you can use R function instead in a more familiar environment, for example
-using standard tools such as ``options(error=recover)``.
+## Viewing & editing model code
 
-You can also use ``edit()`` to edit the R function directly and re-run the
-model:
+gadget3 models are converted to R or TMB source code, which is often useful to study to see what the model will do at any point.
+It is also possible to edit the source code and e.g. add debugging breaks with ``recover()``.
+
+An R model function can be viewed / edited directly using the R ``edit()`` function:
 
 ```{r, eval=FALSE}
-# Model setup will look something like this
-ling_model <- g3_to_r(...)
+# Create model based on your actions
+model_fn <- g3_to_r(actions)
 
-ling_model <- edit(ling_model) ; ling_model(ling_param)
+# Edit source code & re-run model
+model_fn <- edit(model_fn)
+model_fn(params.in)
 ```
 
-...this is useful if you want to add trace ``print()`` statements around a
-particular part of the model that's failing, e.g. or insert a breakpoint by
-adding a ``recover()`` line.
+The TMB source code could also be inspected using ``edit()``:
 
-## Debugging the TMB model
+```{r, eval=FALSE}
+tmb_model <- g3_to_tmb(actions)
 
-It's possible to have a working R model that doesn't compile using TMB, due to
-the relative strictness of the Eigen array library in comparison to R arrays,
-for example. In which case you'll need to debug the TMB version.
+# Edit source code & re-run model
+tmb_model <- edit(tmb_model)
+obj.fn <- g3_tmb_adfun(tmb_model, params.in, Type = "Fun")
+r <- obj.fn$report()
+```
+As the R & TMB model will be equivalent, you can view the source of whichever you are more comfortable with.
 
-### Preserving your R session whilst building
+## ``NaN`` in likelihood / reports
+
+A non-finite value, once generated, will spread to all related parts of the model,
+so trying to debug by looking at the final result is often useless.
+
+To pinpoint where the problem is, you can add ``g3a_trace_var()`` to find where the problem originates.
+See the manpage for how to use it.
+
+### "Error in optim(...): initial value in 'vmmin' is not finite"
+
+The optimiser is telling you that the initial values you provided do not produce a finite likelihood.
+Add ``g3a_trace_var()`` and run your model outside the optimiser, with e.g:
+
+```{r, eval=FALSE}
+tmb_model <- g3_to_tmb(c(actions, list(
+  g3a_report_detail(actions),
+  g3a_trace_var(actions),
+  gadget3::g3l_bounds_penalty(actions) )))
+obj.fn <- g3_tmb_adfun(tmb_model, params.in, Type = "Fun")
+r <- obj.fn$report()
+```
+
+## TMB model crashes your R session
 
 If the model crashes whilst forming the TMB ADFun object, then it takes your R
-session with it. To prevent this, wrap ``g3_tmb_adfun()`` with
+session with it. If this is happening, wrap ``g3_tmb_adfun()`` with
 ``TMB::gdbsource()`` as follows:
 
 ```{r, eval=FALSE}
@@ -64,29 +90,12 @@ writeLines(TMB::gdbsource(g3_tmb_adfun(
 ``output_script = TRUE`` tells ``g3_tmb_adfun()`` to, after compilation, write
 a temporary R script that will build the TMB ADFun object (and presumably crash
 in the process). ``TMB::gdbsource()`` in turn runs a provided R script in a
-fresh R session wrapped in gdb. By default it will print a stacktrace and quit,
-which should show you where the crash occured.
+fresh R session wrapped in gdb. By default it will print a stacktrace and quit.
 
-### Editing C++ code
+In the stacktrace you should see a line number for where the crash occured.
+You can then look at the TMB model source code, find the line number and thus the action that is currently failing.
 
-As with the R model you can edit the raw C++ source before building:
-
-```{r, eval=FALSE}
-tmb_ling <- edit(tmb_ling)
-writeLines(TMB::gdbsource(g3_tmb_adfun(
-    tmb_ling,
-    tmb_param,
-    compile_flags = "-g",
-    output_script = TRUE)))
-```
-
-Through this you can...
-
-* Print the contents of single values with ``std::cout << ling__Linf << std::endl;``
-* Use ``().cols()`` and ``().rows()`` to get the size of an array expression
-* Print the contents of array objects with ``ling_imm__consratio.print()``
-
-### Interactive debugging
+## Interactive debugging of TMB models
 
 In theory you can use ``interactive = TRUE`` with ``TMB::gdbsource()``, however
 as this eats error messages it's better to do this by hand:
@@ -111,6 +120,10 @@ Array val: -nan -nan -nan -nan -nan
 (gdb) print cur_time
 $5 = 0
 ```
+
+* Print the contents of single values with ``std::cout << ling__Linf << std::endl;``
+* Use ``().cols()`` and ``().rows()`` to get the size of an array expression
+* Print the contents of array objects with ``ling_imm__consratio.print()``
 
 Note that for the ``.print()`` method to be available for arrays, it has to be
 referenced at least once in the model source, otherwise it won't be compiled


### PR DESCRIPTION
Add g3a_trace_var, based on long-running g3experiments::g3a_trace_nan.

Fixes #164 