### PR TITLE
Include gadget3 version/SHA in TMB source code #232

### DIFF
--- a/R/run.R
+++ b/R/run.R
@@ -129,3 +129,25 @@ gen_param_tbl_name <- function (base, vals) {
     if (endsWith(base, '_exp')) out <- paste0(out, '_exp')
     return(out)
 }
+
+# Extract version info stored in description
+package_version_info <- function (pkg) {
+    desc <- utils::packageDescription(pkg)
+
+    # https://github.com/r-lib/remotes/blob/main/R/install-github.R#L125-L150
+    if (!is.null(desc$RemoteSha)) return(paste(
+        desc$Version,
+        desc$RemoteSha,
+        sep = "-" ))
+
+    # https://github.com/r-lib/remotes/blob/main/R/install-local.R#L72-L78
+    if (!is.null(desc$RemoteUrl)) return(paste(
+        desc$Version,
+        paste(desc$RemoteType, desc$RemoteUrl, sep = ":"),
+        sep = "-" ))
+
+    return(paste(
+        desc$Version,
+        sep = "-" ))
+}
+# package_version_info("TMB") ; package_version_info("gadgetplots") ; package_version_info("gadget3")

--- a/R/run_tmb.R
+++ b/R/run_tmb.R
@@ -1035,6 +1035,7 @@ Type objective_function<Type>::operator() () {
 
     # Make sure we include TMB
     out <- c(
+        sprintf("// Model generated with gadget3 %s", package_version_info("gadget3")),
         "#include <TMB.hpp>",
         "#include <numeric>",  # Required for std::partial_sum, std::adjacent_difference
         "", out)

--- a/R/test_utils.R
+++ b/R/test_utils.R
@@ -158,7 +158,9 @@ vignette_base_dir <- function (extra) {
 
 vignette_test_output <- function (vign_name, model_code, params.out, tolerance = 1.5e-5) {
     out_base <- vignette_base_dir(vign_name)
-    writeLines(model_code, con = paste0(out_base, ".cpp"))
+    writeLines(
+        grep("// Model generated with", model_code, invert = TRUE, value = TRUE),
+        con = paste0(out_base, ".cpp") )
 
     if (!file.exists(paste0(out_base, '.params'))) {
         # Set baseline optimised params

--- a/inttest/codegeneration-defaults/run.R
+++ b/inttest/codegeneration-defaults/run.R
@@ -111,7 +111,9 @@ writeLines(deparse(model_fn, width.cutoff = 500L), con = 'inttest/codegeneration
 
 # Build and write out TMB-based model
 model_cpp <- g3_to_tmb(actions)
-writeLines(model_cpp, con = 'inttest/codegeneration-defaults/model.cpp')
+writeLines(
+    grep("// Model generated with", model_cpp, invert = TRUE, value = TRUE),
+    con = 'inttest/codegeneration-defaults/model.cpp' )
 
 # Write out default paramter_template
 params <- attr(model_cpp, 'parameter_template')

--- a/inttest/codegeneration/run.R
+++ b/inttest/codegeneration/run.R
@@ -193,7 +193,9 @@ model_cpp <- g3_to_tmb(c(
     igfs_actions,
     likelihood_actions,
     time), strict = TRUE)
-writeLines(model_cpp, con = 'inttest/codegeneration/ling.cpp')
+writeLines(
+    grep("// Model generated with", model_cpp, invert = TRUE, value = TRUE),
+    con = 'inttest/codegeneration/ling.cpp')
 
 # model_cpp <- edit(model_cpp)
 tmb_param <- attr(model_cpp, 'parameter_template')


### PR DESCRIPTION
As suggested in #232, include the gadget3 version used to generate a model in the code.

As well as being informative, it'll also change the hash of the source when changing gadget3 versions, although this only works if you've used remotes::install_github().

Unfortunately, ``remotes::install_local()`` doesn't note a SHA, it won't work in that case, but still useful.