### PR TITLE
Fixes to get GHL model going

### DIFF
--- a/R/action_predate.R
+++ b/R/action_predate.R
@@ -250,6 +250,12 @@ g3a_predate <- function (
 
     stopifnot(g3_is_stock(predstock))
     stopifnot(is.list(prey_stocks) && all(sapply(prey_stocks, g3_is_stock)))
+    if (rlang::is_formula(catchability_f)) catchability_f <- list(
+        # Back-compatibility, for e.g. g3experiments::g3a_predate_catchability_hockeyfleet()
+        suit_unit = "total biomass",
+        suit = quote( suit_f * stock_ss(stock__num) * stock_ss(stock__wgt) ),
+        cons = catchability_f )
+    stopifnot(is.list(catchability_f) && all(c("cons", "suit", "suit_unit") %in% names(catchability_f)))
 
     # Variables used:
     # stock__totalpredate: Biomass of total consumed (prey_stock) (prey matrix)

--- a/R/formula_utils.R
+++ b/R/formula_utils.R
@@ -73,6 +73,9 @@ f_substitute <- function (f, env) {
         if (is.call(o) && !rlang::is_formula(o)) {  # Bare code (no environment)
             # Add brackets if appropriate
             assign(n, explicit_bracket(o), envir = env)
+        } else if (rlang::is_formula(o) && is.null(rlang::f_rhs(o))) {  # ~NULL
+            # NB: Handle ~NULL separately, as rlang::f_rhs(o) <- NULL will produce nonsense
+            assign(n, NULL, envir = env)
         } else if (rlang::is_formula(o)) {  # Formula
             # Add brackets if appropriate
             rlang::f_rhs(o) <- explicit_bracket(rlang::f_rhs(o))

--- a/R/step.R
+++ b/R/step.R
@@ -339,7 +339,12 @@ g3_step <- function(step_f, recursing = FALSE, orig_env = environment(step_f)) {
                 subpop_num_c = subpop_num_c,
                 subpop_wgt_c = subpop_wgt_c,
                 end = NULL ))
-            return(rlang::f_rhs(g3_step(out_c, recursing = TRUE, orig_env = orig_env)))
+            # Run g3_step again to fix up dependents that got added
+            out_f <- g3_step(out_c, recursing = TRUE, orig_env = orig_env)
+
+            # Add environment to formulae's environment, return inner call
+            environment_merge(environment(step_f), rlang::f_env(out_f))
+            return(rlang::f_rhs(out_f))
         },
         # stock_ss subsets stock data var, overriding any set expressions
         stock_ss = function (x) { # Arguments: stock data variable (i.e. stock__num), [dim_name = override expr, ...]

--- a/tests/test-formula_utils.R
+++ b/tests/test-formula_utils.R
@@ -128,6 +128,10 @@ ok(cmp_code(
         a = as.formula(call("~", call("<-", quote(q), 2))))),
     ~{z <- 1 ; q <- 2}), "f_substitute: No extra brackets for assignment")
 
+ok(cmp_code(
+    gadget3:::f_substitute(~x + 2, list(x = ~NULL)),
+    ~NULL + 2 ), "f_substitute: Can substitute a ~NULL formula")
+
 ### f_chain_conditional
 
 out <- gadget3:::f_chain_conditional(list(g3_formula(x*2, x = 4), ~b), age = c(1,2), area = c(4,5))


### PR DESCRIPTION
* ``stock_combine_subpop()`` wasn't preserving environment, so transform matrices were being lost
* Add backwards-compatibility so ``g3experiments::g3a_predate_catchability_hockeyfleet()`` can keep working
* Support substituting ``~NULL`` (not that this is actually required, but was a follow-on bug from the above