### PR TITLE
Don't generate TMB ADGrad function if random effects not used

### DIFF
--- a/R/run_tmb.R
+++ b/R/run_tmb.R
@@ -1151,6 +1151,7 @@ g3_tmb_adfun <- function(
         tmb_random <- NULL
     } else {
         tmb_random <- cpp_escape_varname(parameters[parameters$random == TRUE, 'switch'])
+        if (length(tmb_random) == 0) tmb_random <- NULL
     }
 
     if (any(parameters$random & parameters$optimise)) {

--- a/tests/test-run_tmb.R
+++ b/tests/test-run_tmb.R
@@ -1122,8 +1122,9 @@ if (nzchar(Sys.getenv('G3_TEST_TMB'))) {
     model_cpp <- g3_to_tmb(actions, trace = FALSE)
     # model_cpp <- edit(model_cpp)
     w <- capture_warnings(model_tmb <- g3_tmb_adfun(model_cpp, params, compile_flags = c("-O0", "-g")))$warnings
+    ok(length(w) > 2, "g3_tmb_adfun: Generated at least 2 warnings")
     ok(ut_cmp_identical(w, c(
-        rep("No value found in g3_param_table param_table, ifmissing not specified", 10),
+        rep("No value found in g3_param_table param_table, ifmissing not specified", length(w)),
         NULL )), "g3_tmb_adfun: Compiling generated a param_table warning")
 } else {
     writeLines("# skip: not compiling TMB model")


### PR DESCRIPTION
TMB's default for type is:

   type = c("ADFun", "Fun", "ADGrad"[!intern && (!is.null(random) || !is.null(profile))]),

But when there are no random effects we were setting ``random`` to an empty list, not NULL.

This results a noticeable time-saving when taping a non-trivial model that doesn't use random effects (i.e. most of them currently).