### PR TITLE
Add g3_tmb_fn(), for projection runs & similar

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -166,6 +166,7 @@ S3method(print, g3_r)
 # R/run_tmb.R
 export(g3_to_tmb)
 export(g3_tmb_adfun)
+export(g3_tmb_fn)
 S3method(edit, g3_cpp)
 S3method(print, g3_cpp)
 export(g3_tmb_par)

--- a/R/run_tmb.R
+++ b/R/run_tmb.R
@@ -1094,6 +1094,7 @@ g3_tmb_adfun <- function(
             framework = getOption("gadget3.tmb.framework", default = "TMBad") ),
         ...) {
     model_params <- attr(cpp_code, 'parameter_template')
+    if ("Type" %in% ...names()) warning("'Type' isn't a TMB::MakeADFun parameter, use 'type'")
 
     if (!dir.exists(work_dir)) dir.create(work_dir, showWarnings = FALSE, recursive = TRUE)
 

--- a/R/test_utils.R
+++ b/R/test_utils.R
@@ -21,6 +21,7 @@ ut_tmb_r_compare2 <- function (
         params,
         g3_test_tmb = 1,
         gdbsource = FALSE,
+        test_tmb_fn = TRUE,
         tolerance = 1e-5 ) {
     dearray <- function (x) {
         # TMB Will produce 0/1 for TRUE/FALSE
@@ -79,6 +80,19 @@ ut_tmb_r_compare2 <- function (
             dearray(model_tmb_report[[n]]),
             dearray(attr(r_result, n)),
             tolerance = tolerance), paste("TMB and R match", n))
+    }
+
+    if (test_tmb_fn) {
+        tmb_fn <- g3_tmb_fn(model_cpp, work_dir = work_dir, compile_flags = c("-O0", "-g"))
+        # NB: Either raw values or a parameter template should work, choose one at random
+        tmb_fn_report <- tmb_fn(if (stats::runif(1) < 0.5) param_template$value else param_template)
+
+        for (n in names(attributes(r_result))) {
+            unittest::ok(unittest::ut_cmp_equal(
+                dearray(model_tmb_report[[n]]),
+                dearray(attr(r_result, n)),
+                tolerance = tolerance), paste("TMBfn and R match", n))
+        }
     }
 }
 

--- a/man/run_tmb.Rd
+++ b/man/run_tmb.Rd
@@ -1,6 +1,7 @@
 \name{run_tmb}
 \alias{g3_to_tmb}
 \alias{g3_tmb_adfun}
+\alias{g3_tmb_fn}
 \alias{g3_tmb_par}
 \alias{g3_tmb_lower}
 \alias{g3_tmb_upper}
@@ -27,6 +28,11 @@ g3_tmb_adfun(
         compile_args = list(
             framework = getOption("gadget3.tmb.framework", default = "TMBad") ),
         ...)
+
+g3_tmb_fn(
+        cpp_code,
+        parameters = attr(cpp_code, 'parameter_template'),
+        ... )
 
 g3_tmb_par(parameters, include_random = TRUE)
 
@@ -89,6 +95,7 @@ g3_tmb_relist(parameters, par)
   }
   \item{...}{
     Any other options handed directly to \link[TMB:MakeADFun]{MakeADFun}
+    or \code{\link{g3_tmb_adfun}} (for \code{\link{g3_tmb_fn}}).
   }
 }
 
@@ -100,6 +107,13 @@ g3_tmb_relist(parameters, par)
 
     If \link[TMB:MakeADFun]{MakeADFun} is crashing your R session, then you can use \var{output_script} to run
     in a separate R session. Use this with \link[TMB:gdbsource]{gdbsource} to debug your model.
+  }
+  \subsection{g3_tmb_fn}{
+    Wraps \code{\link{g3_tmb_adfun}} to produce a function suitable for single model runs or projection, like \code{\link{g3_to_r}}.
+    \var{optimise} & \var{random} are ignored, instead all values from the provided parameters will be used when calling the function.
+
+    Internally it uses \code{obj.fn$simulate}, so the R RNG is updated after the run is finished
+    (i.e. successive runs will produce different answers).
   }
 }
 
@@ -114,6 +128,12 @@ g3_tmb_relist(parameters, par)
     Use e.g. \code{attr(cpp_code, 'parameter_template')} to retrieve them.
   }
   \subsection{g3_tmb_adfun}{An ADFun as produced by TMB's \link[TMB:MakeADFun]{MakeADFun}, or location of temporary script if \var{output_script} is TRUE}
+  \subsection{g3_tmb_fn}{
+    An R function with the signature \code{function (par = NULL)}, where:
+    \var{par} can be \code{NULL} (use default parameter values), a parameter template \code{\link{data.frame}}, or a parameter list.
+
+    Returns a list with all report variables.
+  }
   \subsection{g3_tmb_par}{Values extracted from \var{parameters} table converted into a vector of values for \code{obj$fn(par)} or \code{nlminb}}
   \subsection{g3_tmb_lower}{Lower bounds extracted from \var{parameters} table converted into a vector of values for \code{nlminb}. Random parameters are always excluded}
   \subsection{g3_tmb_upper}{Lower bounds extracted from \var{parameters} table converted into a vector of values for \code{nlminb}. Random parameters are always excluded}
@@ -234,13 +254,24 @@ if (!( nzchar(Sys.getenv('GITHUB_CI')) && .Platform$OS.type == "windows" )) {
 }
 
 if (!( nzchar(Sys.getenv('GITHUB_CI')) && .Platform$OS.type == "windows" )) {
+  # Rebuild a simple function version for projection
+  proj.fn <- g3_tmb_fn(cpp)
+
+  # Get the reported results from a single run
+  result <- proj.fn(tmb_param)
+}
+
+if (!( nzchar(Sys.getenv('GITHUB_CI')) && .Platform$OS.type == "windows" )) {
+  # We can do similar to g3_tmb_fn() by using g3_tmb_adfun() directly
+
   # Rebuild, only including "Fun" (i.e. without auto-differentiation)
   # Result will only work for tmb$report
-  tmb <- g3_tmb_adfun(cpp, tmb_param, type = "Fun")
-  result <- tmb$report(g3_tmb_par(tmb_param, include_random = TRUE))
+  # NB: Only parameters with optimise=TRUE can be varied
+  obj.fn <- g3_tmb_adfun(cpp, tmb_param, type = "Fun")
+  result <- obj.fn$report(g3_tmb_par(tmb_param, include_random = TRUE))
 
-  # We can also use tmb$simulate
-  result <- tmb$simulate(g3_tmb_par(tmb_param, include_random = TRUE))
+  # We can also use obj.fn$simulate
+  result <- obj.fn$simulate(g3_tmb_par(tmb_param, include_random = TRUE))
 
   # NB: Before running simulations, you should use set.seed() to ensure random output
 }


### PR DESCRIPTION
Creating a TMB function to do simulation & other single runs directly is awkward.

* Only parameters that are being optimised can vary without recreating the objective function
* Random effect parameters complicate what needs to be added to ``par``

Make a wrapper to simplify this, resulting in a function that can be treated like the R model. Hand parameter list/data.frame in, get report back.

It also uses ``$simulate()`` instead of ``$report()``, as then successive runs result in different results. Generally one would set the seed before calling the function anyway, but IMO this is more intuitive.