### PR TITLE
Separate lastx to it's own parameter, off by default, in g3_param_project_*ar1

### DIFF
--- a/man/param_project.Rd
+++ b/man/param_project.Rd
@@ -48,8 +48,9 @@ g3_param_project_ar1(
             prepend_extra = quote(param_name) ),
         level_f = g3_parameterized(
             "proj.ar1.level",
-            value = -1, optimise = FALSE,
-            prepend_extra = quote(param_name) ))
+            value = 0,
+            prepend_extra = quote(param_name) ),
+        lastx_f = 0L)
 
 g3_param_project_logar1(
         logphi_f = g3_parameterized(
@@ -62,8 +63,9 @@ g3_param_project_logar1(
             prepend_extra = quote(param_name) ),
         loglevel_f = g3_parameterized(
             "proj.logar1.loglevel",
-            value = -1, optimise = FALSE,
-            prepend_extra = quote(param_name) ))
+            value = 0,
+            prepend_extra = quote(param_name) ),
+        lastx_f = 0L)
 
 g3_param_project(
         param_name,
@@ -85,9 +87,12 @@ g3_param_project(
   }
   \item{level_f, loglevel_f}{
     (logspace) level (or offset) applied on top of ar1/logar1 regression.
-    If negative, use the mean of the last (x) non-projection values as (log)level.
     Defaults to parameter with name \code{(by_stock).(param_name).proj.(level|loglevel)},
-    which itself defaults to -1 (i.e. use the last non-projection value)
+  }
+  \item{lastx_f}{
+    If \code{> 0}, the setting of \var{level_f} / \var{loglevel_f} will be ignored,
+    and the mean of the last (x) non-projection values are used as (log)level.
+    Defaults to 0L, i.e. disabled.
   }
   \item{param_name}{
     Character string used to name the parameters.

--- a/tests/test-param_project-ar1.R
+++ b/tests/test-param_project-ar1.R
@@ -41,46 +41,6 @@ full_actions <- c(actions, list(
 model_fn <- g3_to_r(full_actions)
 model_cpp <- g3_to_tmb(full_actions)
 
-ok_group("No noise") ##########################################################
-
-attr(model_fn, 'parameter_template') |>
-    g3_init_val("stst.rec.#", rnorm(5, 1e5, 500)) |>
-    g3_init_val("stst.rec.proj.ar1.stddev", 0) |>  # i.e. no noise
-    g3_init_val("stst.rec.proj.ar1.phi", 0.8) |>
-    g3_init_val("stst_mat.spawn.blim", 1e2) |>  # blim too low to trigger
-
-    g3_init_val("*.K", 0.3, lower = 0.04, upper = 1.2) |>
-    g3_init_val("*.Linf", max(g3_stock_def(st_imm, "midlen")), spread = 0.2) |>
-    g3_init_val("*.t0", g3_stock_def(st_imm, "minage") - 0.8, spread = 2) |>
-    g3_init_val("*.walpha", 0.01, optimise = FALSE) |>
-    g3_init_val("*.wbeta", 3, optimise = FALSE) |>
-
-    g3_init_val("project_years", 100) |>
-    identity() -> params.in
-nll <- model_fn(params.in) ; r <- attributes(nll) ; nll <- as.vector(nll)
-
-ok(ut_cmp_equal(
-    as.vector(tail(r$proj_ar1_stst_rec__var, -4)),
-    as.vector(rep(r$proj_ar1_stst_rec__var["1994"], 101)),
-    end = NULL), "r$proj_ar1_stst_rec__var: Projected values just repeat final non-projected value")
-ok(ut_cmp_equal(
-    as.vector( g3_array_agg(r$detail_stst_imm__spawnednum, c("year"), step = 1, age = 0) ),
-    as.vector( r$proj_ar1_stst_rec__var ),
-    end = NULL), "r$detail_stst_imm__spawnednum: projection variable used for recruitment")
-
-ok(ut_cmp_equal(nll, sum(r$proj_ar1_stst_rec__nll)), "nll: Consistent with r$proj_ar1_stst_rec__nll")
-ok(ut_cmp_equal(
-    as.vector(r$proj_ar1_stst_rec__nll),
-    as.vector(c(0, -dnorm(
-        tail(r$proj_ar1_stst_rec__var, -1) -
-        0.8 * head(r$proj_ar1_stst_rec__var, -1) -
-        0.2 * 0, # Level would be negative
-        0,
-        1e-7,  # Minimum stddev, so we don't return Inf
-        1 )))), "r$proj_ar1_stst_rec__nll: Consistent with proj_ar1_stst_rec__var, not accounting for level, minimum stddev")
-
-gadget3:::ut_tmb_r_compare2(model_fn, model_cpp, params.in)
-
 ok_group("No noise, fixed loglevel") ##########################################
 
 attr(model_fn, 'parameter_template') |>
@@ -112,46 +72,13 @@ ok(ut_cmp_equal(
         1 )))), "r$proj_ar1_stst_rec__nll: Consistent with proj_ar1_stst_rec__var, use minimum stddev, account for level")
 
 ok(ut_cmp_equal(
+    as.vector( g3_array_agg(r$detail_stst_imm__spawnednum, c("year"), step = 1, age = 0) ),
+    as.vector( r$proj_ar1_stst_rec__var ),
+    end = NULL), "r$detail_stst_imm__spawnednum: projection variable used for recruitment")
+ok(ut_cmp_equal(
     as.vector(tail(r$proj_ar1_stst_rec__var, 5)),
     rep(params.in$stst.rec.proj.ar1.level, 5),
     end = NULL ), "proj_ar1_stst_rec__var: Settles to loglevel in projection, regardless of initial value")
-
-gadget3:::ut_tmb_r_compare2(model_fn, model_cpp, params.in)
-
-ok_group("No noise, last 3 values as loglevel") ###############################
-
-attr(model_fn, 'parameter_template') |>
-    g3_init_val("stst.rec.#", rnorm(5, 1e5, 500)) |>
-    g3_init_val("stst.rec.proj.ar1.stddev", 0) |>  # i.e. no noise
-    g3_init_val("stst.rec.proj.ar1.phi", 0.8) |>
-    g3_init_val("stst.rec.proj.ar1.level", -3) |>
-    g3_init_val("stst_mat.spawn.blim", 1e2) |>  # blim too low to trigger
-
-    g3_init_val("*.K", 0.3, lower = 0.04, upper = 1.2) |>
-    g3_init_val("*.Linf", max(g3_stock_def(st_imm, "midlen")), spread = 0.2) |>
-    g3_init_val("*.t0", g3_stock_def(st_imm, "minage") - 0.8, spread = 2) |>
-    g3_init_val("*.walpha", 0.01, optimise = FALSE) |>
-    g3_init_val("*.wbeta", 3, optimise = FALSE) |>
-
-    g3_init_val("project_years", 200) |>
-    identity() -> params.in
-nll <- model_fn(params.in) ; r <- attributes(nll) ; nll <- as.vector(nll)
-
-ok(ut_cmp_equal(
-    as.vector(tail(r$proj_ar1_stst_rec__var, 10)),
-    rep( mean(r$proj_ar1_stst_rec__var[c("1992", "1993", "1994")]), 10),
-    tolerance = 5e-5 ), "proj_ar1_stst_rec__var: Settles to loglevel matching mean of last 3 values")
-
-ok(ut_cmp_equal(nll, sum(r$proj_ar1_stst_rec__nll)), "nll: Consistent with r$proj_ar1_stst_rec__nll")
-ok(ut_cmp_equal(
-    as.vector(r$proj_ar1_stst_rec__nll),
-    as.vector(c(0, -dnorm(
-        tail(r$proj_ar1_stst_rec__var, -1) -
-        0.8 * head(r$proj_ar1_stst_rec__var, -1) -
-        0.2 * 0, # Level would be negative
-        0,
-        1e-7,  # NB: Used hard-coded minimum stddev
-        1 )))), "r$proj_ar1_stst_rec__nll: Consistent with proj_ar1_stst_rec__var, use minimum stddev, level not included as < 0")
 
 gadget3:::ut_tmb_r_compare2(model_fn, model_cpp, params.in)
 
@@ -163,8 +90,8 @@ attr(model_fn, 'parameter_template') |>
     g3_init_val("stst.rec.#", rnorm(5, 1e5, 500)) |>
     g3_init_val("stst.rec.proj.ar1.stddev", 0.1) |>
     g3_init_val("stst.rec.proj.ar1.phi", 0.8) |>
+    g3_init_val("stst.rec.proj.ar1.level", 1e5) |>
     g3_init_val("stst_mat.spawn.blim", 1e2) |>  # blim too low to trigger
-    # NB: level defaults to -1
 
     g3_init_val("*.K", 0.3, lower = 0.04, upper = 1.2) |>
     g3_init_val("*.Linf", max(g3_stock_def(st_imm, "midlen")), spread = 0.2) |>
@@ -183,10 +110,10 @@ ok(ut_cmp_equal(
     as.vector(c(0, -dnorm(
         tail(r$proj_ar1_stst_rec__var, -1) -
         0.8 * head(r$proj_ar1_stst_rec__var, -1) -
-        0.2 * 0, # Level would be negative
+        0.2 * params.in[["stst.rec.proj.ar1.level"]],
         0,
         0.1,
-        1 )))), "r$proj_ar1_stst_rec__nll: Consistent with proj_ar1_stst_rec__var, not accounting for level")
+        1 )))), "r$proj_ar1_stst_rec__nll: Consistent with proj_ar1_stst_rec__var")
 
 gadget3:::ut_tmb_r_compare2(model_fn, model_cpp, params.in)
 
@@ -195,7 +122,7 @@ ok_group("With noise") ########################################################
 attr(model_fn, 'parameter_template') |>
     g3_init_val("stst.rec.#", rnorm(5, 1e5, 500)) |>
     g3_init_val("stst.rec.proj.ar1.stddev", 1) |>
-    g3_init_val("stst.rec.proj.ar1.level", -4) |>
+    g3_init_val("stst.rec.proj.ar1.level", 1e5) |>
     g3_init_val("stst.rec.proj.ar1.phi", 0.8) |>
     g3_init_val("stst_mat.spawn.blim", 1e2) |>  # blim too low to trigger
 
@@ -222,7 +149,75 @@ ok(ut_cmp_equal(
     as.vector(c(0, -dnorm(
         tail(r$proj_ar1_stst_rec__var, -1) -
         0.8 * head(r$proj_ar1_stst_rec__var, -1) -
-        0.2 * 0, # Level would be negative
+        0.2 * params.in[["stst.rec.proj.ar1.level"]],
         0,
         params.in[["stst.rec.proj.ar1.stddev"]],
-        1 )))), "r$proj_ar1_stst_rec__nll: Consistent with proj_ar1_stst_rec__var, not accounting for level")
+        1 )))), "r$proj_ar1_stst_rec__nll: Consistent with proj_ar1_stst_rec__var")
+
+ok_group("lastx mode", local({ ################################################
+
+    st_imm <- g3_stock(c("stst", maturity = "imm"), c(10, 20, 30)) |> g3s_age(0, 5)
+    st_mat <- g3_stock(c("stst", maturity = "mat"), c(10, 20, 30)) |> g3s_age(3, 15)
+    stocks_st <- list(st_imm, st_mat)
+    fl <- g3_fleet(c("fl", "surv"))
+
+    actions <- list(
+        g3a_time(1990, 1994, c(6,6)),
+        g3a_initialconditions(st_imm,
+            quote( 100 + stock__minlen ),
+            quote( 1e4 + 0 * stock__minlen ) ),
+        g3a_initialconditions(st_mat,
+            quote( 100 + stock__minlen ),
+            quote( 1e4 + 0 * stock__minlen ) ),
+        g3a_age(st_imm),
+        g3a_age(st_mat),
+
+        g3a_spawn(
+            st_mat,
+            g3a_spawn_recruitment_hockeystick(
+                r0 = g3_param_project(
+                    "rec",
+                    g3_param_project_ar1(lastx_f = g3_parameterized("lastx", value = 2)),
+                    random = FALSE,
+                    scale = "rec.scalar",
+                    by_stock = stocks_st,
+                    by_step = FALSE )),
+                output_stocks = list(st_imm),
+                run_step = 1 ),
+
+        # NB: Only required for testing
+        gadget3:::g3l_test_dummy_likelihood() )
+    full_actions <- c(actions, list(
+        g3a_report_detail(actions),
+        g3a_report_history(actions, 'proj_.*', out_prefix = NULL),
+        NULL))
+    model_fn <- g3_to_r(full_actions)
+    model_cpp <- g3_to_tmb(full_actions)
+
+    attr(model_fn, 'parameter_template') |>
+        g3_init_val("stst.rec.#", rnorm(5, 1e5, 500)) |>
+        g3_init_val("stst.rec.proj.ar1.stddev", 0) |>  # i.e. no noise
+        g3_init_val("stst.rec.proj.ar1.phi", 0) |>
+        g3_init_val("stst_mat.spawn.blim", 1e2) |>  # blim too low to trigger
+        g3_init_val("lastx", floor(runif(1, 1, 4))) |>
+
+        g3_init_val("*.K", 0.3, lower = 0.04, upper = 1.2) |>
+        g3_init_val("*.Linf", max(g3_stock_def(st_imm, "midlen")), spread = 0.2) |>
+        g3_init_val("*.t0", g3_stock_def(st_imm, "minage") - 0.8, spread = 2) |>
+        g3_init_val("*.walpha", 0.01, optimise = FALSE) |>
+        g3_init_val("*.wbeta", 3, optimise = FALSE) |>
+
+        g3_init_val("project_years", 100) |>
+        identity() -> params.in
+    nll <- model_fn(params.in) ; r <- attributes(nll) ; nll <- as.vector(nll)
+
+    ok(!("stst.rec.proj.ar1.level" %in% names(params.in)), "level parameter disabled")
+
+    ok(ut_cmp_equal(nll, sum(r$proj_ar1_stst_rec__nll)), "nll: Consistent with r$proj_ar1_stst_rec__nll (sums to same values)")
+    ok(ut_cmp_equal(
+        as.vector( r$proj_ar1_stst_rec__var[length(r$proj_ar1_stst_rec__var)] ),
+        as.vector( mean(r$proj_ar1_stst_rec__var[as.character(seq(1994 - params.in$lastx + 1, 1994))]) ),
+        tolerance = 1e-6 ), paste0("proj_ar1_stst_rec__var: Settled to mean of lastx (", params.in$lastx, ")"))
+
+    gadget3:::ut_tmb_r_compare2(model_fn, model_cpp, params.in)
+}))

--- a/tests/test-param_project-logar1.R
+++ b/tests/test-param_project-logar1.R
@@ -41,47 +41,6 @@ full_actions <- c(actions, list(
 model_fn <- g3_to_r(full_actions)
 model_cpp <- g3_to_tmb(full_actions)
 
-ok_group("No noise") ##########################################################
-
-attr(model_fn, 'parameter_template') |>
-    g3_init_val("stst.rec.#", rnorm(5, 1e5, 500)) |>
-    g3_init_val("stst.rec.proj.logar1.lstddev", -1e6) |>  # i.e. no noise
-    g3_init_val("stst.rec.proj.logar1.logphi", 0.8) |>
-    g3_init_val("stst_mat.spawn.blim", 1e2) |>  # blim too low to trigger
-
-    g3_init_val("*.K", 0.3, lower = 0.04, upper = 1.2) |>
-    g3_init_val("*.Linf", max(g3_stock_def(st_imm, "midlen")), spread = 0.2) |>
-    g3_init_val("*.t0", g3_stock_def(st_imm, "minage") - 0.8, spread = 2) |>
-    g3_init_val("*.walpha", 0.01, optimise = FALSE) |>
-    g3_init_val("*.wbeta", 3, optimise = FALSE) |>
-
-    g3_init_val("project_years", 100) |>
-    identity() -> params.in
-nll <- model_fn(params.in) ; r <- attributes(nll) ; nll <- as.vector(nll)
-
-ok(ut_cmp_equal(
-    as.vector(tail(r$proj_logar1_stst_rec__var, -4)),
-    as.vector(rep(r$proj_logar1_stst_rec__var["1994"], 101)),
-    end = NULL), "r$proj_logar1_stst_rec__var: Projected values just repeat final non-projected value")
-ok(ut_cmp_equal(
-    as.vector( g3_array_agg(r$detail_stst_imm__spawnednum, c("year"), step = 1, age = 0) ),
-    as.vector( r$proj_logar1_stst_rec__var ),
-    end = NULL), "r$detail_stst_imm__spawnednum: projection variable used for recruitment")
-
-ok(ut_cmp_equal(nll, sum(r$proj_logar1_stst_rec__nll)), "nll: Consistent with r$proj_logar1_stst_rec__nll (sums to same values)")
-ok(ut_cmp_equal(
-    as.vector(r$proj_logar1_stst_rec__nll),
-    as.vector(c(0, -dnorm(
-        tail(log(r$proj_logar1_stst_rec__var), -1) -
-        0.8 * head(log(r$proj_logar1_stst_rec__var), -1) -
-        0.2 * 0,  # level not accounted for as it's negative
-        0 - exp(2*-exp(params.in[["stst.rec.proj.logar1.lstddev"]])) / 2,
-        1e-7,  # i.e. using hard-coded minimum stddev
-        1 ))),
-    tolerance = 1e7), "r$proj_logar1_stst_rec__nll: Consistent with proj_logar1_stst_rec__var, level not accounted for, minimum stddev")
-
-gadget3:::ut_tmb_r_compare2(model_fn, model_cpp, params.in)
-
 ok_group("No noise, fixed loglevel") ##########################################
 
 attr(model_fn, 'parameter_template') |>
@@ -105,6 +64,10 @@ ok(ut_cmp_equal(
     as.vector(tail(r$proj_logar1_stst_rec__var, 10)),
     rep(exp(params.in$stst.rec.proj.logar1.loglevel), 10),
     end = NULL ), "proj_logar1_stst_rec__var: Settles to loglevel in projection, regardless of initial value")
+ok(ut_cmp_equal(
+    as.vector( g3_array_agg(r$detail_stst_imm__spawnednum, c("year"), step = 1, age = 0) ),
+    as.vector( r$proj_logar1_stst_rec__var ),
+    end = NULL), "r$detail_stst_imm__spawnednum: projection variable used for recruitment")
 
 ok(ut_cmp_equal(nll, sum(r$proj_logar1_stst_rec__nll)), "nll: Consistent with r$proj_logar1_stst_rec__nll (sums to same values)")
 ok(ut_cmp_equal(
@@ -113,44 +76,6 @@ ok(ut_cmp_equal(
         tail(log(r$proj_logar1_stst_rec__var), -1) -
         0.8 * head(log(r$proj_logar1_stst_rec__var), -1) -
         0.2 * params.in[["stst.rec.proj.logar1.loglevel"]],
-        0 - exp(2*-exp(params.in[["stst.rec.proj.logar1.lstddev"]])) / 2,
-        1e-7,  # i.e. using hard-coded minimum stddev
-        1 ))),
-    tolerance = 1e7), "r$proj_logar1_stst_rec__nll: Consistent with proj_logar1_stst_rec__var, minimum stddev")
-
-gadget3:::ut_tmb_r_compare2(model_fn, model_cpp, params.in)
-
-ok_group("No noise, last 3 values as loglevel") ###############################
-
-attr(model_fn, 'parameter_template') |>
-    g3_init_val("stst.rec.#", rnorm(5, 1e5, 500)) |>
-    g3_init_val("stst.rec.proj.logar1.lstddev", -1e6) |>  # i.e. no noise
-    g3_init_val("stst.rec.proj.logar1.logphi", 0.8) |>
-    g3_init_val("stst.rec.proj.logar1.loglevel", -3) |>
-    g3_init_val("stst_mat.spawn.blim", 1e2) |>  # blim too low to trigger
-
-    g3_init_val("*.K", 0.3, lower = 0.04, upper = 1.2) |>
-    g3_init_val("*.Linf", max(g3_stock_def(st_imm, "midlen")), spread = 0.2) |>
-    g3_init_val("*.t0", g3_stock_def(st_imm, "minage") - 0.8, spread = 2) |>
-    g3_init_val("*.walpha", 0.01, optimise = FALSE) |>
-    g3_init_val("*.wbeta", 3, optimise = FALSE) |>
-
-    g3_init_val("project_years", 100) |>
-    identity() -> params.in
-nll <- model_fn(params.in) ; r <- attributes(nll) ; nll <- as.vector(nll)
-
-ok(ut_cmp_equal(
-    as.vector(tail(r$proj_logar1_stst_rec__var, 10)),
-    rep( mean(r$proj_logar1_stst_rec__var[c("1992", "1993", "1994")]), 10),
-    tolerance = 5e-5 ), "proj_logar1_stst_rec__var: Settles to loglevel matching mean of last 3 values")
-
-ok(ut_cmp_equal(nll, sum(r$proj_logar1_stst_rec__nll)), "nll: Consistent with r$proj_logar1_stst_rec__nll (sums to same values)")
-ok(ut_cmp_equal(
-    as.vector(r$proj_logar1_stst_rec__nll),
-    as.vector(c(0, -dnorm(
-        tail(log(r$proj_logar1_stst_rec__var), -1) -
-        0.8 * head(log(r$proj_logar1_stst_rec__var), -1) -
-        0.2 * 0,  # Not accounting for loglevel
         0 - exp(2*-exp(params.in[["stst.rec.proj.logar1.lstddev"]])) / 2,
         1e-7,  # i.e. using hard-coded minimum stddev
         1 ))),
@@ -199,6 +124,7 @@ attr(model_fn, 'parameter_template') |>
     g3_init_val("stst.rec.#", rnorm(5, 1e5, 500)) |>
     g3_init_val("stst.rec.proj.logar1.lstddev", -8) |>
     g3_init_val("stst.rec.proj.logar1.logphi", 0.8) |>
+    g3_init_val("stst.rec.proj.logar1.loglevel", log(1e5)) |>
     g3_init_val("stst_mat.spawn.blim", 1e2) |>  # blim too low to trigger
 
     g3_init_val("*.K", 0.3, lower = 0.04, upper = 1.2) |>
@@ -224,10 +150,78 @@ ok(ut_cmp_equal(
     as.vector(c(0, -dnorm(
         tail(log(r$proj_logar1_stst_rec__var), -1) -
         0.8 * head(log(r$proj_logar1_stst_rec__var), -1) -
-        0.2 * 0,  # level not accounted for as it's negative
+        0.2 * params.in[["stst.rec.proj.logar1.loglevel"]],
         0 - exp(2*-exp(params.in[["stst.rec.proj.logar1.lstddev"]])) / 2,
         exp(params.in[["stst.rec.proj.logar1.lstddev"]]),
         1 ))),
-    tolerance = 1e7), "r$proj_logar1_stst_rec__nll: Consistent with proj_logar1_stst_rec__var, level not accounted for")
+    tolerance = 1e7), "r$proj_logar1_stst_rec__nll: Consistent with proj_logar1_stst_rec__var")
 
 # plot(r$proj_logar1_stst_rec__var)
+
+ok_group("lastx mode", local({ ################################################
+
+    st_imm <- g3_stock(c("stst", maturity = "imm"), c(10, 20, 30)) |> g3s_age(0, 5)
+    st_mat <- g3_stock(c("stst", maturity = "mat"), c(10, 20, 30)) |> g3s_age(3, 15)
+    stocks_st <- list(st_imm, st_mat)
+    fl <- g3_fleet(c("fl", "surv"))
+
+    actions <- list(
+        g3a_time(1990, 1994, c(6,6)),
+        g3a_initialconditions(st_imm,
+            quote( 100 + stock__minlen ),
+            quote( 1e4 + 0 * stock__minlen ) ),
+        g3a_initialconditions(st_mat,
+            quote( 100 + stock__minlen ),
+            quote( 1e4 + 0 * stock__minlen ) ),
+        g3a_age(st_imm),
+        g3a_age(st_mat),
+
+        g3a_spawn(
+            st_mat,
+            g3a_spawn_recruitment_hockeystick(
+                r0 = g3_param_project(
+                    "rec",
+                    g3_param_project_logar1(lastx_f = g3_parameterized("lastx", value = 2)),
+                    random = FALSE,
+                    scale = "rec.scalar",
+                    by_stock = stocks_st,
+                    by_step = FALSE )),
+                output_stocks = list(st_imm),
+                run_step = 1 ),
+
+        # NB: Only required for testing
+        gadget3:::g3l_test_dummy_likelihood() )
+    full_actions <- c(actions, list(
+        g3a_report_detail(actions),
+        g3a_report_history(actions, 'proj_.*', out_prefix = NULL),
+        NULL))
+    model_fn <- g3_to_r(full_actions)
+    model_cpp <- g3_to_tmb(full_actions)
+
+    attr(model_fn, 'parameter_template') |>
+        g3_init_val("stst.rec.#", rnorm(5, 1e5, 500)) |>
+        g3_init_val("stst.rec.proj.logar1.lstddev", -1e6) |>  # i.e. no noise
+        g3_init_val("stst.rec.proj.logar1.logphi", 0) |>
+        g3_init_val("stst_mat.spawn.blim", 1e2) |>  # blim too low to trigger
+        g3_init_val("lastx", floor(runif(1, 1, 4))) |>
+
+        g3_init_val("*.K", 0.3, lower = 0.04, upper = 1.2) |>
+        g3_init_val("*.Linf", max(g3_stock_def(st_imm, "midlen")), spread = 0.2) |>
+        g3_init_val("*.t0", g3_stock_def(st_imm, "minage") - 0.8, spread = 2) |>
+        g3_init_val("*.walpha", 0.01, optimise = FALSE) |>
+        g3_init_val("*.wbeta", 3, optimise = FALSE) |>
+
+        g3_init_val("project_years", 100) |>
+        identity() -> params.in
+    nll <- model_fn(params.in) ; r <- attributes(nll) ; nll <- as.vector(nll)
+
+    ok(!("stst.rec.proj.logar1.loglevel" %in% names(params.in)), "loglevel parameter disabled")
+
+    ok(ut_cmp_equal(nll, sum(r$proj_logar1_stst_rec__nll)), "nll: Consistent with r$proj_logar1_stst_rec__nll (sums to same values)")
+    ok(ut_cmp_equal(
+        as.vector( r$proj_logar1_stst_rec__var[length(r$proj_logar1_stst_rec__var)] ),
+        as.vector( exp(mean(log(r$proj_logar1_stst_rec__var[as.character(seq(1994 - params.in$lastx + 1, 1994))]))) ),
+        tolerance = 1e-7 ), paste0("proj_logar1_stst_rec__var: Settled to mean of lastx (", params.in$lastx, ")"))
+
+    gadget3:::ut_tmb_r_compare2(model_fn, model_cpp, params.in)
+}))


### PR DESCRIPTION
From #221: The "last (n) values" isn't amazingly useful. Switching modes based on positive/negative is problematic, especially for _ar1(), where a negative level isn't unreasonable.

Instead, break out ``lastx_f`` as a separate option, which when configured, overrides ``loglevel_f`` and replaces the level at run time.

By default disable it, so you get a loglevel parameter, which should be a more useful default.