### PR TITLE
Add g3a_trace_timings, for investigating relative action speed

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -85,6 +85,7 @@ export(g3a_tag_shedding)
 
 # R/action_trace.R
 export(g3a_trace_var)
+export(g3a_trace_timings)
 
 # R/action_order.R
 export(g3_action_order)

--- a/R/action_renewal.R
+++ b/R/action_renewal.R
@@ -87,7 +87,7 @@ g3a_initialconditions <- function (stock, num_f, wgt_f, run_f = ~cur_time == 0L,
 
     out <- list()
     action_name <- unique_action_name()
-    out[[step_id(run_at, stock, action_name)]] <- g3_step(f_substitute(~{
+    out[[step_id(run_at, "g3a_initialconditions", stock, action_name)]] <- g3_step(f_substitute(~{
         debug_label("g3a_initialconditions for ", stock)
         stock_iterate(stock, if (run_f && renew_into_f) {
             stock_ss(stock__num) <- num_f
@@ -127,7 +127,7 @@ g3a_initialconditions_normalparam <- function (
     # NB: Generate action name with our arguments
     out <- list()
     action_name <- unique_action_name()
-    out[[step_id(run_at, stock, action_name)]] <- g3a_initialconditions(
+    out[[step_id(run_at, "g3a_initialconditions", stock, action_name)]] <- g3a_initialconditions(
         stock,
         num_f = g3a_renewal_len_dnorm(mean_f, stddev_f, factor_f),
         wgt_f = g3a_renewal_wgt_wl(alpha_f, beta_f),
@@ -173,7 +173,7 @@ g3a_renewal <- function (stock, num_f, wgt_f, run_f = ~TRUE, run_at = g3_action_
 
     out <- list()
     action_name <- unique_action_name()
-    out[[step_id(run_at, stock, action_name)]] <- g3_step(f_substitute(~{
+    out[[step_id(run_at, "g3a_renewal", stock, action_name)]] <- g3_step(f_substitute(~{
         debug_label("g3a_renewal for ", stock)
         stock_iterate(stock, if (run_f && renew_into_f) {
             stock_ss(stock__renewalnum) <- num_f
@@ -226,7 +226,7 @@ g3a_renewal_normalparam <- function (
     # NB: Generate action name with our arguments
     out <- list()
     action_name <- unique_action_name()
-    out[[step_id(run_at, stock, action_name)]] <- g3a_renewal(
+    out[[step_id(run_at, "g3a_renewal", stock, action_name)]] <- g3a_renewal(
         stock,
         num_f = g3a_renewal_len_dnorm(mean_f, stddev_f, factor_f),
         wgt_f = g3a_renewal_wgt_wl(alpha_f, beta_f),
@@ -298,7 +298,7 @@ g3a_otherfood <- function (
     }
     out <- list()
     action_name <- unique_action_name()
-    out[[step_id(run_at, stock, action_name)]] <- g3_step(f_substitute(~{
+    out[[step_id(run_at, "g3a_otherfood", stock, action_name)]] <- g3_step(f_substitute(~{
         debug_label("g3a_otherfood for ", stock)
         stock_iterate(stock, if (run_f && renew_into_f) {
             stock_ss(stock__num) <- num_f
@@ -334,7 +334,7 @@ g3a_otherfood_normalparam <- function (
     # NB: Generate action name with our arguments
     out <- list()
     action_name <- unique_action_name()
-    out[[step_id(run_at, stock, action_name)]] <- g3a_otherfood(
+    out[[step_id(run_at, "g3a_otherfood", stock, action_name)]] <- g3a_otherfood(
         stock,
         num_f = g3a_renewal_len_dnorm(mean_f, stddev_f, factor_f),
         wgt_f = g3a_renewal_wgt_wl(alpha_f, beta_f),

--- a/R/action_time.R
+++ b/R/action_time.R
@@ -66,7 +66,7 @@ g3a_time <- function(
     nll <- 0.0
 
     out <- new.env(parent = emptyenv())
-    out[[step_id(run_at)]] <- g3_step(f_substitute(~{
+    out[[step_id(run_at, "-")]] <- g3_step(f_substitute(~{
         debug_label("g3a_time: Start of time period")
         cur_time <- cur_time + 1L
         if (have_retro_years) if (cur_time == 0 && assert_msg(retro_years >= 0, "retro_years must be >= 0")) return(NaN)

--- a/R/run_tmb.R
+++ b/R/run_tmb.R
@@ -213,9 +213,9 @@ cpp_code <- function(in_call, in_envir, indent = "\n    ", statement = FALSE, ex
         # Add += operators if possible
         assign_op <- "="
         if (is.call(assign_rhs)
+                && length(assign_rhs) == 3  # NB: Do this first so x <- y() doesn't trip us up
                 && identical(assign_lhs, assign_rhs[[2]])
-                && as.character(assign_rhs[[1]]) %in% c("+", "-", "*", "/")
-                && length(assign_rhs) == 3) {
+                && as.character(assign_rhs[[1]]) %in% c("+", "-", "*", "/") ) {
             # Operating on iself, use a += operation
             assign_op <- paste0(assign_rhs[[1]], "=")
             assign_rhs <- assign_rhs[[3]]

--- a/man/action_trace.Rd
+++ b/man/action_trace.Rd
@@ -1,10 +1,11 @@
 \name{action_trace}
 \alias{g3a_trace_var}
+\alias{g3a_trace_timings}
 \concept{G3 utilities}
 
-\title{Trace value of variables in a G3 model}
+\title{Tracing and debugging tools}
 \description{
-  Trace value of variables in a G3 model, warning if conditions are met
+  Tracing and debugging tools for a G3 model
 }
 
 \usage{
@@ -16,6 +17,10 @@ g3a_trace_var(
         on_error = c("continue", "browser", "stop"),
         print_var = FALSE,
         var_re = c("__num$", "__wgt$"))
+
+g3a_trace_timings(
+        actions,
+        action_re = NULL )
 }
 
 \arguments{
@@ -35,6 +40,9 @@ g3a_trace_var(
   }
   \item{var_re}{
     Regular expression(s), variable whose name matches will be traced.
+  }
+  \item{action_re}{
+    Regular expression(s), action step IDs that match will be traced (or all if NULL)
   }
 }
 
@@ -58,6 +66,10 @@ g3a_trace_var(
       }
     }
   }
+
+  \code{g3a_trace_timings} will report a variable, \code{trace_timings},
+  with the min/mean/max number of seconds spent computing each step in the model.
+  You can use \code{\link{g3_to_desc}} to extract more descriptive names for each step.
 }
 
 \seealso{
@@ -67,6 +79,9 @@ g3a_trace_var(
 \value{
   \subsection{g3_trace_var}{
     A list of actions that will report when variables stop being finite (e.g.)
+  }
+  \subsection{g3_trace_timings}{
+    A list of actions to report a \code{trace_timings} variable, with how long each step is taking
   }
 }
 
@@ -81,9 +96,10 @@ actions <- list(
         maxlengthgroupgrowth = 2L) ),
 
     NULL )
-model_fn <- g3_to_r(c(actions,
-    list(g3a_trace_var(actions)),
-    g3a_report_detail(actions) ))
+model_fn <- g3_to_r(c(actions, list(
+    g3a_trace_var(actions),
+    g3a_trace_timings(actions),
+    g3a_report_detail(actions) )))
 
 # Configure set of working parameters
 attr(model_fn, "parameter_template") |>
@@ -96,6 +112,12 @@ attr(model_fn, "parameter_template") |>
     g3_init_val("*.M.#", 0.01) |>
     identity() -> params.in
 nll <- model_fn(params.in) ; r <- attributes(nll) ; nll <- as.vector(nll)
+
+# Show timings of each step of model
+r$trace_timings
+
+# Find more informative names with g3_to_desc
+as.list(g3_to_desc(actions))
 
 # Try setting parameters to NaN and see what fails:
 r <- model_fn(params.in |> g3_init_val("*.t0", NaN))

--- a/tests/test-action_trace-timing.R
+++ b/tests/test-action_trace-timing.R
@@ -1,0 +1,72 @@
+if (!interactive()) options(warn=2, error = function() { sink(stderr()) ; traceback(3) ; q(status = 1) })
+library(unittest)
+
+library(gadget3)
+
+comven12 <- g3_fleet("comven12")
+st_imm <- g3_stock(c(species = "st", maturity = "imm"), 1:10 * 10) |> g3s_age(1, 20)
+st_mat <- g3_stock(c(species = "st", maturity = "mat"), 1:10 * 10) |> g3s_age(1, 20)
+stocks_st <- list(st_imm, st_mat)
+
+actions <- list(
+    g3a_time(2000, 2010, step_lengths = c(6,6), project_years = 0),
+    g3a_growmature(st_imm,
+        g3a_grow_impl_bbinom(
+            maxlengthgroupgrowth = 4L ),
+        maturity_f = g3a_mature_continuous(),
+        output_stocks = list(st_mat),
+        transition_f = ~TRUE ),
+    g3a_naturalmortality(st_imm),
+    g3a_initialconditions_normalcv(st_imm),
+    g3a_renewal_normalcv(st_imm),
+    g3a_age(st_imm, output_stocks = list(st_mat)),
+    g3a_growmature(st_mat,
+        g3a_grow_impl_bbinom(
+            maxlengthgroupgrowth = 4L )),
+    g3a_naturalmortality(st_mat),
+    g3a_initialconditions_normalcv(st_mat),
+    g3a_age(st_mat),
+
+    g3a_predate_fleet(
+        fleet_stock = comven12,
+        prey_stocks = stocks_st,
+        suitabilities = g3_suitability_exponentiall50(
+            l50 = g3_timevariable('com.l50', list(
+                "init" = g3_parameterized('com.l50.early'),
+                "2003" = g3_parameterized('com.l50.late') ))),
+        catchability_f = g3a_predate_catchability_totalfleet(100) ),
+    # NB: Only required for testing
+    gadget3:::g3l_test_dummy_likelihood() )
+full_actions <- c(actions, list(
+    gadget3:::g3a_trace_timings(actions),
+    g3a_report_detail(actions) ))
+model_fn <- g3_to_r(full_actions)
+model_cpp <- g3_to_tmb(full_actions)
+
+attr(model_cpp, 'parameter_template') |>
+    g3_init_val("*.K", 0.3, lower = 0.04, upper = 1.2) |>
+    g3_init_val("*.Linf", max(g3_stock_def(st_imm, "midlen")), spread = 0.2) |>
+    g3_init_val("*.t0", g3_stock_def(st_imm, "minage") - 0.8, spread = 2) |>
+    g3_init_val("*.lencv", 0.1, optimise = FALSE) |>
+    g3_init_val("*.walpha", 0.01, optimise = FALSE) |>
+    g3_init_val("*.wbeta", 3, optimise = FALSE) |>
+
+    g3_init_val("*.*.alpha", 1) |>
+    g3_init_val("com.l50.early", 5) |>
+    g3_init_val("com.l50.late", 25) |>
+    identity() -> params.in
+nll <- model_fn(params.in) ; r <- attributes(nll) ; nll <- as.vector(nll)
+
+ok(ut_cmp_identical(
+    unique(strtrim(dimnames(r$trace_timings)[[1]], 4)),
+    c("-01:", "000:", "001", "003:", "004:", "005:", "007:", "008:", "010:", "012:") ), "trace_timings: One dimension is action IDs")
+ok(all(r$trace_timings[,"min"] <= r$trace_timings[,"mean"]), "trace_timings: min less than mean")
+ok(any(r$trace_timings[,"min"] != r$trace_timings[,"mean"]), "trace_timings: some mean/mins don't match")
+ok(all(r$trace_timings[,"mean"] <= r$trace_timings[,"max"]), "trace_timings: mean less than max")
+ok(any(r$trace_timings[,"mean"] != r$trace_timings[,"max"]), "trace_timings: some mean/maxs don't match")
+ok(ut_cmp_equal(
+    r$trace_timings[,"total"] / 22,
+    r$trace_timings[,"mean"]), "trace_timings: total & mean match")
+
+# NB: Arrays only roughly match, obviously timing should be different
+gadget3:::ut_tmb_r_compare2(model_fn, model_cpp, params.in, tolerance = 1e-2)

--- a/tests/test-run_tmb.R
+++ b/tests/test-run_tmb.R
@@ -631,6 +631,16 @@ actions <- c(actions, ~{
 expecteds$assign_right <- assign_subset[,2,2]
 expecteds$assign_leftright <- assign_subset[4,,2]
 
+# NB: The tests for += were tripping up over calls with length < 3
+assign_nullary_fn <- g3_native(function () { return(42.9) }, cpp = '[]() -> double { return 42.9; }')
+assign_nullary_out <- 0.0
+actions <- c(actions, ~{
+    comment('assign_nullary')
+    assign_nullary_out <- assign_nullary_fn()
+    REPORT(assign_nullary_out)
+})
+expecteds$assign_nullary_out <- 42.9
+
 cmp_inf <- array(c(5, Inf), dim = c(2))
 cmp_inf_out <- array(0, dim = c(4))
 actions <- c(actions, ~{


### PR DESCRIPTION
g3a_trace_timings produces an array of time spent in each part of an action. This will be useful when trying to refactor actions to improve performance.